### PR TITLE
Wave B-runtime PR-5: install scripts + CI workflow URL rewrite

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -126,7 +126,7 @@ jobs:
           echo "$out"
           # Sanity-check the dry-run actually reached the clone step and
           # honored --skip-mcp, so a silent early-exit can't pass.
-          echo "$out" | grep -qE "git[[:space:]]+clone[[:space:]]+--branch[[:space:]]+main[[:space:]]+https://github\.com/suisya-systems/claude-org-ja\.git" \
+          echo "$out" | grep -qE "git[[:space:]]+clone[[:space:]]+--branch[[:space:]]+main[[:space:]]+https://github\.com/suisya-systems/claude-org\.git" \
             || { echo "smoke: missing 'git clone --branch main' echo from dry-run" >&2; exit 1; }
           echo "$out" | grep -q "Skipping 'renga mcp install'" \
             || { echo "smoke: --skip-mcp banner missing" >&2; exit 1; }
@@ -148,7 +148,7 @@ jobs:
             Write-Error "smoke: install.ps1 exited with $LASTEXITCODE"
             exit 1
           }
-          if ($out -notmatch 'git\s+clone\s+--branch\s+main\s+https://github\.com/suisya-systems/claude-org-ja\.git') {
+          if ($out -notmatch 'git\s+clone\s+--branch\s+main\s+https://github\.com/suisya-systems/claude-org\.git') {
             Write-Error "smoke: missing 'git clone --branch main' echo from dry-run"
             exit 1
           }
@@ -206,7 +206,7 @@ jobs:
           git -C "$work_dir" branch test-fixture-ref-v1
           git clone --bare -q "$work_dir" "$fixture_dir"
           git config --global "url.${fixture_dir}.insteadOf" \
-            "https://github.com/suisya-systems/claude-org-ja.git"
+            "https://github.com/suisya-systems/claude-org.git"
 
       - name: Set up local clone fixture (Windows)
         if: runner.os == 'Windows'
@@ -224,7 +224,7 @@ jobs:
           & git -C $workDir -c user.email=ci@example.com -c user.name=CI commit --allow-empty -q -m "fixture commit"
           & git -C $workDir branch test-fixture-ref-v1
           & git clone --bare -q $workDir $fixtureDir
-          & git config --global "url.${fixtureDir}.insteadOf" "https://github.com/suisya-systems/claude-org-ja.git"
+          & git config --global "url.${fixtureDir}.insteadOf" "https://github.com/suisya-systems/claude-org.git"
           if ($LASTEXITCODE -ne 0) { Write-Error "fixture setup failed (exit $LASTEXITCODE)"; exit 1 }
 
       # ---- Case 2: CLAUDE_ORG_REF success path (Issue #154). Pin the
@@ -243,7 +243,7 @@ jobs:
           rm -rf "$target"
           out=$(CLAUDE_ORG_REF=test-fixture-ref-v1 bash scripts/install.sh --skip-mcp --dir "$target" 2>&1)
           echo "$out"
-          echo "$out" | grep -qE "git[[:space:]]+clone[[:space:]]+--branch[[:space:]]+test-fixture-ref-v1[[:space:]]+https://github\.com/suisya-systems/claude-org-ja\.git" \
+          echo "$out" | grep -qE "git[[:space:]]+clone[[:space:]]+--branch[[:space:]]+test-fixture-ref-v1[[:space:]]+https://github\.com/suisya-systems/claude-org\.git" \
             || { echo "smoke: CLAUDE_ORG_REF success: missing 'git clone --branch test-fixture-ref-v1' echo" >&2; exit 1; }
           echo "$out" | grep -q "Done. Next steps:" \
             || { echo "smoke: CLAUDE_ORG_REF success: tail marker 'Done. Next steps:' missing" >&2; exit 1; }
@@ -270,7 +270,7 @@ jobs:
             Write-Error "smoke: CLAUDE_ORG_REF success: install.ps1 exited with $LASTEXITCODE"
             exit 1
           }
-          if ($out -notmatch 'git\s+clone\s+--branch\s+test-fixture-ref-v1\s+https://github\.com/suisya-systems/claude-org-ja\.git') {
+          if ($out -notmatch 'git\s+clone\s+--branch\s+test-fixture-ref-v1\s+https://github\.com/suisya-systems/claude-org\.git') {
             Write-Error "smoke: CLAUDE_ORG_REF success: missing 'git clone --branch test-fixture-ref-v1' echo"
             exit 1
           }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,12 +1,12 @@
-# One-liner installer for claude-org-ja (Windows / PowerShell 7+).
+# One-liner installer for claude-org (Windows / PowerShell 7+).
 # Usage:
-#   iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
+#   iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.ps1 | iex
 #   pwsh -NoProfile -File scripts/install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp]
 #
 # This script:
 #   1. Checks for required commands (git, claude, renga, gh) and prints
 #      installation hints when something is missing.
-#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
+#   2. Clones suisya-systems/claude-org (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
 #      server is registered with Claude Code.
@@ -17,7 +17,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Dir = 'claude-org-ja',
+    [string]$Dir = 'claude-org',
     [switch]$DryRun,
     [switch]$SkipMcp,
     [switch]$Help
@@ -31,7 +31,7 @@ if ($Help) {
 Usage: install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp] [-Help]
 
 Options:
-  -Dir <path>   Target directory for the clone (default: .\claude-org-ja).
+  -Dir <path>   Target directory for the clone (default: .\claude-org).
   -DryRun       Print commands that would run without executing them.
   -SkipMcp      Skip `renga mcp install` (use when already registered).
   -Help         Show this help and exit.
@@ -39,7 +39,7 @@ Options:
     return
 }
 
