### PR TITLE
Wave B-runtime PR-6: dashboard UI + server.py englishization (B2)

### DIFF
--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -115,7 +115,7 @@ function workerCard(w) {
       <span class="worker-task-tag">${esc(w.task || "–")}</span>
       <span class="worker-pulse"></span>
     </div>
-    <div class="worker-progress">${esc(w.lastProgress || "作業中...")}</div>
+    <div class="worker-progress">${esc(w.lastProgress || "Working...")}</div>
     <div class="worker-footer">
       <span id="el-${esc(w.id)}">${elapsedStr(w.started)}</span>
       ${w.paneId ? `<span>pane ${esc(w.paneId)}</span>` : ""}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -54,7 +54,7 @@ def _parse_org_state(text):
         if m:
             objective = m.group(1).strip()
 
-        # Work items: "- task-id: タイトル [STATUS]"
+        # Work items: "- task-id: title [STATUS]"
         m = re.match(r"^- ([\w-]+):\s*(.+?)\s*\[(\w+)\]", line)
         if m:
             work_items.append({
@@ -117,11 +117,11 @@ def _parse_journal(text):
             pass
 
     EVENT_LABELS = {
-        "worker_spawned": "ワーカー派遣",
-        "worker_respawned": "ワーカー再派遣",
-        "worker_closed": "ワーカー終了",
-        "suspend": "組織を中断",
-        "resume": "組織を再開",
+        "worker_spawned": "Worker dispatched",
+        "worker_respawned": "Worker redispatched",
+        "worker_closed": "Worker closed",
+        "suspend": "Org suspended",
+        "resume": "Org resumed",
     }
 
     result = []

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -60,13 +60,13 @@ class TestParseJournal(unittest.TestCase):
 
         # Reversed order: last valid event first
         self.assertEqual(result[0]["event"], "resume")
-        self.assertEqual(result[0]["summary"], "組織を再開")
+        self.assertEqual(result[0]["summary"], "Org resumed")
 
         self.assertEqual(result[1]["event"], "worker_closed")
-        self.assertIn("ワーカー終了", result[1]["summary"])
+        self.assertIn("Worker closed", result[1]["summary"])
 
         self.assertEqual(result[2]["event"], "worker_spawned")
-        self.assertIn("ワーカー派遣", result[2]["summary"])
+        self.assertIn("Worker dispatched", result[2]["summary"])
         # Worker ID truncated to 8 chars
         self.assertIn("abc12345", result[2]["summary"])
         self.assertNotIn("abc12345-long-id", result[2]["summary"])


### PR DESCRIPTION
## Summary

Wave B-runtime PR-6 of the 5-Wave plan for claude-org-ja#110.

- `dashboard/index.html`, `dashboard/style.css`, `dashboard/app.js` — UI strings translated, `lang="en"` set.
- `dashboard/server.py` — `EVENT_LABELS` and other user-visible strings translated. Originally flagged as out-of-scope by Codex but pulled in to keep dashboard surfaces consistent.
- `tests/test_parsers.py` — updated to follow new `EVENT_LABELS` values.

Codex self-review converged in 2 rounds (Blocker:0 / Major:0 / Minor:1 retained / Nit:3 retained).

## Intentional non-translations

- `toLocaleTimeString("ja-JP", ...)` left as-is — locale code is a code literal, not user-facing prose.
- `dashboard/server.py` L70/L73 regexes (`- 結果:`, `- ワーカー:`) and L157 `、` separator — these are schema literals that parse the existing Japanese `.state/org-state.md` and `registry/projects.md` formats. Same schema is unchanged in `tests/fixtures/org-state-sample.md` / `docs/org-state-schema.md`. Translating these would break existing state files. Out of B2 scope; deferred to a coordinated state-format migration.

## Manifest entries

- `dashboard/index.html` | translated
- `dashboard/style.css` | translated (comments only; was minimal)
- `dashboard/app.js` | translated
- `dashboard/server.py` | translated (user-visible strings)

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] `python -m unittest tests.test_parsers -v` 10/10
- [x] No identifier / class / id / API endpoint changes
- [x] Codex review converged
- [ ] CI green