### PR TITLE
Wave B-runtime PR-7: tools/*.py + role_configs_schema.json descriptions

### DIFF
--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -82,7 +82,7 @@
       "disallow_allow_regex": []
     },
     "secretary": {
-      "description": "Secretary (窓口) — repo .claude/settings.local.json.",
+      "description": "Lead (role id: secretary) — repo .claude/settings.local.json.",
       "docs_section": "窓口",
       "settings_paths": [".claude/settings.local.json"],
       "closed_world": true,


### PR DESCRIPTION
## Summary

Wave B-runtime PR-7 of the 5-Wave plan for claude-org-ja#110.

- `tools/*.py` — already in English; no changes needed.
- `tools/role_configs_schema.json` — `secretary` description rewritten to `Lead (role id: secretary) — repo .claude/settings.local.json.` (Codex Round 1 Major: previous draft had `Secretary (Lead)` which made the glossary-locked `Lead` look secondary).

`docs_section` values (Japanese role headings) intentionally left unchanged — they are indexes into `permissions.md` heading anchors, which is part of a different translation surface.

Codex self-review converged in 2 rounds (Blocker:0 / Major:0 / Minor:0 / Nit:0).

Out-of-scope per B1 tier (left for follow-up):
- `dispatcher_runner.py` exception messages and worker instruction body templates contain Japanese string literals. Logic/string literals are out of B1 docstring scope.
- `test_org_setup_prune.py` SAMPLE fixtures depend on the unchanged `docs_section` values.

## Manifest entries

- `tools/role_configs_schema.json` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] `python -c "import json; json.load(open('tools/role_configs_schema.json'))"` OK
- [x] `python -m py_compile tools/*.py` OK
- [x] Codex review converged (2 rounds)
- [ ] CI green