-$RepoUrl = 'https://github.com/suisya-systems/claude-org-ja.git'
+$RepoUrl = 'https://github.com/suisya-systems/claude-org.git'
 # CLAUDE_ORG_REF pins the clone to a specific branch or tag for
 # reproducibility. Default `main` preserves latest-features behaviour
 # when the env var is unset.
@@ -82,7 +82,7 @@ function Read-YesNo {
     return ($reply -match '^(y|yes)$')
 }
 
-Write-Host '== claude-org-ja installer =='
+Write-Host '== claude-org installer =='
 Write-Host ''
 
 Write-Host 'Checking prerequisites...'
@@ -164,7 +164,7 @@ if (Test-Path -LiteralPath $Dir) {
             # message verbatim and matches install.sh's behaviour.
             [Console]::Error.WriteLine("install.ps1: failed to clone ref '$Ref' from $RepoUrl.")
             [Console]::Error.WriteLine("install.ps1: check that `$env:CLAUDE_ORG_REF names an existing branch or tag.")
-            [Console]::Error.WriteLine("install.ps1: branches and tags are accepted; see https://github.com/suisya-systems/claude-org-ja/releases for stable tags.")
+            [Console]::Error.WriteLine("install.ps1: branches and tags are accepted; see https://github.com/suisya-systems/claude-org/releases for stable tags.")
             exit 1
         }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# One-liner installer for claude-org-ja (Linux / macOS).
+# One-liner installer for claude-org (Linux / macOS).
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.sh | bash
 #   bash scripts/install.sh [--dir <path>] [--dry-run] [--skip-mcp]
 #
 # This script:
 #   1. Checks for required commands (git, claude, renga, gh) and prints
 #      installation hints when something is missing.
-#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
+#   2. Clones suisya-systems/claude-org (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
 #      server is registered with Claude Code.
@@ -17,8 +17,8 @@
 # permission prompts.
 set -euo pipefail
 
-REPO_URL="https://github.com/suisya-systems/claude-org-ja.git"
-TARGET_DIR="claude-org-ja"
+REPO_URL="https://github.com/suisya-systems/claude-org.git"
+TARGET_DIR="claude-org"
 DRY_RUN=0
 SKIP_MCP=0
 # CLAUDE_ORG_REF pins the clone to a specific branch or tag for
@@ -31,7 +31,7 @@ usage() {
 Usage: install.sh [--dir <path>] [--dry-run] [--skip-mcp] [--help]
 
 Options:
-  --dir <path>   Target directory for the clone (default: ./claude-org-ja).
+  --dir <path>   Target directory for the clone (default: ./claude-org).
   --dry-run      Print the commands that would run without executing them.
   --skip-mcp     Skip `renga mcp install` (use when already registered).
   -h, --help     Show this help and exit.
@@ -104,7 +104,7 @@ require_or_warn() {
   return 1
 }
 
-echo "== claude-org-ja installer =="
+echo "== claude-org installer =="
 echo
 
 echo "Checking prerequisites..."
@@ -170,7 +170,7 @@ else
     if ! git clone --branch "$REF" "$REPO_URL" "$TARGET_DIR"; then
       echo "install.sh: failed to clone ref '$REF' from $REPO_URL." >&2
       echo "install.sh: check that CLAUDE_ORG_REF names an existing branch or tag." >&2
-      echo "install.sh: branches and tags are accepted; see https://github.com/suisya-systems/claude-org-ja/releases for stable tags." >&2
+      echo "install.sh: branches and tags are accepted; see https://github.com/suisya-systems/claude-org/releases for stable tags." >&2
       exit 1
     fi
   else


### PR DESCRIPTION
## Summary

Wave B-runtime PR-5 of the 5-Wave plan for claude-org-ja#110.

- `scripts/install.sh`, `scripts/install.ps1`, `scripts/install-hooks.sh` — URL rewrite to `suisya-systems/claude-org`. Source files were already in English; this PR only re-points repo URLs and dirname references.
- `.github/workflows/install-scripts.yml` — same URL rewrite (grep regex / fixture redirect / failure-path regex). Originally flagged as out-of-scope by Codex, brought into this PR because it is tightly coupled to the install-script smoke test.

Codex self-review converged in 2 rounds (Blocker:0 / Major:0 / Minor:0 / Nit:0). Surviving non-actionable observations:
- `Secretary` in install scripts (lines 200/202 / 192/194) refers to the `Secretary` role, which is distinct from the glossary-locked `Lead`. Not a glossary violation.
- `latest-features behaviour` phrasing left as-is.

## Manifest entries

- `scripts/install.sh` | translated
- `scripts/install.ps1` | translated
- `scripts/install-hooks.sh` | translated
- `.github/workflows/install-scripts.yml` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] No remaining `claude-org-ja` URLs in scripts/ or .github/workflows/install-scripts.yml
- [x] No remaining ja-glossary terms in scope
- [x] Codex review converged (2 rounds, no Blocker/Major remaining)
- [ ] CI install-scripts workflow green