### PR TITLE
Wave B-core PR-4: translate non-goals / getting-started / oss-comparison / org-state-schema

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,228 +1,230 @@
 # Getting Started
 
-claude-orgの使い方ガイド。
+A usage guide for claude-org.
 
 ---
 
-## セットアップ
+## Setup
 
-### 前提条件
+### Prerequisites
 
-以下が全てインストール・設定済みであること。詳細は [README.md](../README.md#クイックスタート) を参照。
+The following must all be installed and configured. See [README.md](../README.md#quickstart) for details.
 
-- **Claude Code** — AIエージェント本体
-- **renga** — ターミナルマルチプレクサ (組織のペイン管理に使用)
-- **renga-peers MCP** — 同タブ内インスタンス間通信とペイン操作（`renga mcp install` で登録）
-- **GitHub CLI (`gh`)** — 認証済み（`gh auth status` で確認）
+- **Claude Code** — the AI agent itself
+- **renga** — terminal multiplexer (used to manage the org's panes)
+- **renga-peers MCP** — same-tab inter-instance communication and pane control (registered with `renga mcp install`)
+- **GitHub CLI (`gh`)** — authenticated (verify with `gh auth status`)
 
-### インストール
+### Install
 
-依存ツール（`git` / `claude` / `renga` / `gh`）が揃っていれば、ワンライナーでクローン + `renga mcp install` までを一括実行できる。
+If the dependencies (`git` / `claude` / `renga` / `gh`) are present, a one-liner clones the repo and runs `renga mcp install`.
 
-**macOS / Linux（bash）**:
+**macOS / Linux (bash)**:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
-cd claude-org-ja
+curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.sh | bash
+cd claude-org
 bash scripts/install-hooks.sh
 renga --layout ops
 ```
 
-**Windows（PowerShell 7+）**:
+**Windows (PowerShell 7+)**:
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
-cd claude-org-ja
-bash scripts/install-hooks.sh   # Git Bash / WSL 上で実行
+iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.ps1 | iex
+cd claude-org
+bash scripts/install-hooks.sh   # run inside Git Bash / WSL
 renga --layout ops
 ```
 
-スクリプトは前提コマンドの導入有無を確認し、未導入があれば導入手順を案内して終了する（自動インストールはしない）。
+The script checks whether each prerequisite is present and, if any is missing, prints installation guidance and exits (it does not auto-install).
 
-クローン先のディレクトリ名を変えたい場合は、ワンライナーではなくスクリプトを直接実行してフラグを渡す（パイプ実行ではフラグを転送できない）:
+To clone into a non-default directory name, don't use the one-liner — download the script and pass a flag (a piped invocation cannot forward flags):
 
 ```bash
-# bash: スクリプトを保存してから実行
-curl -fsSLo /tmp/install.sh https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh
+# bash: save the script first, then run it
+curl -fsSLo /tmp/install.sh https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.sh
 bash /tmp/install.sh --dir my-claude-org
 
-# PowerShell: 同様にダウンロードしてから実行
-iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 -OutFile $env:TEMP\install.ps1
+# PowerShell: download then run
+iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.ps1 -OutFile $env:TEMP\install.ps1
 pwsh -NoProfile -File $env:TEMP\install.ps1 -Dir my-claude-org
 ```
 
-利用可能なフラグは `bash install.sh --help` / `pwsh install.ps1 -Help` を参照。
+For all flags see `bash install.sh --help` / `pwsh install.ps1 -Help`.
 
-ワンライナーを使わない場合は手動で以下を実行する:
+If you skip the one-liner, run the steps manually:
 
 ```bash
-git clone https://github.com/suisya-systems/claude-org-ja.git
-cd claude-org-ja
-renga mcp install              # 初回のみ。renga-peers MCP を user-scope 登録
+git clone https://github.com/suisya-systems/claude-org.git
+cd claude-org
+renga mcp install              # first time only — registers the renga-peers MCP at user scope
 renga --layout ops
 ```
 
-`renga-layouts/ops.toml` の定義に従って窓口 (Secretary) ペインが立ち上がる。
-窓口の Claude Code が立ち上がったら、**順に以下を実行する**:
+A Lead pane comes up per the definition in `renga-layouts/ops.toml`.
+Once the Lead's Claude Code is up, **run the following in order**:
 
-1. `/org-setup` — ロール別 `settings.local.json`（窓口・フォアマン・キュレーター・ワーカー）と必須 hook を配置。**初回のみ必須**。未実行だと renga-peers MCP / git / gh で大量の許可プロンプトが出る。
-2. `/org-start` — 組織を起動。フォアマンとキュレーターが同一タブ内に派生する。
+1. `/org-setup` — places per-role `settings.local.json` (Lead, Dispatcher, Curator, Worker) and the required hooks. **Required on the first run.** Without it, `renga-peers` MCP / git / gh produce a flood of permission prompts.
+2. `/org-start` — boots the organization. The Dispatcher and the Curator are spawned in the same tab.
 
-`/org-setup` は **additive-only**（不足分を追加するだけで既存を消さない）。drift を baseline に戻したい場合は [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md) のロール別サンプル JSON で `settings.local.json` を手動置換する。
+`/org-setup` is **additive-only** (it adds what's missing without removing what exists). To return drift back to the baseline, replace `settings.local.json` by hand using the per-role sample JSON in [`.claude/skills/org-setup/references/permissions.md`](../.claude/skills/org-setup/references/permissions.md).
 
-### 互換性プリフライト（任意、推奨）
+### Compatibility preflight (optional, recommended)
 
-`/org-start` を実行する前に、renga のバージョンと MCP ツール surface が claude-org の要件を満たすか検証できる:
+Before running `/org-start`, you can verify that the renga version and MCP tool surface meet claude-org's requirements:
 
 ```bash
 py -3 tools/check_renga_compat.py            # Windows
 python3 tools/check_renga_compat.py          # macOS / Linux
 ```
 
-- renga バージョン（0.18.0 以上を要求）
-- `renga-peers` MCP 登録 (`claude mcp list` で Connected)
-- 必須 14 ツールが tools/list に出現するか
+This checks:
 
-機械可読 JSON が欲しい場合は `--json`。フェイルを終了コードで扱いたいスクリプトはこちらを使う:
+- The renga version (≥ 0.18.0)
+- That the `renga-peers` MCP is registered (`claude mcp list` reports Connected)
+- That all 14 required tools appear in `tools/list`
+
+For machine-readable JSON, pass `--json`. Use that variant in scripts that want to react to the exit code:
 
 ```bash
 py -3 tools/check_renga_compat.py --json
 ```
 
-このスクリプトは live renga セッションを必要としない（静的 + MCP stdio probe のみ）ので、`renga --layout ops` の前にも後にも実行できる。
+The script does not require a live renga session (static checks plus an MCP stdio probe), so it is safe to run before or after `renga --layout ops`.
 
 ---
 
-## 基本的な使い方
+## Day-to-day usage
 
-### 起動する
+### Booting
 
-初回 clone 後は、上の「インストール」節に従って `/org-setup` → `/org-start` の順で 1 回だけ実行する（`/org-setup` 未実行だと許可プロンプトが多発する）。
+After the first clone, follow the "Install" section above and run `/org-setup` then `/org-start`, in that order, exactly once (skipping `/org-setup` will produce a flood of permission prompts).
 
-2 回目以降は `renga --layout ops` で窓口ペインを開き、Claude Code で `/org-start` を実行するだけでよい。
-前回の状態があれば報告され、フォアマン（作業割り当て担当）とキュレーター（知見整理担当）が自動で起動する。
-
-```
-あなた: /org-start
-窓口:   組織を起動しました。
-        前回の状態: ブログ記事更新が完了、ECサイト修正が途中です。
-        フォアマンとキュレーターを起動しました。
-        何をしますか？
-```
-
-### やりたいことを伝える
-
-やりたいことをそのまま伝える。
-技術的な言葉を使う必要はない。窓口Claudeが内容を理解し、適切なワーカーに作業を割り当てる。
-相談や質問には窓口が直接答える。
+From the second session onward, just open the Lead pane with `renga --layout ops` and run `/org-start` in Claude Code.
+If a previous state exists, it is reported, and the Dispatcher (work assignment) and Curator (knowledge curation) are spawned automatically.
 
 ```
-あなた: ブログに新しい記事を追加したい
-窓口:   ブログですね。記事のタイトルと内容を教えてください。
+You:    /org-start
+Lead:   The organization is up.
+        Previous state: blog-post update completed; storefront fix is in progress.
+        The Dispatcher and the Curator have been started.
+        What would you like to do?
 ```
 
-窓口は登録済みプロジェクトの中から「ブログ」を特定し、適切に作業を進める。
-どのプロジェクトか分からないときは聞き返してくれる。
+### Stating what you want done
+
+Just say what you want, in plain language.
+You don't need technical vocabulary; the Lead understands the request and dispatches a suitable Worker.
+For questions and discussion, the Lead answers directly.
 
 ```
-窓口:   どのプロジェクトですか？
-        ・ブログ（会社ブログサイト）
-        ・ECサイト（EC販売サイト）
-        ・管理画面（社内管理ツール）
+You:    I want to add a new post to the blog
+Lead:   Got it — the blog. What's the title and content?
 ```
 
-### 複数の作業を同時に頼む
+The Lead resolves "the blog" against the registered projects and proceeds appropriately.
+If the project is ambiguous, the Lead asks back with a list:
 
 ```
-あなた: ブログの記事を更新して、あとECサイトの商品ページも直して
-窓口:   2つの作業を同時に進めます。
-        ・ブログ: 記事更新
-        ・ECサイト: 商品ページ修正
-        それぞれ担当を割り当てました。完了したら報告します。
+Lead:   Which project do you mean?
+        - blog (company blog site)
+        - storefront (e-commerce site)
+        - admin console (internal admin tool)
 ```
 
-裏側で別々のワーカーが並行して作業する。完了するとまとめて報告が届く。
-
-### 作業結果の確認
-
-窓口は技術用語を避けて報告する。
+### Asking for several things at once
 
 ```
-窓口:   ブログの記事更新が完了しました。
-        ・新しい記事「2026年春の新商品」を追加しました
-        ・変更内容を提出済みです。レビュー待ちの状態です
+You:    Update the blog post, and also fix the product page on the storefront
+Lead:   I'll run the two in parallel:
+        - blog: post update
+        - storefront: product-page fix
+        Each has been assigned. I'll report back as they complete.
 ```
 
-### 中断する
+Behind the scenes, separate Workers run in parallel; reports come back as they finish.
+
+### Reading the result
+
+The Lead reports without technical jargon.
 
 ```
-あなた: 今日は終わり
-窓口:   組織を中断しました。状態は保存済みです。
+Lead:   The blog post update is complete.
+        - Added a new post titled "Spring 2026 New Arrivals"
+        - The change has been submitted; it's awaiting review
 ```
 
-端末を安全に閉じてよい。
-
-### 再開する
-
-次に本リポジトリのディレクトリで `renga --layout ops` を起動して窓口の Claude Code に入ると、自動的に前回の状態を報告する。
+### Suspending
 
 ```
-窓口:   前回の状態（4/5 18:30に中断）:
-        ・ブログ記事更新: 完了
-        ・ECサイト商品ページ: 作業途中（60%）
-        ・テスト追加: まだ手をつけていません
-        続けますか？
-あなた: ECサイトの続きからお願い
-窓口:   承知しました。ECサイトの作業を再開します。
+You:    We're done for today
+Lead:   The organization has been suspended. State has been saved.
+```
+
+You can safely close the terminal at this point.
+
+### Resuming
+
+Next time you start `renga --layout ops` in this repository's directory and enter the Lead's Claude Code, the previous state is reported automatically.
+
+```
+Lead:   Previous state (suspended at 4/5 18:30):
+        - Blog post update: complete
+        - Storefront product page: in progress (60%)
+        - Test addition: not started
+        Continue?
+You:    Please continue the storefront work
+Lead:   Understood. Resuming the storefront task.
 ```
 
 ---
 
-## トラブルシューティング
+## Troubleshooting
 
-### 起動時に大量の許可プロンプトが出る
+### A flood of permission prompts at boot
 
-**症状**: 窓口・フォアマン・ワーカーのいずれかで `mcp__renga-peers__*` / `git` / `gh` 系ツール呼び出しのたびに許可ダイアログが立つ。
+**Symptoms**: any of the Lead, Dispatcher, or Worker raises a permission dialog every time it calls `mcp__renga-peers__*` / `git` / `gh` tools.
 
-**診断**: まず該当ロールの `settings.local.json` の状態を確認する。
+**Diagnosis**: first, inspect the state of that role's `settings.local.json`:
 
 ```bash
 python tools/check_role_configs.py --include-local
 ```
 
-特定 role の worktree 内で実行する場合は `--role <secretary|dispatcher|curator|worker>` を併用する。出力で role 別の missing / unknown allow と必須 hook の欠落が列挙される。
+To inspect inside a specific role's worktree, also pass `--role <secretary|dispatcher|curator|worker>` (`secretary` is the implementation identifier for the Lead role; the CLI literal is kept as-is). The output enumerates per-role missing/unknown allow entries and missing required hooks.
 
-**対処**:
+**Fix**:
 
-- **`settings.local.json` が存在しない / 必須 allow と hook が大量に missing**: 窓口の Claude Code で `/org-setup` を実行する（additive-only なので既存設定は壊れない）。実行後にもう一度 `check_role_configs.py` で missing が解消されたか確認する。
-- **missing が局所的（特定の allow が 1〜2 件足りないだけ）**: schema → `permissions.md` → 実 `settings.local.json` の順で当該エントリを足す（次節の drift 解消フローと同じ手順）。
+- **No `settings.local.json`, or many required allows and hooks are missing**: run `/org-setup` from the Lead's Claude Code (additive-only — existing settings are not destroyed). After it runs, re-run `check_role_configs.py` to confirm the missing entries are gone.
+- **Only a couple of allows are missing locally**: add them in the order schema → `permissions.md` → actual `settings.local.json` (the same flow as the next section's drift fix).
 
-### `tools/check_role_configs.py` が schema/permissions/settings の drift を報告する
+### `tools/check_role_configs.py` reports drift between schema, permissions, and settings
 
-**症状**: CI または手元の `python tools/check_role_configs.py --include-local` が `unknown allow entry` / `permissions.md mismatch` / `missing required hook` を報告する。
+**Symptoms**: CI or local `python tools/check_role_configs.py --include-local` reports `unknown allow entry` / `permissions.md mismatch` / `missing required hook`.
 
-**診断**: drift の発生源を「schema 側 / permissions.md 側 / 実 settings.local.json 側」のどこかに切り分ける。
+**Diagnosis**: identify which side the drift is on — schema, `permissions.md`, or actual `settings.local.json`.
 
 ```bash
-python tools/check_role_configs.py --include-local        # 全 role を一括検証
-python tools/check_role_configs.py --role <role>          # 当該 role の worktree で個別検証
-git diff tools/role_configs_schema.json                   # schema 側の最近の編集を確認
+python tools/check_role_configs.py --include-local        # validate all roles at once
+python tools/check_role_configs.py --role <role>          # individual validation in that role's worktree
+git diff tools/role_configs_schema.json                   # recent edits on the schema side
 git diff .claude/skills/org-setup/references/permissions.md
 ```
 
-正典は `tools/role_configs_schema.json`。**ルール追加・修正は必ず schema → `permissions.md` → 実 `settings.local.json` の順で反映する**。逆順にすると CI が drift を検出する。
+`tools/role_configs_schema.json` is the canonical source. **Add or modify rules in the order schema → `permissions.md` → actual `settings.local.json`**, always. Reverse order will trip CI's drift detector.
 
-**対処** — 切り分け結果ごとに:
+**Fix** — by where the drift is:
 
-- **schema に未登録の allow が `permissions.md` または実 settings に混入している場合**: 必要なエントリなら schema にまず追記してから permissions.md / settings.local.json に展開する。不要なら該当エントリを削除する。
-- **`permissions.md` のサンプル JSON が schema と乖離している場合**: schema を正と見なし、`permissions.md` 側を schema に合わせて書き直す。
-- **`/org-setup` 再実行後も `settings.local.json` に drift が残る場合**: additive-only なので自動では消えない。`.claude/skills/org-setup/references/permissions.md` のロール別サンプル JSON で該当ロールの `settings.local.json` を**丸ごと置換**して baseline に戻す（**last resort**）。worker サンプルの `{worker_dir}` / `{claude_org_path}` プレースホルダは置換時に実環境の絶対パスへ手で解決する必要がある。ローカル独自に追加していた override があれば事前に控えておくこと。
+- **An allow entry not registered in the schema is present in `permissions.md` or actual settings**: if it's needed, add it to the schema first, then propagate to `permissions.md` and `settings.local.json`. If it isn't, delete it.
+- **The sample JSON in `permissions.md` has diverged from the schema**: treat the schema as canonical and rewrite the `permissions.md` side to match.
+- **`/org-setup` re-run does not eliminate drift in `settings.local.json`**: additive-only mode can't remove anything automatically. As a **last resort**, replace the role's `settings.local.json` wholesale with the per-role sample JSON in `.claude/skills/org-setup/references/permissions.md` to return to baseline. The `{worker_dir}` / `{claude_org_path}` placeholders in the worker sample must be hand-resolved to absolute paths in your environment. Make sure to record any local overrides before doing this.
 
-### schema の JSON parse エラー / 読み込み失敗
+### Schema JSON parse error / read failure
 
-**症状**: `check_role_configs.py` または `/org-setup` が schema 読み込み時に即時 fail する（JSON syntax error 等）。
+**Symptoms**: `check_role_configs.py` or `/org-setup` fails immediately when reading the schema (JSON syntax error, etc.).
 
-**診断**:
+**Diagnosis**:
 
 ```bash
 git status tools/role_configs_schema.json
@@ -230,91 +232,90 @@ git diff tools/role_configs_schema.json
 python -c "import json; json.load(open('tools/role_configs_schema.json'))"
 ```
 
-**対処**: 直近の編集で壊しているなら `git restore tools/role_configs_schema.json` で戻すか、未コミットの変更を一旦 `git stash push tools/role_configs_schema.json` で退避してから再挑戦する。schema 構文を修正したら必ず `python tools/check_role_configs.py --include-local` を通してから commit する。
+**Fix**: if a recent edit broke the file, restore it with `git restore tools/role_configs_schema.json`, or temporarily set the change aside with `git stash push tools/role_configs_schema.json` and try again. After fixing the schema syntax, always run `python tools/check_role_configs.py --include-local` cleanly before committing.
 
 ---
 
-## ダッシュボードで全体像を見る
+## See the whole picture in the dashboard
 
-「ダッシュボード見せて」と言えば、ブラウザで組織の全体像を確認できる。
+Say "show me the dashboard" and the browser opens with a high-level view.
 
 ```
-あなた: ダッシュボード見せて
-窓口:   （ライブサーバーを起動してブラウザで http://localhost:8099 を開く）
+You:    Show me the dashboard
+Lead:   (starts the live server and opens http://localhost:8099 in the browser)
 ```
 
-ダッシュボードには以下が表示される:
+The dashboard shows:
 
-- **プロジェクト一覧** — 登録済みプロジェクトと、よくある作業例
-- **作業状況** — 現在進行中・完了・保留の作業アイテム
-- **最近のアクティビティ** — いつ何が起きたかのタイムライン
-- **蓄積された知見** — テーマ別にどんな知見が溜まっているか
+- **Project list** — registered projects with example tasks
+- **Work status** — work items in progress, completed, or pending
+- **Recent activity** — a timeline of what happened when
+- **Accumulated knowledge** — what kinds of knowledge have been gathered, by topic
 
-ダッシュボードはSSEで自動更新される。ブラウザをリロードしなくてもリアルタイムで最新状態が反映される。
+The dashboard auto-updates over SSE, so the latest state is reflected in real time without reloading the browser.
 
 ---
 
-## スキル一覧
+## Skill index
 
-| コマンド | 用途 | いつ使うか |
+| Command | Purpose | When to use |
 |---|---|---|
-| `/org-start` | 組織の起動 | **Claude Code 起動直後に1回実行する** |
-| `/org-delegate` | 作業の割り当て | 作業依頼時に自動発動（窓口は司令塔、実作業はワーカー） |
-| `/org-suspend` | 作業の中断 | 「終わり」「中断」と言えば自動発動 |
-| `/org-resume` | 作業の再開 | 前回中断していた場合に org-start から自動呼び出し |
-| `/org-retro` | 学びの記録 | 作業完了後（多くは自動発動） |
-| `/org-curate` | 知見の整理 | 自動実行。手動でも可 |
-| `/org-dashboard` | ダッシュボード表示 | 「ダッシュボード見せて」で発動 |
+| `/org-start` | Boot the organization | **Run once, right after Claude Code starts** |
+| `/org-delegate` | Assign work | Fires automatically when a request comes in (the Lead is a coordinator; real work goes to a Worker) |
+| `/org-suspend` | Suspend work | Auto-fires on "we're done", "suspend", etc. |
+| `/org-resume` | Resume work | Auto-called from `/org-start` when a previous suspend exists |
+| `/org-retro` | Capture learnings | After work completes (mostly auto) |
+| `/org-curate` | Curate knowledge | Auto-runs; manual is fine too |
+| `/org-dashboard` | Show the dashboard | Fires on "show me the dashboard" |
 
-基本的に、スキルを意識して呼ぶ必要はない。
-窓口Claudeが状況に応じて適切なスキルを使う。
+You generally don't need to be aware of these — the Lead picks the right skill based on context.
 
 ---
 
-## ディレクトリ構造
+## Directory layout
 
 ```
-claude-org-ja/
-  CLAUDE.md              <- 窓口Claudeの行動指針
-  .claude/skills/        <- 組織のスキル群（git管理）
-  .state/                <- セッション状態（git管理外）
-  dashboard/             <- ダッシュボード（HTML/CSS/JS/server.pyはgit管理）
+claude-org/
+  CLAUDE.md              <- Lead's behavior guide
+  .claude/skills/        <- Skill set (tracked)
+  .state/                <- Session state (untracked)
+  dashboard/             <- Dashboard (HTML/CSS/JS/server.py are tracked)
   knowledge/
-    raw/                 <- 生の学び（git管理外）
-    curated/             <- 整理済み知見（git管理）
+    raw/                 <- Raw notes (untracked)
+    curated/             <- Curated knowledge (tracked)
   registry/
-    projects.md          <- プロジェクト一覧（自動登録）
-  docs/                  <- ドキュメント
+    projects.md          <- Project list (auto-registered)
+  docs/                  <- Documentation
 ```
 
-### 自分で触るもの
-- `knowledge/curated/` — 整理された知見を確認する（自動生成される）
+### Things you might touch
+- `knowledge/curated/` — review the curated knowledge (auto-generated)
 
-### 触らなくていいもの
-- `registry/projects.md` — 作業依頼時に自動登録される
-- `dashboard/` — ダッシュボードのデザインとデータ。自動管理される
-- `.claude/skills/` — スキル定義。組織の成長に伴い自動改善提案される
-- `.state/` — セッション状態。自動管理される
-- `CLAUDE.md` — 変えたくなったら変えてよいが、薄く保つこと
+### Things you don't need to touch
+- `registry/projects.md` — auto-registered when work is requested
+- `dashboard/` — dashboard design and data; auto-managed
+- `.claude/skills/` — skill definitions; improved via auto proposals as the org evolves
+- `.state/` — session state; auto-managed
+- `CLAUDE.md` — change it if you want, but keep it thin
 
 ---
 
-## 知見の蓄積と成長
+## How knowledge accumulates and the org grows
 
-組織は使うほど賢くなる。
+The organization gets smarter the more you use it.
 
-1. 作業が完了するたびに、学びが記録される
-2. 30分ごとに自動で整理される（5件以上溜まったとき）
-3. 整理された知見はテーマ別に保存される
-4. スキルやプロセスの改善が必要な場合、提案される
-5. 承認すると改善が反映され、次回から組織全体が改善された状態で動く
+1. Every time work completes, a learning is recorded
+2. Curation runs automatically every 30 minutes (when 5+ entries have accumulated)
+3. Curated knowledge is filed by topic
+4. When a skill or process change would help, you'll see a proposal
+5. If you approve, the improvement takes effect, and the whole org runs with it from then on
 
 ---
 
 ## Tips
 
-- **端末を突然閉じても大丈夫**: 状態は定期的に保存されている。次回起動時に復元される。ただし「今日は終わり」と言って正式に中断したほうが、より正確な状態が残る。
-- **作業が多すぎると思ったら**: 「1つずつやって」と言えばよい。窓口は人間の指示を優先する。
-- **学びが的外れなら**: 「その学びは不要」と言えば記録されない。改善提案も却下できる。
-- **プロジェクトの登録は自動**: 新しいプロジェクトの作業を依頼すると、名前や場所を確認してから自動登録される。
-- **ダッシュボードはいつでも見られる**: 「ダッシュボード見せて」「全体像見せて」と言えばブラウザで開く。
+- **Closing the terminal abruptly is OK**: state is saved periodically and is restored next launch. Saying "we're done for today" produces a more accurate save, though.
+- **Too many tasks at once?** Just say "one at a time" — the Lead obeys human direction.
+- **A learning misses the mark**: say "skip that learning" and it isn't recorded. Improvement proposals can also be rejected.
+- **Project registration is automatic**: when you ask about a new project, the Lead confirms its name and location and registers it.
+- **The dashboard is always available**: "show me the dashboard" or "show me the big picture" opens it in the browser.

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -1,159 +1,159 @@
-# 意図的に持たない機能（Non-goals）
+# Non-goals (Things this project deliberately doesn't do)
 
-claude-org-ja は**運用規律フレームワーク**であり、Claude Code 上での組織運用に対象を絞っています。「あった方が便利そうに見えるが、設計哲学上あえて持たない」機能を以下に明示します。能動的な不在表明は、本フレームワークの境界と価値を読者に正しく伝えるための装置です。
+claude-org is an **operational-discipline framework** scoped to running an organization on top of Claude Code. The list below makes explicit which capabilities we have decided not to build, even though they may sound convenient. Stating absences actively is the device we use to communicate the boundary — and the value — of this framework.
 
-> README には特に強い 5 項目だけ要約しています。本ドキュメントはその詳細版で、全 12 項目を扱います。
+> The README summarizes only the five strongest items. This document is the long form and covers all twelve.
 
 ---
 
-## 1. ワーカーに `--dangerously-skip-permissions` を既定で撒かない
+## 1. We don't hand `--dangerously-skip-permissions` to Workers by default
 
-**やらないこと**: 実作業を担うワーカー（とその指示を出す窓口）に対して、Claude Code の許可プロンプトを全面的に回避する `--dangerously-skip-permissions`（= `permission_mode="bypassPermissions"`）を既定として配ること。「全ロール一律で bypass を有効にする」運用は採用しません。
+**What we don't do**: ship `--dangerously-skip-permissions` (= `permission_mode="bypassPermissions"`), which broadly suppresses Claude Code's permission prompts, as a default for the Workers that do real work (and for the Lead that instructs them). We do not adopt the "every role uniformly bypasses" stance.
 
-**理由**: claude-org-ja は**許可エントリの絞り込み + 多層防御**を中核価値としています。実作業ロールに許可境界の全面回避を撒くと、`git push --force` や `.env` の読み取りなど、組織運用で最も致命的な事故クラスを事前に止められなくなります。farm 系の全自動志向とは方向が逆で、「目の届かないところでこっそり危険な操作が走る」状況は許容しません。
+**Why**: claude-org's core value is **narrow allow-listing plus defense in depth**. Handing a blanket bypass to the role that actually does work eliminates our ability to pre-empt the most catastrophic accident classes — `git push --force`, reads of `.env`, and so on. This is the opposite direction from farm-style "everything fully automatic" tools; we don't accept "dangerous operations quietly running where no one is watching."
 
-ただし、claude-org-ja は**ロールごとに permission_mode を意図的に使い分ける**設計です。建前として「全ロール `auto` モード」と書くと現実と乖離するため、ここで正直に整理しておきます:
+That said, claude-org is **deliberately heterogeneous in `permission_mode` across roles**. Pretending "every role runs in `auto`" would diverge from reality, so we lay it out honestly:
 
-| ロール | `permission_mode` | モデル | 補足 |
+| Role | `permission_mode` | Model | Notes |
 |---|---|---|---|
-| 窓口（Secretary） | `auto` | Opus | 許可エントリを絞った `settings.local.json` + PreToolUse フックで防御 |
-| フォアマン（Dispatcher） | `bypassPermissions` | Sonnet | **例外**。理由は下記 |
-| キュレーター（Curator） | `auto` | Opus | 最小許可（読み取り中心 + ナレッジ整理に必要な書き込みのみ） |
-| ワーカー（Worker） | `auto` | Opus | 許可エントリの絞り込み + ロール別フック + タスクごとの作業ディレクトリ境界 |
+| Lead | `auto` | Opus | Narrow allow-list in `settings.local.json` plus PreToolUse hooks |
+| Dispatcher | `bypassPermissions` | Sonnet | **Exception.** See below |
+| Curator | `auto` | Opus | Minimal allow-list (read-mostly plus the writes needed for curation) |
+| Worker | `auto` | Opus | Narrow allow-list + role-specific hooks + per-task working-directory boundary |
 
-フォアマンだけが `bypassPermissions` 固定の理由は **コスト最適化の必然的な帰結**です。Claude Code（TUI）では `auto` モードが Opus 系でのみ起動し、Sonnet では `auto` モード自体が利用できません。フォアマンを Sonnet で運用する以上、`permission_mode` の選択肢は実質 `bypassPermissions` 一択であり、これは分類器の挙動を回避しているわけではなく、そもそも `auto` を選べない環境での唯一の選択です。
+The reason only the Dispatcher is pinned to `bypassPermissions` is **a forced consequence of cost optimization**. In Claude Code (TUI), `auto` mode is only available on Opus-class models — Sonnet cannot run `auto` at all. Since we run the Dispatcher on Sonnet, the only realistic value of `permission_mode` is `bypassPermissions`. This isn't classifier evasion; it's the only choice the environment offers.
 
-### `bypassPermissions` の実際の挙動（誤魔化さない）
+### What `bypassPermissions` actually does (no fudging)
 
-`bypassPermissions` モードはその名の通り、`permissions.allow` と `permissions.deny` の **両方を bypass します**。つまり「`permissions.deny` に並べた `git push --force` 等の拒否ルールはフォアマン側では効きません」。Claude Code 公式が bypass モードでも残しているのは、`.git/`, `.claude/`, `.vscode/`, `.idea/`, `.husky/` 等の保護対象ディレクトリに対する書き込み確認プロンプトのみです。
+True to its name, `bypassPermissions` mode bypasses **both** `permissions.allow` and `permissions.deny`. That is, "the deny rules in `permissions.deny` such as `git push --force` are not enforced on the Dispatcher." What Claude Code itself still preserves under bypass is only the write-confirmation prompt for protected directories such as `.git/`, `.claude/`, `.vscode/`, `.idea/`, and `.husky/`.
 
-したがってフォアマンの実効防御層は次のように整理されます:
+So the Dispatcher's effective defense layers come out as:
 
-1. **保護対象ディレクトリの自動確認プロンプト**（Claude Code 側で `bypassPermissions` でも保持される範囲のみ）
-2. **PreToolUse フック**（`bypassPermissions` でも実行され、exit code 2 でツール呼び出しをブロックできる。allow ルールより優先される）。フォアマン用には以下のフックが配備済みです:
-   - `block-dispatcher-out-of-scope.sh` — Edit/Write 対象を `.dispatcher/`, `.state/`, `knowledge/raw/YYYY-MM-DD-{topic}.md` に限定。アプリケーションコード（`tools/`, `dashboard/`, `tests/`, `.claude/skills/`, `docs/`, `registry/` 等）への直接編集は exit 2 でブロック
-   - `block-git-push.sh` — フォアマンからの直接 push を禁止（push は窓口経由）
-   - `block-dangerous-git.sh` — `git push --force` / `git reset --hard` / `git branch -D` の遮断
-   - `block-workers-delete.sh` — workers ディレクトリの再帰削除を遮断
-   - `block-no-verify.sh` — `--no-verify` 系の検証バイパスを遮断
-3. **ロール契約による自主規律**（フォアマンの `CLAUDE.md` に記載された業務スコープ宣言と、窓口によるライフサイクル監視）
+1. **Auto-confirmation prompts for protected directories** (the residual range Claude Code keeps even under `bypassPermissions`)
+2. **PreToolUse hooks** (run even under `bypassPermissions`, can block a tool call by exiting with code 2; take precedence over allow rules). The following hooks are deployed for the Dispatcher:
+   - `block-dispatcher-out-of-scope.sh` — restricts Edit/Write targets to `.dispatcher/`, `.state/`, and `knowledge/raw/YYYY-MM-DD-{topic}.md`. Direct edits to application code (`tools/`, `dashboard/`, `tests/`, `.claude/skills/`, `docs/`, `registry/`, etc.) are blocked with exit 2
+   - `block-git-push.sh` — forbids direct push from the Dispatcher (push goes through the Lead)
+   - `block-dangerous-git.sh` — blocks `git push --force` / `git reset --hard` / `git branch -D`
+   - `block-workers-delete.sh` — blocks recursive deletion of the workers directory
+   - `block-no-verify.sh` — blocks `--no-verify`-style verification bypasses
+3. **Self-discipline through the role contract** (the business-scope declarations in the Dispatcher's `CLAUDE.md`, plus lifecycle oversight by the Lead)
 
-bypass モードでも (2) の PreToolUse フックは有効に作動するため、`git push --force` 系の履歴上書きやアプリケーションコードへの不意の書き込みは技術的にも止まります。ただしフックは Bash コマンド文字列に対する loose match であり、関数定義やシェル変数経由の極端な迂回までは捕捉しません — その意味で「ロール契約に基づく自主規律」は依然として補完的に必要です（誇張なく言えば「複数層の網が重なっているが、各層の網目は粗い」状態）。
+Layer (2) — PreToolUse hooks — does run under bypass, so history-rewriting commands like `git push --force` and unintended writes into application code are technically blocked. That said, hooks loose-match against Bash command strings, so they don't catch every extreme workaround such as function definitions or routing through shell variables — which is why "self-discipline through the role contract" remains a complementary necessity. Honest framing: "multiple layers of net are stacked, but each layer has wide gaps."
 
-**代替手段**: 各ロールごとに `tools/role_configs_schema.json` を正典とした `settings.local.json` を `/org-setup` で配布します。許可エントリとフックはスキーマに登録され、CI (`tools/check_role_configs.py`) で設定の乖離を検出します。フォアマンの `bypassPermissions` 例外そのものは、Sonnet で `auto` モードが利用可能になった時点で再評価します。
-
----
-
-## 2. 固定ロールプール（フロントエンド / バックエンド / QA エージェント等）を持たない
-
-**やらないこと**: 「フロントエンド担当エージェント」「バックエンド担当エージェント」のような事前定義されたロールプールを提供すること。
-
-**理由**: claude-org-ja は**タスクごとに**作業ディレクトリと `CLAUDE.md` を都度生成する設計です。事前のロールプールは「タスクが来る前にロールが決まっている」前提で動くため、タスクごとの規律（タスクごとに環境を作り直す）と矛盾します。同じ「フロントエンド作業」でも、対象リポジトリ・ブランチ・検証深度ごとに必要な許可と文脈は異なるため、定型化されたロールを再利用することで文脈のずれが起きやすくなります。
-
-**代替手段**: `/org-delegate` がタスクごとにワーカーを派生させ、その都度作業ディレクトリの中に `CLAUDE.local.md`（タスク固有の指示書）を生成します。「定型タスク」を扱いたい場合はロールではなく**作業スキル**として切り出してください（`/org-retro` → スキル候補キュー → `skill-creator` の流れ）。
+**Alternative**: each role gets a `settings.local.json` distributed via `/org-setup`, with `tools/role_configs_schema.json` as the canonical source. Allow entries and required hooks are registered in the schema, and CI (`tools/check_role_configs.py`) detects drift. The Dispatcher's `bypassPermissions` exception will be re-evaluated as soon as `auto` mode becomes available on Sonnet.
 
 ---
 
-## 3. 大規模並列（20+ エージェント）はしない
+## 2. We don't ship a fixed pool of pre-defined roles (front-end / back-end / QA agents, etc.)
 
-**やらないこと**: いわゆる farm 系のように 20〜100 並列でエージェントを回し、各エージェントが同一タスクを試行錯誤する運用を採用すること。
+**What we don't do**: provide a pre-defined pool of "front-end agent", "back-end agent", and similar role archetypes.
 
-**理由**: claude-org-ja は **3〜5 ワーカー / 品質重視**の立ち位置です。大規模並列は「数で殴って 1 つでも当たれば勝ち」のアプローチで、人間レビュアーが追えない量のプルリクエスト・コミットを生み出します。巻き戻し・再現性・知見蓄積という運用規律の観点では、ワーカー数を絞って `/org-retro` で振り返るほうが自己成長ループが回ります。
+**Why**: claude-org generates **per-task** working directories and `CLAUDE.md` files freshly each time. A pre-baked role pool assumes "the role is decided before the task arrives", which conflicts with our discipline of remaking the environment per task. Even within "front-end work", the required permissions and context vary by repository, branch, and verification depth; reusing a stock role tends to produce contextual drift.
 
-**代替手段**: 現状のフォアマンは同時に複数のワーカーを派生できますが、ピークでも 3〜5 を上限の目安としてください。「大量の似たタスクをまとめて処理したい」用途なら、ワーカーを多重化するのではなく、タスクをまとめて 1 ワーカーに渡し、進捗をジャーナルで追う方が適しています。
-
----
-
-## 4. 自然言語からのプロジェクト雛形生成（Auto-create app）はしない
-
-**やらないこと**: 「Twitter クローンを作って」のような自然言語からプロジェクトの雛形を生成する機能。
-
-**理由**: claude-org-ja は運用規律フレームワークであり、雛形生成器ではありません。雛形生成は「最初の 5 分」を短くするツールで、claude-org-ja の主戦場である「長期運用での規律維持」とは関心領域が異なります。両方を 1 つのツールに混ぜると、どちらの責務もぼやけます。
-
-**代替手段**: 雛形生成が必要なら `create-react-app` / `cargo new` / `npm init` 等の専用ツールを使い、その後 claude-org-ja で組織運用を始めてください。
+**Alternative**: `/org-delegate` derives a Worker per task and writes a task-specific `CLAUDE.local.md` into its working directory. If you want to repeat **routine tasks**, factor them out as **work skills** rather than as roles (`/org-retro` → skill candidate queue → `skill-creator`).
 
 ---
 
-## 5. 複数プロバイダー切替（Aider / Codex / Gemini 等）はしない
+## 3. We don't run massive parallelism (20+ agents)
 
-**やらないこと**: Claude Code 以外の言語モデル（OpenAI / Gemini / DeepSeek 等）を主役のワーカーとして切り替え可能にすること。
+**What we don't do**: farm-style operation in which 20–100 agents run in parallel and each tries the same task.
 
-**理由**: claude-org-ja は **Claude 専用**で立ち位置を取っています。複数プロバイダー対応は魅力的に見えますが、プロバイダーごとに許可モデル・フック機構・MCP サーバーとの互換性・文脈窓の形状・ツール呼び出し仕様が異なり、「規律を強制する」というフレームワークの本質がプロバイダー数だけ薄まります。Claude Code に深く張ることで、`renga-peers` MCP サーバー・フック・設定スキーマ・サンドボックス等、Claude Code 由来の規律を最大限活用できます。
+**Why**: claude-org sits in the **3–5 Workers / quality-first** position. Massive parallelism is a "swing for hits at scale" approach that produces more pull requests and commits than human reviewers can keep up with. From the operational-discipline viewpoint — rollback, reproducibility, knowledge accumulation — keeping the Worker count small and reviewing via `/org-retro` is what makes the self-improvement loop spin.
 
-**代替手段**: レビュー用途や別視点の確認に限り、`codex:rescue` や `codex` セルフレビューゲートのような**任意のレビュー用フック**として他プロバイダーを呼ぶことは想定範囲です（主役ではなく補助）。多様なプロバイダーを主役で使い分けたい場合は、汎用エージェントフレーム（Aider / LangGraph / CrewAI 等）の方が適合します。
-
----
-
-## 6. PTY や端末多重化器の層を持たない
-
-**やらないこと**: 疑似端末（PTY）操作・ペイン分割・キーストローク注入のような低レイヤ実装を本リポジトリに持つこと。
-
-**理由**: PTY や端末多重化の層は **Layer 3 = `renga`**（`suisya-systems/renga`）に分離されています。claude-org-ja は Layer 4 = 「Claude Code を素で叩く運用層」であり、低レイヤの端末制御は依存先に責務を譲ります。同一リポジトリで両方を抱えると、運用規律の改修と PTY 層のバグ修正が干渉してリリース速度が落ちます。
-
-**代替手段**: ペイン操作・構造化ペイン生成・ピア通信は `renga-peers` MCP サーバー（Layer 3 が提供、14 種のツール）を通じて利用してください。
+**Alternative**: the Dispatcher today can spawn multiple Workers concurrently, but treat 3–5 as the peak guideline. If you want to handle a large batch of similar tasks, don't multiplex Workers — bundle the tasks into a single Worker and follow progress through the journal.
 
 ---
 
-## 7. ベンチマークスイート（SWE-Bench スコア等）を持たない
+## 4. We don't generate project scaffolds from natural language (auto-create app)
 
-**やらないこと**: エージェント性能比較用のベンチマーク実行・スコア公開機能。
+**What we don't do**: features that accept "build me a Twitter clone" and generate a project scaffold from natural language.
 
-**理由**: claude-org-ja はエージェント性能比較フレームワークではありません。「窓口の指示がワーカーでどう実行されたか」「生の知見が整理済み知見に正しく昇華したか」のような**運用ロジックの正しさ**は対象ですが、「Claude Code がベンチマークで何点取るか」は Claude Code 自体の評価であり、claude-org-ja の射程外です。
+**Why**: claude-org is an operational-discipline framework, not a scaffold generator. Scaffold generators shorten "the first five minutes"; claude-org's main field — "maintaining discipline over the long run of operation" — is a different concern. Mixing the two into a single tool blurs both responsibilities.
 
-**代替手段**: SWE-Bench / HumanEval 等の標準ベンチマークは Anthropic 側や専用 OSS（`swe-bench` 等）を使ってください。
-
----
-
-## 8. スタック別プロンプトテンプレート集を持たない
-
-**やらないこと**: 「Next.js 用」「Rails 用」「Django 用」など、フレームワーク別のプロンプトテンプレート集を本フレームワーク同梱で配布すること。
-
-**理由**: claude-org-ja は**プロジェクト固有の文脈構築**を主役にする設計です。`CLAUDE.md` と作業ディレクトリの `CLAUDE.local.md` がプロジェクト固有の正典になり、スタック別プロンプトは「最大公約数の汎用文」になりがちで、プロジェクト固有の文脈を希釈します。
-
-**代替手段**: スタック別プロンプトが必要なら、プロジェクトの `CLAUDE.md` に各自記述するか、外部のプロンプト集（Awesome Prompts 系）を別途参照してください。
+**Alternative**: if you need a scaffold, use the dedicated tool (`create-react-app`, `cargo new`, `npm init`, etc.), then start operating it with claude-org afterwards.
 
 ---
 
-## 9. `tools` フロントマターによる許可宣言形式を採らない
+## 5. We don't switch between providers (Aider / Codex / Gemini, etc.)
 
-**やらないこと**: スキルやエージェントの定義ファイルのフロントマターで `tools: [Read, Edit, Bash]` のように、ツール許可をファイル単位で宣言する公式形式。
+**What we don't do**: make non-Claude language models (OpenAI / Gemini / DeepSeek, etc.) interchangeable as the primary Worker.
 
-**理由**: claude-org-ja は **`settings.local.json` + 拒否フックでタスクごとに制御**します。フロントマター方式の許可宣言は静的で、「いつ・どのワーカーが・どこの作業ディレクトリで」という動的境界を表現できません。同じスキルでもタスクによって許可境界が変わるため、ロール × タスクの 2 軸で動的に決定する設計を採用しています。
+**Why**: claude-org takes a **Claude-only** stance. Multi-provider support is appealing on paper, but each provider has a different permission model, hook mechanism, MCP-server compatibility, context-window shape, and tool-call spec — and "the framework enforces discipline" thins out by exactly the number of providers you support. Going all-in on Claude Code is what lets us fully exploit Claude-Code-native discipline: the `renga-peers` MCP server, hooks, configuration schemas, sandboxing, and so on.
 
-**代替手段**: ツール許可の追加が必要なら、`tools/role_configs_schema.json` を更新してください（ルール追加フロー: スキーマ → ドキュメント → 実 `settings.local.json` の順）。drift 検出時の対処手順は [docs/getting-started.md](getting-started.md) の `tools/check_role_configs.py` の節を参照。
-
----
-
-## 10. `--add-dir` による横断アクセスを既定で許可しない
-
-**やらないこと**: ワーカーが自分の作業ディレクトリの外（他ワーカーの作業領域、リポジトリ外のホームディレクトリ等）に自由にアクセスすること。
-
-**理由**: claude-org-ja は**作業ディレクトリの境界を強制境界**としています。ワーカー間で作業ツリーや状態を共有すると、並列作業時の競合や、誤って他ワーカーのコミットを上書きする事故が起こります。境界を緩めるたびに「どのワーカーが何を見たか」を追跡するコストが増えます。
-
-**代替手段**: 共有が必要な情報は `knowledge/curated/` や `registry/` 等の窓口管理領域に置き、フォアマン・窓口経由でのみ書き換えてください。
+**Alternative**: bringing in another provider as an **optional review hook** — for example via `codex:rescue` or a `codex` self-review gate — for review or second-opinion purposes is in scope (a complement, not a star). If you want to swap providers in the primary role, a provider-agnostic agent framework (Aider / LangGraph / CrewAI, etc.) is the better fit.
 
 ---
 
-## 11. 公式同梱スキル（`/simplify` 等）を再実装しない
+## 6. We don't host a PTY or terminal-multiplexer layer
 
-**やらないこと**: Claude Code 公式に同梱されているスキル群（`simplify` / `init` / `review` / `security-review` 等）の機能を claude-org-ja 側で再実装すること。
+**What we don't do**: keep low-level implementations such as pseudo-terminal (PTY) control, pane splitting, or keystroke injection inside this repository.
 
-**理由**: 公式スキルに乗っかる方針です。再実装すると公式の更新のたびに追従コストがかかり、しかもユーザーから見ると「公式版と何が違うのか」が分かりにくくなります。claude-org-ja の対象範囲は公式が提供しない運用規律層に絞ります。
+**Why**: PTY and terminal-multiplexing concerns are separated into **Layer 3 = `renga`** (`suisya-systems/renga`). claude-org is Layer 4, "the operational layer that drives Claude Code as-is", and defers low-level terminal control to the dependency. Hosting both in one repository would cause the operational-discipline track and the PTY-fix track to interfere, slowing release cadence.
 
-**代替手段**: 公式スキルはそのまま使ってください。組織運用文脈で公式スキルを呼び出すラッパーが必要な場合のみ、`/org-*` 系として薄く包みます（例: `/org-retro` は振り返りの組織化ラッパー）。
-
----
-
-## 12. MCP の HTTP 公開形式の外部統合は持たない
-
-**やらないこと**: MCP サーバーを HTTP で外部公開し、ブラウザ拡張や別マシンの IDE から接続できるようにすること。
-
-**理由**: claude-org-ja の MCP サーバーは `renga-peers`（ローカル標準入出力経由）に集約されており、**同一タブ内 P2P** が通信モデルの正本です。HTTP 公開は認証・流量制御・TLS・ネットワーク境界という別レイヤの問題を呼び込み、「ローカルで完結する運用規律」というシンプルな保証が崩れます。
-
-**代替手段**: 別マシンや別タブからの監視は、状態ファイル（`.state/`）とダッシュボード（`/org-dashboard`）経由で行ってください。リアルタイムの外部統合が必要なら、別途 MCP の HTTP サーバーを併設する設計も可能ですが、claude-org-ja 本体の責務外とします。
+**Alternative**: pane operations, structured pane spawning, and peer communication go through the `renga-peers` MCP server (provided by Layer 3, 14 tools).
 
 ---
 
-## 改訂履歴
+## 7. We don't ship a benchmark suite (SWE-Bench scores, etc.)
 
-- 2026-04-27: 初版（Issue #107 README 全面書き換えに伴い分離）
+**What we don't do**: features that run agent-benchmark suites and publish scores.
+
+**Why**: claude-org is not an agent-performance benchmarking framework. We do care about **whether the operational logic is correct** — "did the Lead's instruction get carried out by the Worker the way it should have?", "did raw notes graduate to curated knowledge correctly?" — but "what score Claude Code gets on a benchmark" is an evaluation of Claude Code itself, outside claude-org's scope.
+
+**Alternative**: use Anthropic's published numbers or dedicated OSS (`swe-bench`, etc.) for SWE-Bench, HumanEval, and the like.
+
+---
+
+## 8. We don't ship a stack-by-stack prompt template library
+
+**What we don't do**: bundle stack-specific prompt template libraries ("Next.js prompts", "Rails prompts", "Django prompts", etc.) with this framework.
+
+**Why**: claude-org's design centers on **building project-specific context**. The repository-level `CLAUDE.md` and the per-task `CLAUDE.local.md` are the canonical context; stack-by-stack prompts tend toward "lowest-common-denominator generic text" and dilute project-specific context.
+
+**Alternative**: if you want a stack-specific prompt, write it into the project's own `CLAUDE.md`, or reference an external prompt library (Awesome-Prompts-style) separately.
+
+---
+
+## 9. We don't adopt the `tools` front-matter form for permission declarations
+
+**What we don't do**: an official form in which a skill or agent definition file declares tool permissions per-file via front matter such as `tools: [Read, Edit, Bash]`.
+
+**Why**: claude-org controls permissions per task via **`settings.local.json` plus deny hooks**. A front-matter declaration is static and can't express the dynamic boundary of "which Worker, when, in which working directory". The same skill needs different permissions in different tasks, so we make the decision dynamic on the role × task axes.
+
+**Alternative**: when you need to extend tool permissions, update `tools/role_configs_schema.json` (the propagation order is schema → `permissions.md` → actual `settings.local.json`). For drift handling see the `tools/check_role_configs.py` section in [docs/getting-started.md](getting-started.md).
+
+---
+
+## 10. We don't allow cross-cutting access via `--add-dir` by default
+
+**What we don't do**: let a Worker freely access locations outside its own working directory (other Workers' working trees, the home directory outside the repo, etc.).
+
+**Why**: claude-org treats **the working-directory boundary as a hard boundary**. Sharing trees or state across Workers introduces concurrent-work conflicts and accidents like overwriting another Worker's commits. Every relaxation of the boundary increases the cost of tracking "who saw what".
+
+**Alternative**: anything that genuinely needs to be shared belongs in Lead-managed areas such as `knowledge/curated/` or `registry/`, and is rewritten only via the Dispatcher or the Lead.
+
+---
+
+## 11. We don't reimplement the bundled official skills (`/simplify`, etc.)
+
+**What we don't do**: rebuild the functionality of skills bundled with Claude Code (`simplify` / `init` / `review` / `security-review`, etc.) inside claude-org.
+
+**Why**: we lean on the official skills. Reimplementing them costs follow-up effort each time the official versions update, and from a user's standpoint it becomes hard to tell "what's different from official". claude-org's scope is limited to the operational-discipline layer that the official skills don't cover.
+
+**Alternative**: use the official skills directly. Only when an organization-context wrapper around an official skill is needed do we wrap it thinly under the `/org-*` family (e.g. `/org-retro` is a retrospective wrapper organized for the org).
+
+---
+
+## 12. We don't expose MCP over HTTP for external integrations
+
+**What we don't do**: expose an MCP server over HTTP so it can be reached from a browser extension or an IDE on a different machine.
+
+**Why**: claude-org's MCP server is consolidated into `renga-peers` (over local stdio), and the canonical communication model is **same-tab P2P**. An HTTP exposure brings in a separate layer of concerns — auth, rate limiting, TLS, network boundary — and breaks the simple guarantee of "operational discipline that completes locally".
+
+**Alternative**: monitor from another machine or another tab via the state files (`.state/`) and the dashboard (`/org-dashboard`). If real-time external integration is needed, you can stand up an additional HTTP MCP server alongside, but that responsibility lies outside claude-org proper.
+
+---
+
+## Revision history
+
+- 2026-04-27: Initial version (split out alongside the README rewrite in Issue #107)

--- a/docs/org-state-schema.md
+++ b/docs/org-state-schema.md
@@ -1,41 +1,41 @@
-# org-state.json スキーマ定義
+# org-state.json schema definition
 
-## 概要
+## Overview
 
-`.state/org-state.json` は `.state/org-state.md` の機械可読スナップショットです。
-ダッシュボード（`dashboard/server.py`）その他のプログラム的消費者が JSON を優先的に読み込めるようにするために導入されました。
+`.state/org-state.json` is the machine-readable snapshot of `.state/org-state.md`.
+It was introduced so that programmatic consumers — the dashboard (`dashboard/server.py`) and others — can prefer reading JSON.
 
-### Source of truth ルール
+### Source-of-truth rule
 
-**Markdown が正本、JSON は派生です。**
+**Markdown is canonical; JSON is derived.**
 
-- `org-state.md` が常に正本です。Claude Code インスタンスが直接読み書きします。
-- `org-state.json` は派生ファイルです。`org_state_converter.py` が生成します。
-- `org-state.md` を手動編集した場合は、必ず converter を再実行してください。
-- 両者が矛盾する場合は `org-state.md` を信頼してください。
+- `org-state.md` is always canonical. Claude Code instances read and write it directly.
+- `org-state.json` is a derived file. `org_state_converter.py` generates it.
+- If you edit `org-state.md` by hand, re-run the converter afterwards.
+- When the two disagree, trust `org-state.md`.
 
-### JSON の再生成
+### Regenerating the JSON
 
 ```bash
 py -3 dashboard/org_state_converter.py      # Windows
 python3 dashboard/org_state_converter.py     # Mac/Linux
 ```
 
-### 更新ポイント
+### Update points
 
-以下の操作を行った後、converter を実行して JSON を更新してください:
+After the operations below, run the converter to update the JSON:
 
-| 操作 | スキル | 更新内容 |
+| Operation | Skill | What is updated |
 |---|---|---|
-| ワーカー派遣 | org-delegate Step 4 | Current Objective, Active Work Items, Worker Directory Registry |
-| ステータス変更 | org-delegate Step 5 | Work Item のステータス（REVIEW/COMPLETED/IN_PROGRESS） |
-| 組織中断 | org-suspend Phase 3 | Status=SUSPENDED, Updated, Work Items, Resume Instructions |
-| 組織再開 | org-resume Phase 4 | Status=ACTIVE |
-| 起動（Dispatcher/Curator 記録） | org-start Steps 2-3 | Dispatcher/Curator のピア ID とペイン名 |
+| Worker dispatch | org-delegate Step 4 | Current Objective, Active Work Items, Worker Directory Registry |
+| Status change | org-delegate Step 5 | Work Item status (REVIEW/COMPLETED/IN_PROGRESS) |
+| Organization suspend | org-suspend Phase 3 | Status=SUSPENDED, Updated, Work Items, Resume Instructions |
+| Organization resume | org-resume Phase 4 | Status=ACTIVE |
+| Boot (Dispatcher / Curator records) | org-start Steps 2-3 | Dispatcher / Curator peer ID and pane name |
 
 ---
 
-## スキーマ（version 1）
+## Schema (version 1)
 
 ```json
 {
@@ -75,75 +75,75 @@ python3 dashboard/org_state_converter.py     # Mac/Linux
 
 ---
 
-## フィールド説明
+## Field descriptions
 
-### トップレベル
+### Top level
 
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| `version` | `integer` | スキーマバージョン。現在は `1`。将来の非互換変更時にインクリメント |
-| `updated` | `string \| null` | org-state.md の `Updated:` フィールドの値（ISO 8601）。未設定なら `null` |
-| `status` | `string` | 組織の状態。`ACTIVE`（稼働中）/ `SUSPENDED`（中断）/ `IDLE`（未使用） |
-| `currentObjective` | `string \| null` | 現在の目標（`Current Objective:` フィールド）。未設定なら `null` |
-| `workItems` | `array` | 作業アイテム一覧 |
-| `workerDirectoryRegistry` | `array` | ワーカーディレクトリ再利用テーブル |
-| `dispatcher` | `object \| null` | フォアマンのピア・ペイン情報。未記録なら `null` |
-| `curator` | `object \| null` | キュレーターのピア・ペイン情報。未記録なら `null` |
-| `resumeInstructions` | `string \| null` | 再開時の注意事項（org-suspend が書く）。なければ `null` |
+| `version` | `integer` | Schema version. Currently `1`. Bumped on future incompatible changes |
+| `updated` | `string \| null` | The value of `Updated:` in org-state.md (ISO 8601). `null` if unset |
+| `status` | `string` | Organization state. `ACTIVE` (running) / `SUSPENDED` (suspended) / `IDLE` (unused) |
+| `currentObjective` | `string \| null` | Current objective (the `Current Objective:` field). `null` if unset |
+| `workItems` | `array` | List of work items |
+| `workerDirectoryRegistry` | `array` | Worker-directory reuse table |
+| `dispatcher` | `object \| null` | Dispatcher's peer and pane info. `null` if unrecorded |
+| `curator` | `object \| null` | Curator's peer and pane info. `null` if unrecorded |
+| `resumeInstructions` | `string \| null` | Notes for resume (written by org-suspend). `null` if absent |
 
-### workItems 要素
+### workItems element
 
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| `id` | `string` | タスク ID（kebab-case 英語）。例: `blog-redesign`, `data-analysis` |
-| `title` | `string` | タスク名（日本語可）。org-state.md の `- {id}: {title} [{status}]` から取得 |
-| `status` | `string` | タスクの状態（下記参照） |
-| `progress` | `string \| null` | 最新の進捗メモ（`- 結果:` サブ項目）。なければ `null` |
-| `worker` | `string \| null` | 担当ワーカーのピア ID（`- ワーカー:` サブ項目）。なければ `null` |
+| `id` | `string` | Task ID (kebab-case English). Examples: `blog-redesign`, `data-analysis` |
+| `title` | `string` | Task title (Japanese is allowed). Taken from `- {id}: {title} [{status}]` in org-state.md |
+| `status` | `string` | Task status (see below) |
+| `progress` | `string \| null` | Latest progress note (the `- 結果:` sub-item). `null` if absent |
+| `worker` | `string \| null` | Assigned Worker's peer ID (the `- ワーカー:` sub-item). `null` if absent |
 
-**status の値:**
+**status values:**
 
-| 値 | 意味 |
+| Value | Meaning |
 |---|---|
-| `IN_PROGRESS` | 作業中 |
-| `COMPLETED` | 完了（人間が承認済み） |
-| `PENDING` | 待機中（まだ開始していない） |
-| `BLOCKED` | ブロック中（依存関係や問題あり） |
-| `REVIEW` | レビュー中（ワーカーが完了報告済み、人間の承認待ち） |
-| `ABANDONED` | 中止 |
+| `IN_PROGRESS` | In progress |
+| `COMPLETED` | Completed (approved by the human) |
+| `PENDING` | Pending (not yet started) |
+| `BLOCKED` | Blocked (dependency or issue) |
+| `REVIEW` | Under review (Worker has reported completion; awaiting human approval) |
+| `ABANDONED` | Abandoned |
 
-### workerDirectoryRegistry 要素
+### workerDirectoryRegistry element
 
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| `taskId` | `string` | そのディレクトリを使用しているタスク ID |
-| `pattern` | `string` | ディレクトリパターン: `A`（プロジェクトディレクトリ）/ `B`（worktree）/ `C`（エフェメラル） |
-| `directory` | `string` | ワーカーディレクトリの絶対パス |
-| `project` | `string` | プロジェクト名。エフェメラルの場合は `-` |
-| `status` | `string` | `in_use`（作業中）/ `available`（完了済み・再利用可能） |
+| `taskId` | `string` | Task ID using the directory |
+| `pattern` | `string` | Directory pattern: `A` (project directory) / `B` (worktree) / `C` (ephemeral) |
+| `directory` | `string` | Absolute path of the Worker directory |
+| `project` | `string` | Project name. `-` for ephemeral |
+| `status` | `string` | `in_use` (active) / `available` (completed, reusable) |
 
-### dispatcher / curator
+### `dispatcher` / `curator`
 
-| フィールド | 型 | 説明 |
+| Field | Type | Description |
 |---|---|---|
-| `peerId` | `string` | renga-peers のペイン名（`worker-{task_id}` / `dispatcher` / `curator` 形式）。`mcp__renga-peers__send_message` の `to_id` に渡す値 |
-| `paneId` | `string` | renga のペイン名 (`--id` で命名したもの、例: `dispatcher`, `curator`)。旧 WezTerm 時代は数値の pane-id を格納していたが、ccmux 移行に伴い安定名ベースに変更。現行仕様では `peerId` と同値になることが多い |
+| `peerId` | `string` | renga-peers pane name (`worker-{task_id}` / `dispatcher` / `curator` form). Pass to `mcp__renga-peers__send_message` as `to_id` |
+| `paneId` | `string` | renga pane name (the value passed via `--id`, e.g. `dispatcher`, `curator`). Older WezTerm builds stored a numeric pane-id; after migrating to ccmux this became a stable name. In the current spec this is often the same value as `peerId` |
 
 ---
 
-## ダッシュボードとの統合
+## Integration with the dashboard
 
-`dashboard/server.py` は以下の優先順位で org-state を読み込みます:
+`dashboard/server.py` reads org-state in this order of preference:
 
-1. `.state/org-state.json` が存在し、かつ mtime が `.state/org-state.md` 以上の場合 → JSON を使用
-2. それ以外 → `.state/org-state.md` を正規表現でパース（フォールバック）
+1. If `.state/org-state.json` exists and its mtime is at least `.state/org-state.md`'s → use the JSON
+2. Otherwise → parse `.state/org-state.md` with regex (fallback)
 
-この設計により、converter 未実行の環境や JSON が stale な場合でも正常動作します。
+This design works correctly even when the converter has not been run, or when the JSON is stale.
 
 ---
 
-## バージョン履歴
+## Version history
 
-| バージョン | 変更内容 |
+| Version | Changes |
 |---|---|
-| 1 | 初版。Issue #20 で導入 |
+| 1 | Initial version. Introduced in Issue #20 |

--- a/docs/oss-comparison.md
+++ b/docs/oss-comparison.md
@@ -1,31 +1,31 @@
-# マルチエージェントAI協調フレームワーク — OSS比較レポート
+# Multi-Agent AI Coordination Frameworks — OSS Comparison Report
 
-> 調査日: 2026-04-06
-> 目的: claude-orgの設計思想（複数AIインスタンスの協調・役割分担・常駐ロール・自己成長ループ・スキルによるプログレッシブディスクロージャー）と類似するOSSを網羅的に調査し、比較する
+> Survey date: 2026-04-06
+> Purpose: comprehensively survey and compare OSS projects similar to claude-org's design philosophy (multi-instance AI coordination, role separation, resident roles, self-improvement loop, progressive disclosure via skills).
 
 ---
 
-## 1. claude-orgの設計特徴（比較の基準）
+## 1. claude-org's design characteristics (the basis for comparison)
 
-claude-orgは以下の特徴を持つ:
+claude-org has the following characteristics:
 
-| 特徴 | 内容 |
+| Characteristic | Description |
 |---|---|
-| **マルチインスタンス協調** | 窓口・フォアマン・キュレーター・ワーカーの4種類のClaude Codeインスタンスが協調動作 |
-| **役割分担** | Secretary（対話）、Dispatcher（ペイン管理）、Curator（知見整理）、Worker（実作業）の明確な分業 |
-| **常駐ロール** | Secretary/Dispatcher/Curatorは常駐、Workerはオンデマンド起動 |
-| **状態管理** | ジャーナル（JSONL）＋スナップショット（Markdown）＋サスペンドの三層構造 |
-| **自己成長ループ** | Worker→raw知見→Curator整理→改善提案→ユーザー承認→スキル/CLAUDE.md更新 |
-| **通信方式** | `renga-peers` MCP（同タブ内 P2P プッシュ型）＋ CLAUDE.md（永続ベースライン） |
-| **プログレッシブディスクロージャー** | スキルシステムにより必要時のみ詳細手順をロード |
+| **Multi-instance coordination** | Four kinds of Claude Code instance — Lead, Dispatcher, Curator, Worker — coordinate together |
+| **Role separation** | Clear division of labor: Lead (dialogue), Dispatcher (pane management), Curator (knowledge curation), Worker (real work) |
+| **Resident roles** | Lead / Dispatcher / Curator are resident; Workers boot on demand |
+| **State management** | Three-layer structure: journal (JSONL) + snapshot (Markdown) + suspend |
+| **Self-improvement loop** | Worker → raw learning → Curator curation → improvement proposal → user approval → skill / CLAUDE.md update |
+| **Communication model** | `renga-peers` MCP (same-tab P2P, push-style) + CLAUDE.md (persistent baseline) |
+| **Progressive disclosure** | The skill system loads detailed procedures only when needed |
 
 ---
 
-## 2. 比較対象OSS一覧
+## 2. List of OSS projects compared
 
-### 2.1 汎用マルチエージェントフレームワーク
+### 2.1 General-purpose multi-agent frameworks
 
-| # | プロジェクト | 開発元 | GitHub Stars | ライセンス |
+| # | Project | Developer | GitHub Stars | License |
 |---|---|---|---|---|
 | 1 | [CrewAI](https://github.com/crewaiinc/crewai) | CrewAI Inc. | 44,300+ | MIT |
 | 2 | [LangGraph](https://github.com/langchain-ai/langgraph) | LangChain | 24,800+ | MIT |
@@ -34,190 +34,190 @@ claude-orgは以下の特徴を持つ:
 | 5 | [Google ADK](https://github.com/google/adk-python) | Google | — | Apache 2.0 |
 | 6 | [AWS Agent Squad](https://github.com/awslabs/agent-squad) | AWS Labs | — | Apache 2.0 |
 
-### 2.2 Claude Code特化型マルチエージェント
+### 2.2 Claude-Code-specific multi-agent
 
-| # | プロジェクト | 開発元 | 特徴 |
+| # | Project | Developer | Notes |
 |---|---|---|---|
-| 7 | [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams) | Anthropic（公式） | 公式のマルチセッション協調機能（実験的） |
-| 8 | [Ruflo](https://github.com/ruvnet/ruflo) | ruvnet | Claude Code向けスウォーム型エージェントプラットフォーム |
-| 9 | [oh-my-claudecode](https://github.com/yeachan-heo/oh-my-claudecode) | Yeachan Heo | チーム指向のマルチエージェントオーケストレーション |
-| 10 | [claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents) | baryhuang | @mentionベースのマルチエージェント協調 |
+| 7 | [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams) | Anthropic (official) | Official multi-session coordination feature (experimental) |
+| 8 | [Ruflo](https://github.com/ruvnet/ruflo) | ruvnet | Swarm-style agent platform for Claude Code |
+| 9 | [oh-my-claudecode](https://github.com/yeachan-heo/oh-my-claudecode) | Yeachan Heo | Team-oriented multi-agent orchestration |
+| 10 | [claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents) | baryhuang | @mention-based multi-agent coordination |
 
-### 2.3 自己成長・自己改善系
+### 2.3 Self-improvement / self-evolution
 
-| # | プロジェクト | 開発元 | 特徴 |
+| # | Project | Developer | Notes |
 |---|---|---|---|
-| 11 | [Agent Zero](https://github.com/agent0ai/agent-zero) | agent0ai | 自律的ツール作成と永続メモリによる学習 |
-| 12 | [OpenSpace](https://github.com/HKUDS/OpenSpace) | HKUDS（香港大学） | 自己進化型スキルエンジン |
-| 13 | [AutoAgent](https://github.com/kevinrgu/autoagent) | Kevin Gu / thirdlayer | エージェントハーネスの自律的最適化 |
-| 14 | [SuperAGI](https://github.com/TransformerOptimus/SuperAGI) | TransformerOptimus | 自律エージェントフレームワーク（パフォーマンス自動改善） |
+| 11 | [Agent Zero](https://github.com/agent0ai/agent-zero) | agent0ai | Autonomous tool creation and learning via persistent memory |
+| 12 | [OpenSpace](https://github.com/HKUDS/OpenSpace) | HKUDS (Univ. of Hong Kong) | Self-evolving skill engine |
+| 13 | [AutoAgent](https://github.com/kevinrgu/autoagent) | Kevin Gu / thirdlayer | Autonomous optimization of the agent harness |
+| 14 | [SuperAGI](https://github.com/TransformerOptimus/SuperAGI) | TransformerOptimus | Autonomous agent framework (auto performance improvement) |
 
 ---
 
-## 3. 比較軸ごとの詳細分析
+## 3. Detailed analysis along each comparison axis
 
-### 3.1 マルチエージェント協調方式
+### 3.1 Multi-agent coordination model
 
-| プロジェクト | 協調方式 | 詳細 |
+| Project | Coordination model | Detail |
 |---|---|---|
-| **claude-org** | **階層型＋P2P** | Secretary→Dispatcher→Worker の階層的委譲 ＋ `renga-peers` MCP でのP2P通信（同タブスコープ） |
-| CrewAI | ロールベース協調 | Agent に role/backstory/goal を定義し、crew として協調。Sequential / Hierarchical プロセス |
-| LangGraph | グラフベース | ノード（エージェント）とエッジ（遷移）でワークフローを定義。条件分岐・ループ対応 |
-| AutoGen | 会話ベース | エージェント間のメッセージパッシングによる協調。GroupChat で複数エージェント会話 |
-| Swarm | ハンドオフ型 | Agent 間の明示的なハンドオフ（引き継ぎ）でタスクを委譲。ステートレス |
-| Google ADK | 階層型 | エージェントを階層的に構成。Sequential / Parallel / Loop ワークフロー ＋ LLM動的ルーティング |
-| Agent Squad | スーパーバイザー型 | SupervisorAgent が agent-as-tools パターンで専門エージェントを並列調整 |
-| Agent Teams | チームリード型 | 1つのリードセッション＋最大15のチームメイト。共有タスクリスト＋P2Pメッセージング |
-| Ruflo | スウォーム型 | 最大100エージェントが並列動作。6種の協調パターン。自己学習ルーティング |
-| oh-my-claudecode | オートパイロット型 | 32専門エージェントの自動委譲。最大5並行ワーカー |
-| Agent Zero | 階層型 | 上位エージェントが下位エージェントを生成・委譲。再帰的な構造 |
-| OpenSpace | スタンドアロン＋共有 | 単体Agent ＋ MCPサーバー経由での統合。スキル共有コミュニティ |
+| **claude-org** | **Hierarchical + P2P** | Hierarchical delegation Lead→Dispatcher→Worker + P2P over `renga-peers` MCP (same-tab scope) |
+| CrewAI | Role-based coordination | Define role/backstory/goal on each Agent and coordinate as a crew. Sequential / Hierarchical processes |
+| LangGraph | Graph-based | Workflows defined as nodes (agents) and edges (transitions). Supports conditional branching and loops |
+| AutoGen | Conversation-based | Coordination via message passing between agents. GroupChat enables multi-agent conversation |
+| Swarm | Hand-off model | Tasks are explicitly handed off between Agents. Stateless |
+| Google ADK | Hierarchical | Agents composed hierarchically. Sequential / Parallel / Loop workflows + LLM dynamic routing |
+| Agent Squad | Supervisor model | A SupervisorAgent coordinates specialist agents in parallel via the agent-as-tools pattern |
+| Agent Teams | Team-lead model | One lead session + up to 15 teammates. Shared task list + P2P messaging |
+| Ruflo | Swarm | Up to 100 agents run in parallel. Six coordination patterns. Self-learning routing |
+| oh-my-claudecode | Autopilot | Auto delegation across 32 specialist agents. Up to 5 parallel workers |
+| Agent Zero | Hierarchical | Higher agents spawn and delegate to lower agents. Recursive structure |
+| OpenSpace | Standalone + sharing | Single Agent + integration via MCP server. Skill-sharing community |
 
-**claude-orgとの類似度**: Agent Teams が最も近い（P2P通信 ＋ 共有タスクリスト）。CrewAI のロールベース設計も概念的に近い。
+**Similarity to claude-org**: Agent Teams is closest (P2P communication + shared task list). CrewAI's role-based design is conceptually close as well.
 
-### 3.2 役割分担
+### 3.2 Role separation
 
-| プロジェクト | 役割モデル | 常駐ロール | 動的ロール |
+| Project | Role model | Resident roles | Dynamic roles |
 |---|---|---|---|
-| **claude-org** | **Secretary / Dispatcher / Curator / Worker** | **3（Sec/Fore/Cur）** | **Worker（オンデマンド）** |
-| CrewAI | ユーザー定義ロール（Manager / Researcher 等） | なし（実行時のみ） | 全エージェント |
-| LangGraph | ノードとして定義（固定名なし） | なし | 全ノード |
-| AutoGen | UserProxy / Assistant / GroupChatManager 等 | なし | 全エージェント |
-| Swarm | ユーザー定義（Triage / Sales 等） | なし | 全エージェント |
-| Google ADK | 階層的エージェント定義 | なし | 全エージェント |
-| Agent Squad | Supervisor ＋ 専門エージェント | なし | 全エージェント |
-| Agent Teams | Team Lead ＋ Teammates | Team Lead（1） | Teammates |
-| Ruflo | Orchestrator ＋ Specialist Swarm | なし（オンデマンド起動） | 全エージェント |
-| oh-my-claudecode | Architect ＋ 32専門エージェント | なし | 全エージェント |
-| Agent Zero | 親エージェント＋子エージェント | 親（1） | 子エージェント |
-| OpenSpace | 単体エージェント（役割分担なし） | — | — |
+| **claude-org** | **Lead / Dispatcher / Curator / Worker** | **3 (Lead / Dispatcher / Curator)** | **Worker (on demand)** |
+| CrewAI | User-defined roles (Manager / Researcher / etc.) | None (only at runtime) | All agents |
+| LangGraph | Defined as nodes (no fixed names) | None | All nodes |
+| AutoGen | UserProxy / Assistant / GroupChatManager / etc. | None | All agents |
+| Swarm | User-defined (Triage / Sales / etc.) | None | All agents |
+| Google ADK | Hierarchical agent definitions | None | All agents |
+| Agent Squad | Supervisor + specialist agents | None | All agents |
+| Agent Teams | Team Lead + Teammates | Team Lead (1) | Teammates |
+| Ruflo | Orchestrator + Specialist Swarm | None (on-demand spawn) | All agents |
+| oh-my-claudecode | Architect + 32 specialist agents | None | All agents |
+| Agent Zero | Parent agent + child agents | Parent (1) | Child agents |
+| OpenSpace | Single agent (no role separation) | — | — |
 
-**claude-orgの独自性**: **常駐ロールの多さ**（3種）と**明確な組織構造**（Secretary-Dispatcher-Curator-Worker）は他に類を見ない。特にCurator（知見整理専門の常駐プロセス）はclaude-org固有の設計。
+**What's distinctive about claude-org**: **the number of resident roles** (three) and **a clear organizational structure** (Lead-Dispatcher-Curator-Worker) is unmatched elsewhere. The Curator in particular — a resident process specialized in knowledge curation — is unique to claude-org.
 
-### 3.3 状態管理
+### 3.3 State management
 
-| プロジェクト | 状態永続化 | 形式 | クラッシュリカバリ |
+| Project | State persistence | Format | Crash recovery |
 |---|---|---|---|
-| **claude-org** | **ジャーナル＋スナップショット＋サスペンド（三層）** | **JSONL / Markdown** | **ジャーナルからの復元 ＋ org-resume** |
-| CrewAI | メモリ（短期/長期/エンティティ） | 内部DB | 限定的 |
-| LangGraph | チェックポイント（永続化） | カスタムストレージ | タイムトラベルデバッグ対応 |
-| AutoGen | セッションベース状態管理 | メモリ / シリアライズ | v0.4で改善 |
-| Swarm | **なし**（ステートレス設計） | — | なし |
-| Google ADK | セッション状態 | カスタム | Vertex AI連携 |
-| Agent Squad | コンテキスト管理 | メモリ | 限定的 |
-| Agent Teams | 共有タスクリスト（ファイルベース） | JSON / ファイル | タスクリストから復元可能 |
-| Ruflo | ニューラルメモリ（v3） | 内部DB | パターン保持（catastrophic forgetting防止） |
-| Agent Zero | 永続メモリ | ファイルベース | メモリから復元 |
-| OpenSpace | スキルDB | ファイルベース | スキルの自動修復（FIXモード） |
+| **claude-org** | **Journal + snapshot + suspend (three layers)** | **JSONL / Markdown** | **Restoration from journal + org-resume** |
+| CrewAI | Memory (short-term / long-term / entity) | Internal DB | Limited |
+| LangGraph | Checkpoints (persisted) | Custom storage | Time-travel debugging supported |
+| AutoGen | Session-based state management | Memory / serialization | Improved in v0.4 |
+| Swarm | **None** (stateless design) | — | None |
+| Google ADK | Session state | Custom | Vertex AI integration |
+| Agent Squad | Context management | Memory | Limited |
+| Agent Teams | Shared task list (file-based) | JSON / files | Recoverable from the task list |
+| Ruflo | Neural memory (v3) | Internal DB | Pattern retention (catastrophic-forgetting prevention) |
+| Agent Zero | Persistent memory | File-based | Recovery from memory |
+| OpenSpace | Skill DB | File-based | Auto skill repair (FIX mode) |
 
-**claude-orgの特徴**: **Markdown形式での状態管理**は、新規インスタンスが読むだけで状況を把握できる点がユニーク。LangGraphのチェックポイント機能が機能面では最も充実。
+**What's distinctive about claude-org**: **Markdown-based state management** is unique in that a fresh instance can grasp the situation just by reading the file. LangGraph's checkpoints are the most full-featured on the functional axis.
 
-### 3.4 自己改善メカニズム
+### 3.4 Self-improvement mechanism
 
-| プロジェクト | 自己改善 | メカニズム | 人間の承認 |
+| Project | Self-improvement | Mechanism | Human approval |
 |---|---|---|---|
-| **claude-org** | **あり（構造化ループ）** | **Worker→raw知見→Curator整理→提案→承認→スキル更新** | **必須（安全弁）** |
-| CrewAI | 限定的 | タスク間でのメモリ蓄積 | なし |
-| LangGraph | なし（外部実装は可能） | — | — |
-| AutoGen | 計画中 | エージェントの長期学習（ロードマップ） | — |
-| Swarm | なし | — | — |
-| Google ADK | なし | — | — |
-| Agent Squad | なし | — | — |
-| Agent Teams | なし | — | — |
-| Ruflo | あり | タスク実行からの自動学習、パターン保持 | なし（自動） |
-| oh-my-claudecode | 限定的 | 実行結果のフィードバック | なし |
-| Agent Zero | あり | 動的ツール作成、永続メモリによる学習 | なし（自律的） |
-| OpenSpace | **あり（最も高度）** | **FIX / DERIVED / CAPTURED の3モード進化。スキルの自動修復・派生・獲得** | **なし（自律的）** |
-| AutoAgent | あり（メタ最適化） | ハーネス自体を自律的に最適化（プロンプト・ツール・ルーティング） | なし（自律的） |
-| SuperAGI | あり | 実行ごとのパフォーマンス改善 | なし |
+| **claude-org** | **Yes (structured loop)** | **Worker → raw learning → Curator curation → proposal → approval → skill update** | **Required (safety valve)** |
+| CrewAI | Limited | Memory accumulated across tasks | None |
+| LangGraph | None (external implementation possible) | — | — |
+| AutoGen | Planned | Long-term agent learning (roadmap) | — |
+| Swarm | None | — | — |
+| Google ADK | None | — | — |
+| Agent Squad | None | — | — |
+| Agent Teams | None | — | — |
+| Ruflo | Yes | Auto learning from task execution, pattern retention | None (autonomous) |
+| oh-my-claudecode | Limited | Feedback from execution results | None |
+| Agent Zero | Yes | Dynamic tool creation, learning via persistent memory | None (autonomous) |
+| OpenSpace | **Yes (most advanced)** | **Three-mode evolution: FIX / DERIVED / CAPTURED. Auto skill repair, derivation, capture** | **None (autonomous)** |
+| AutoAgent | Yes (meta-optimization) | Autonomously optimizes the harness itself (prompts / tools / routing) | None (autonomous) |
+| SuperAGI | Yes | Per-run performance improvement | None |
 
-**claude-orgの独自性**: **人間の承認を挟む自己改善ループ**はclaude-org固有。他の自己改善系は自律的（人間介入なし）。OpenSpaceのスキル進化メカニズムはclaude-orgのスキルシステムと概念的に近いが、人間の承認プロセスがない。
+**What's distinctive about claude-org**: **a self-improvement loop with human approval in the middle** is unique to claude-org. Other self-improvement projects are autonomous (no human in the loop). OpenSpace's skill-evolution mechanism is conceptually close to claude-org's skill system, but lacks the human-approval step.
 
-### 3.5 通信方式
+### 3.5 Communication model
 
-| プロジェクト | 通信方式 | 特徴 |
+| Project | Communication model | Notes |
 |---|---|---|
-| **claude-org** | **`renga-peers` MCP（同タブ内 P2P プッシュ型）＋ CLAUDE.md（永続ベースライン）** | **二重化による信頼性。揮発的通信 ＋ 永続的指示の組み合わせ** |
-| CrewAI | コンテキスト共有・委譲 | エージェント間で context / delegation |
-| LangGraph | 共有State経由 | グラフのState オブジェクトを通じたデータ共有 |
-| AutoGen | メッセージパッシング | エージェント間の直接メッセージ。GroupChatでブロードキャスト |
-| Swarm | ハンドオフ関数 | 会話コンテキストを丸ごと引き継ぎ |
-| Google ADK | 階層的メッセージ ＋ 転送 | 親子間のメッセージ ＋ LLM動的ルーティング |
-| Agent Squad | インテントルーティング | ユーザー入力を動的に適切なエージェントへルーティング |
-| Agent Teams | P2Pメールボックス ＋ 共有タスクリスト | ファイルベースのメールボックスシステム |
-| Ruflo | スウォーム通信 | 階層的協調 ＋ コンセンサスメカニズム |
-| Agent Zero | 親子間メッセージ | 階層的なメッセージパッシング |
+| **claude-org** | **`renga-peers` MCP (same-tab P2P, push-style) + CLAUDE.md (persistent baseline)** | **Reliability via layering. Volatile communication + persistent instructions in combination** |
+| CrewAI | Shared context / delegation | context / delegation between agents |
+| LangGraph | Via shared State | Data sharing through the graph's State object |
+| AutoGen | Message passing | Direct messages between agents. GroupChat broadcasts |
+| Swarm | Hand-off function | The conversation context is handed over wholesale |
+| Google ADK | Hierarchical messages + transfer | Parent–child messages + LLM dynamic routing |
+| Agent Squad | Intent routing | User input is dynamically routed to the right agent |
+| Agent Teams | P2P mailbox + shared task list | File-based mailbox system |
+| Ruflo | Swarm communication | Hierarchical coordination + consensus mechanism |
+| Agent Zero | Parent-child messaging | Hierarchical message passing |
 
-**claude-orgの独自性**: **指示の二重化**（CLAUDE.md永続指示 ＋ `renga-peers` リアルタイム通信）は他に類を見ない設計。Agent Teams のメールボックスシステムが最も近い。
+**What's distinctive about claude-org**: **layered instructions** (CLAUDE.md persistent instructions + `renga-peers` real-time communication) are an unmatched design. Agent Teams' mailbox system is the closest.
 
 ---
 
-## 4. 総合比較表
+## 4. Summary comparison matrix
 
-| 比較軸 | claude-org | CrewAI | LangGraph | AutoGen | Agent Teams | Ruflo | OpenSpace | Agent Zero |
+| Axis | claude-org | CrewAI | LangGraph | AutoGen | Agent Teams | Ruflo | OpenSpace | Agent Zero |
 |---|---|---|---|---|---|---|---|---|
-| 協調方式 | 階層＋P2P | ロール型 | グラフ型 | 会話型 | チーム型 | スウォーム型 | 単体＋共有 | 階層型 |
-| 役割の固定度 | ◎ 4役固定 | △ 自由定義 | △ 自由定義 | △ 自由定義 | ○ Lead＋Members | △ 自由定義 | × なし | ○ 親子 |
-| 常駐ロール | ◎ 3種 | × なし | × なし | × なし | ○ 1種 | × なし | × なし | ○ 1種 |
-| 状態永続化 | ◎ 三層 | ○ メモリ | ◎ チェックポイント | ○ セッション | ○ タスクリスト | ○ ニューラルDB | ○ スキルDB | ○ メモリ |
-| 自己改善 | ◎ 構造化 | △ 限定的 | × なし | × 計画中 | × なし | ○ 自動学習 | ◎ 3モード進化 | ○ ツール生成 |
-| 人間承認 | ◎ 必須 | × なし | × なし | × なし | × なし | × なし | × なし | × なし |
-| P2P通信 | ◎ | × | × | ○ | ◎ | △ | × | × |
-| 指示の永続化 | ◎ 二重化 | × | × | × | △ | × | × | × |
+| Coordination model | Hierarchical + P2P | Role-based | Graph | Conversation | Team | Swarm | Single + share | Hierarchical |
+| Role fixity | ◎ 4 fixed | △ Free-form | △ Free-form | △ Free-form | ○ Lead + Members | △ Free-form | × None | ○ Parent / child |
+| Resident roles | ◎ 3 | × None | × None | × None | ○ 1 | × None | × None | ○ 1 |
+| State persistence | ◎ 3 layers | ○ Memory | ◎ Checkpoint | ○ Session | ○ Task list | ○ Neural DB | ○ Skill DB | ○ Memory |
+| Self-improvement | ◎ Structured | △ Limited | × None | × Planned | × None | ○ Auto-learning | ◎ 3-mode evolution | ○ Tool generation |
+| Human approval | ◎ Required | × None | × None | × None | × None | × None | × None | × None |
+| P2P communication | ◎ | × | × | ○ | ◎ | △ | × | × |
+| Persistent instructions | ◎ Layered | × | × | × | △ | × | × | × |
 
-凡例: ◎ 高度に実装 / ○ 実装あり / △ 限定的 / × なし
-
----
-
-## 5. 特筆すべき類似プロジェクト（Top 3）
-
-### 5.1 Claude Code Agent Teams（最も構造的に近い）
-
-- **類似点**: P2P通信、共有タスクリスト、チームリード＋メンバーの構造
-- **相違点**: 常駐ロールは1種（Lead）のみ、Curator相当なし、自己成長ループなし、指示の二重化なし
-- **評価**: インフラ層（通信・タスク管理）は近いが、組織設計と自己改善の層が欠けている
-
-### 5.2 OpenSpace（自己改善の思想が最も近い）
-
-- **類似点**: スキルの自動進化（FIX/DERIVED/CAPTUREDはclaude-orgのraw→curated→skill更新に類似）、スキルの再利用
-- **相違点**: マルチエージェント協調ではない（単体エージェント＋MCP連携）、人間承認プロセスなし、役割分担なし
-- **評価**: 自己改善メカニズムの成熟度はclaude-orgより高い可能性があるが、組織としての協調機能がない
-
-### 5.3 CrewAI（役割ベース設計が近い）
-
-- **類似点**: エージェントに明確なロール（role/backstory/goal）を定義、階層的プロセス、委譲（delegation）の概念
-- **相違点**: 常駐ロールなし、状態管理は限定的、自己成長ループなし、Claude Code非依存
-- **評価**: 役割ベースの協調パターンは概念的に近いが、永続的な組織としての設計思想は異なる
+Legend: ◎ Highly implemented / ○ Implemented / △ Limited / × None
 
 ---
 
-## 6. claude-orgの差別化ポイント
+## 5. Most notable similar projects (Top 3)
 
-調査の結果、claude-orgには以下の差別化要素が確認された:
+### 5.1 Claude Code Agent Teams (closest structurally)
 
-### 6.1 既存OSSにない特徴
+- **Similar**: P2P communication, shared task list, team-lead + members structure
+- **Different**: only one resident role (Lead); no Curator equivalent; no self-improvement loop; no layered instructions
+- **Verdict**: the infrastructure layer (communication / task management) is close, but the organizational design and self-improvement layers are missing
 
-1. **常駐マルチロール組織**: Secretary/Dispatcher/Curator の3種の常駐ロールを持つ組織構造は他に例がない
-2. **人間承認付き自己改善ループ**: 自己改善を持つフレームワークは複数あるが、人間の承認を安全弁として組み込んでいるのはclaude-orgのみ
-3. **指示の二重化**: CLAUDE.md（永続ベースライン）＋ `renga-peers` メッセージ（リアルタイム補足）の組み合わせは他に類を見ない
-4. **プログレッシブディスクロージャー**: スキルシステムによるコンテキスト消費の最小化戦略
-5. **Markdown状態管理**: 新インスタンスが読むだけで状況把握可能な設計（機械可読かつ人間可読）
+### 5.2 OpenSpace (closest in self-improvement philosophy)
 
-### 6.2 既存OSSから学べる点
+- **Similar**: automatic skill evolution (FIX/DERIVED/CAPTURED resembles claude-org's raw → curated → skill update); skill reuse
+- **Different**: not multi-agent (single agent + MCP integration); no human-approval step; no role separation
+- **Verdict**: the self-improvement mechanism may be more mature than claude-org's, but the project lacks coordination as an organization
 
-1. **LangGraph のチェックポイント**: タイムトラベルデバッグは状態管理の強化に有用
-2. **OpenSpace のスキル進化3モード**: FIX/DERIVED/CAPTURED の分類はclaude-orgの知見整理に適用可能
-3. **Ruflo の自己学習ルーティング**: タスクの自動振り分けの改善に参考になる
-4. **Agent Teams のファイルロック**: 複数ワーカーの同時編集時の衝突防止メカニズム
-5. **AutoAgent のメタ最適化**: ハーネス自体の自動改善は、claude-orgのスキル自動更新の高度化に応用可能
+### 5.3 CrewAI (closest in role-based design)
+
+- **Similar**: clear roles assigned to agents (role/backstory/goal), hierarchical processes, the concept of delegation
+- **Different**: no resident roles; limited state management; no self-improvement loop; not Claude-Code-specific
+- **Verdict**: the role-based coordination pattern is conceptually close, but the design philosophy of being a persistent organization differs
 
 ---
 
-## 7. まとめ
+## 6. claude-org's differentiators
 
-claude-orgは「複数AIインスタンスによる永続的な組織運営」という独自のポジションを持つ。既存OSSの多くは「タスク実行時のエージェント協調」に焦点を当てているのに対し、claude-orgは**組織そのものの継続的運営と自己改善**を目指している。
+The survey identifies the following differentiators for claude-org:
 
-最も近いプロジェクトであるClaude Code Agent Teamsでさえ、常駐キュレーターや自己成長ループを持たない。claude-orgの設計思想は、現時点のOSSランドスケープにおいて明確なギャップを埋めるものである。
+### 6.1 Features absent from existing OSS
+
+1. **A multi-role resident organization**: an organizational structure with three resident roles (Lead / Dispatcher / Curator) is not seen elsewhere
+2. **A self-improvement loop with human approval**: several frameworks have self-improvement, but only claude-org embeds human approval as a safety valve
+3. **Layered instructions**: combining CLAUDE.md (persistent baseline) with `renga-peers` messages (real-time supplement) is unmatched
+4. **Progressive disclosure**: the skill system as a strategy to minimize context consumption
+5. **Markdown-based state management**: a design where a fresh instance can read its way into the situation (machine-readable and human-readable)
+
+### 6.2 What we can learn from existing OSS
+
+1. **LangGraph's checkpoints**: time-travel debugging would help strengthen state management
+2. **OpenSpace's three skill-evolution modes**: the FIX/DERIVED/CAPTURED taxonomy is applicable to claude-org's knowledge curation
+3. **Ruflo's self-learning routing**: a useful reference for improving automatic task assignment
+4. **Agent Teams' file locking**: a conflict-prevention mechanism for simultaneous edits across multiple Workers
+5. **AutoAgent's meta-optimization**: harness self-improvement is applicable to claude-org's auto skill updates
+
+---
+
+## 7. Conclusion
+
+claude-org occupies a unique position: "persistent organizational operation by multiple AI instances". Most existing OSS focuses on "agent coordination during task execution"; claude-org instead aims at **continuous operation and self-improvement of the organization itself**.
+
+Even the closest project — Claude Code Agent Teams — lacks a resident Curator and a self-improvement loop. claude-org's design philosophy fills a clear gap in the current OSS landscape.
 
 ---
 


### PR DESCRIPTION
## Summary

Wave B-core PR-4 of the 5-Wave plan for claude-org-ja#110.

- `docs/non-goals.md` (B3)
- `docs/getting-started.md` (B3)
- `docs/oss-comparison.md` (B2 structure-preserving)
- `docs/org-state-schema.md` (B2 structure-preserving)

Codex self-review: 3 rounds.
- Round 1: 3 Major (Secretary alias drift in oss-comparison/getting-started/non-goals → unified to Lead) + 1 Minor (org-state-schema heading lowercase → backticked).
- Round 2: 1 Major (getting-started.md:195 `--role <secretary|...>` CLI literal needed annotation).
- Round 3: clean.

The literal label `- ワーカー:` in `docs/org-state-schema.md:102` is **intentionally retained** — it is a parser literal for `.state/org-state.md`, not user-facing prose.

## Manifest entries

- `docs/non-goals.md` | translated
- `docs/getting-started.md` | translated
- `docs/oss-comparison.md` | translated
- `docs/org-state-schema.md` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#160 (Wave B-core)

## Test plan

- [x] No remaining ja-glossary terms (except documented parser literal)
- [x] B2 files preserve heading structure of ja source
- [x] Codex review converged (3 rounds, no Blocker/Major remaining)