### PR TITLE
Wave B-runtime PR-9: skill cluster 2 (org-curate / resume / suspend / retro / dashboard)

### DIFF
--- a/.claude/skills/org-curate/SKILL.md
+++ b/.claude/skills/org-curate/SKILL.md
@@ -1,116 +1,116 @@
 ---
 name: org-curate
 description: >
-  蓄積された生の学び（knowledge/raw/）を整理・統合する。
-  キュレーターClaudeの /loop から定期呼び出しされる。
-  手動で「知見を整理して」と言われたときにも使う。
+  Organize and consolidate accumulated raw learnings (knowledge/raw/).
+  Periodically invoked from the Curator Claude's /loop.
+  Also used when manually told "curate the knowledge".
 ---
 
-# org-curate: 知見整理
+# org-curate: Knowledge curation
 
-knowledge/raw/ に蓄積された生の学びを読み、分類・統合して knowledge/curated/ に書き出す。
+Read the raw learnings accumulated in knowledge/raw/, classify and consolidate them, and write them out to knowledge/curated/.
 
-## Step 1: 閾値チェック
+## Step 1: Threshold check
 
-1. `knowledge/raw/` 内のファイルを列挙する
-2. `<!-- curated -->` マーカーが**ない**ファイルを未整理としてカウントする
-3. 未整理ファイルが5件未満なら、何もせずスキップする
-4. 5件以上なら次のステップに進む
+1. Enumerate the files in `knowledge/raw/`.
+2. Count files **without** a `<!-- curated -->` marker as un-curated.
+3. If there are fewer than 5 un-curated files, do nothing and skip.
+4. If there are 5 or more, proceed to the next step.
 
-## Step 2: 読み込みと分類
+## Step 2: Read and classify
 
-1. 未整理ファイルを全て読む
-2. テーマ別に分類する。テーマの粒度は以下を目安にする:
-   - 技術領域（例: authentication, database, frontend）
-   - ツール・サービス（例: renga, github-api, aws）
-   - プロセス（例: code-review, testing, deployment）
-3. 既存の `knowledge/curated/` ファイルも読み、重複がないか確認する
+1. Read all un-curated files.
+2. Classify them by theme. Use the following granularity as a guide:
+   - Technical area (e.g. authentication, database, frontend)
+   - Tool / service (e.g. renga, github-api, aws)
+   - Process (e.g. code-review, testing, deployment)
+3. Read existing `knowledge/curated/` files as well, and check for duplicates.
 
-## Step 2.5: skill 化候補の抽出
+## Step 2.5: Extract skill candidates
 
-Step 2 で分類したテーマ群のうち、以下のいずれかに該当するものについて
-`.claude/skills/skill-eligibility-check/SKILL.md` を呼ぶ:
+Among the themes classified in Step 2, for those that match either of the
+following, call `.claude/skills/skill-eligibility-check/SKILL.md`:
 
-- 同一テーマに属する未整理 raw ファイルが **3 件以上**ある（raw_reappearance シグナルが立つ候補）
-- 既存の `knowledge/curated/` に同テーマ記事が無く、かつ手順的な知見（Step 群で記述できる内容）を含む
+- 3 or more un-curated raw files belong to the same theme (a candidate where the raw_reappearance signal fires)
+- No article on the same theme exists in the existing `knowledge/curated/`, AND it includes procedural knowledge (content describable as a sequence of Steps)
 
-呼び出し時の入力（`context: curation`）は以下のとおり組み立てる:
+Build the input (`context: curation`) on call as follows:
 
 ```yaml
 context: curation
-pattern_name: <推定 skill 名、kebab-case。テーマ名から派生させる>
-summary: <このテーマで何が再利用できるか 1-2 文>
-task_ids: []                    # optional。raw ノートに task_id が無ければ空のままでよい
-raw_files: <同テーマの raw/ パス配列>
-steps_outline: <raw 群から抽出した主要手順>
-trigger_description: <このテーマが発動する場面>
-decision_criteria: <テーマ内に現れる判断基準>
-output_format: <テーマの成果物フォーマット>
+pattern_name: <inferred skill name, kebab-case. derive from the theme name>
+summary: <1-2 sentences on what is reusable for this theme>
+task_ids: []                    # optional. leave empty if raw notes have no task_id
+raw_files: <array of raw/ paths for the same theme>
+steps_outline: <main steps extracted from the raw set>
+trigger_description: <situations where this theme fires>
+decision_criteria: <decision criteria appearing within the theme>
+output_format: <output format of the theme>
 ```
 
-`task_ids` は既存 raw の標準スキーマ（`事実 / 判断 / 根拠 / 適用場面`）に含まれないため、
-curation context では空配列でよい。raw ファイル名から日付等が読み取れればそれを `raw_files` に含めることで代用できる。
+`task_ids` is not part of the existing raw standard schema (`facts / decision / rationale / when-to-apply`),
+so it may be left as an empty array in the curation context. If a date or similar can be read from the raw filename, including it in `raw_files` is an acceptable substitute.
 
-結果の decision によって次の扱いを決める。**いずれの decision でも Step 3 での curated/ 統合は通常どおり実施する**:
+The handling depends on the resulting decision. **In all decisions, the curated/ consolidation in Step 3 proceeds as usual**:
 
-- `skill_recommend` → skill 側が `knowledge/skill-candidates.md` に自動追記済み。本ステップでは追加作業なし。
-  該当 raw ファイルも **Step 3 で curated/ に統合し、Step 4 で `<!-- curated -->` を付与する**
-  （skill 化と curated ノート化は両立。curated ノートは背景知識として残り、
-  skill は手順化として別途作成される。両立させないと未整理 raw が滞留して閾値チェックが壊れる）
-- `candidate_queue` → 通常どおり Step 3 で curated/ に統合（次回の raw_reappearance を待つ）
-- `curated_only` → 通常どおり Step 3 で curated/ に統合
+- `skill_recommend` → the skill side has already auto-appended to `knowledge/skill-candidates.md`. No additional work in this step.
+  The raw files in question are **also consolidated into curated/ in Step 3 and tagged with `<!-- curated -->` in Step 4**
+  (skill creation and curated note creation coexist. The curated note remains as background knowledge,
+  while the skill is created separately as a procedural form. If both are not done, un-curated raw files pile up and the threshold check breaks.)
+- `candidate_queue` → consolidate into curated/ in Step 3 as usual (await the next raw_reappearance)
+- `curated_only` → consolidate into curated/ in Step 3 as usual
 
-人間への問い合わせは窓口 Claude の役目であり、org-curate 側では行わない。
+Asking the human is the Lead Claude's role; org-curate does not do it.
 
-## Step 3: 統合と書き出し
+## Step 3: Consolidate and write out
 
-各テーマについて:
+For each theme:
 
-1. 既存のcuratedファイルがあれば、新しい知見を追記する
-2. なければ新規作成する
-3. ファイル名: `knowledge/curated/{theme}.md`
-4. フォーマット:
+1. If a curated file already exists, append the new knowledge to it.
+2. Otherwise, create a new one.
+3. Filename: `knowledge/curated/{theme}.md`
+4. Format:
    ```markdown
-   # {テーマ名}
+   # {theme name}
 
-   ## {知見タイトル1}
-   {事実・判断・根拠・適用場面を統合した記述}
+   ## {knowledge title 1}
+   {description integrating facts, decision, rationale, and when-to-apply}
 
-   ## {知見タイトル2}
+   ## {knowledge title 2}
    ...
    ```
-5. 重複する知見はマージする（より具体的・正確な記述を残す）
-6. 矛盾する知見がある場合は、より新しい日付のものを優先し、矛盾を明記する
+5. Merge duplicate knowledge (keep the more specific / accurate description).
+6. When two pieces of knowledge contradict each other, prefer the one with the more recent date and clearly note the contradiction.
 
-## Step 4: 処理済みマーカー
+## Step 4: Processed marker
 
-統合が完了したrawファイルの先頭に以下を追記する:
+Prepend the following to raw files whose consolidation is complete:
 ```
 <!-- curated -->
 ```
-これにより次回の閾値チェックでカウントされなくなる。
+This makes them no longer counted in the next threshold check.
 
-## Step 5: 改善提案の検討
+## Step 5: Consider improvement proposals
 
-整理した知見を俯瞰し、以下を検討する:
+Take a step back over the curated knowledge and consider:
 
-1. **スキルの改善**: 知見がスキルの手順改善に繋がるか？
-   - 例: 「ワーカーのペイン数上限」→ org-delegate に制約を追加すべき
-2. **CLAUDE.mdの改善**: 窓口の原則に追加すべきことがあるか？
-3. **新スキルの必要性**: 繰り返し登場するパターンが新スキルとして切り出せるか？
+1. **Skill improvements**: Does the knowledge lead to procedural improvements in a skill?
+   - e.g. "Worker pane count limit" → a constraint should be added to org-delegate.
+2. **CLAUDE.md improvements**: Should something be added to the Lead's principles?
+3. **Need for a new skill**: Can a recurring pattern be split out as a new skill?
 
-改善提案がある場合:
-- references/knowledge-standards.md の基準に従って判断する
-- renga-peers で窓口Claudeに提案を送信する
-- 提案フォーマット: 「[改善提案] {対象}: {変更内容}。理由: {なぜ}」
-- **窓口が人間に承認を取るまで、自分では変更しない**
+When you have improvement proposals:
+- Make the judgment per the criteria in references/knowledge-standards.md
+- Send the proposal to the Lead Claude via renga-peers
+- Proposal format: "[Improvement proposal] {target}: {change}. Reason: {why}"
+- **Do not change anything yourself until the Lead has obtained human approval.**
 
-## Step 6: skill 棚卸しの発火チェック
+## Step 6: Skill audit firing check
 
-以下のいずれかを満たす場合、`.claude/skills/skill-audit/SKILL.md` を起動する:
+If either of the following is met, launch `.claude/skills/skill-audit/SKILL.md`:
 
-- `knowledge/skill-candidates.md` 内の `status: pending` エントリが **5 件（N=5）** 以上
-- `.claude/skills/` 配下の skill ディレクトリ数が **20 件（M=20）** 以上
+- 5 or more (N=5) entries with `status: pending` in `knowledge/skill-candidates.md`
+- 20 or more (M=20) skill directories under `.claude/skills/`
 
-両方を下回るなら何もしない。時間ベースの定期起動はしない。
-閾値は `skill-audit` 自身も発火時に再確認するので、本ステップでは粗くてよい。
+If both are below threshold, do nothing. There is no time-based periodic firing.
+The thresholds are re-checked by `skill-audit` itself at firing time, so this step can be coarse.

--- a/.claude/skills/org-curate/references/knowledge-standards.md
+++ b/.claude/skills/org-curate/references/knowledge-standards.md
@@ -1,59 +1,59 @@
-# 知見管理の基準
+# Knowledge management standards
 
-org-curate と org-retro が共通で参照する、知見の記録・整理基準。
+Standards for recording and curating knowledge, referenced by both org-curate and org-retro.
 
-## 記録フォーマット
+## Recording format
 
 ```markdown
-# {タイトル}
+# {title}
 
-## 事実
-{何が起きたか、観察した事実を客観的に記述}
+## Facts
+{Objective description of what happened or was observed.}
 
-## 判断
-{どういう判断を下したか、何を選択したか}
+## Decision
+{What decision was made or what was chosen.}
 
-## 根拠
-{なぜその判断に至ったか。技術的理由、トレードオフ、制約等}
+## Rationale
+{Why that decision was reached. Technical reasons, trade-offs, constraints, etc.}
 
-## 適用場面
-{この知見が役立つ具体的な状況。「いつ」「どんなとき」に参照すべきか}
+## When to apply
+{The concrete situations where this knowledge is useful. "When" and "in what circumstances" should it be referenced.}
 ```
 
-**記録基準**: 再現性がある / 非自明 / コードを読むだけではわからない。一般的なプログラミング知識や公式ドキュメントに書いてあることは記録不要。
+**Recording criteria**: reproducible / non-obvious / not derivable from reading the code alone. General programming knowledge or things written in the official documentation do not need to be recorded.
 
-## 統合（キュレーション）の判断基準
+## Curation (consolidation) criteria
 
-### マージする場合
-- 同じ技術・サービスに関する知見が複数ある
-- 一方が他方の詳細版である
-- 同じ問題の異なる側面を記述している
+### When to merge
+- Multiple pieces of knowledge concern the same technology or service
+- One is a more detailed version of the other
+- They describe different aspects of the same problem
 
-### マージしない場合
-- テーマは近いが適用場面が異なる
-- 一方が他方と矛盾する（両方残し、矛盾を明記する）
+### When NOT to merge
+- The themes are similar but the application contexts differ
+- One contradicts the other (keep both and clearly note the contradiction)
 
-## 改善提案の判断基準
+## Improvement proposal criteria
 
-### 提案すべき場合
-- 同じ種類の知見が3件以上蓄積された（パターン化している）
-- 既存スキルの手順に明らかな漏れがある
-- 繰り返し発生する問題の予防策が明確になった
+### When to propose
+- 3 or more pieces of knowledge of the same kind have accumulated (a pattern is forming)
+- There is a clear gap in an existing skill's procedure
+- A clear preventive measure has emerged for a recurring problem
 
-### 提案すべきでない場合
-- 1件の知見だけで一般化するのは早計
-- 改善の効果が小さい（手順の微調整程度）
-- 既にスキルに記載されているが、ワーカーが読み飛ばしただけ
+### When NOT to propose
+- Generalizing from a single piece of knowledge is premature
+- The improvement effect is small (just minor procedural tweaks)
+- It is already documented in a skill but the Worker just skipped over it
 
-## skill 化判定の委譲先
+## Delegation target for skill-eligibility judgment
 
-新 skill の必要性判断は `.claude/skills/skill-eligibility-check/SKILL.md` に集約されている。
-本ファイルは知見統合基準の参照元に留め、skill 化判定の重複定義は置かない。
-org-retro と org-curate の両方が `skill-eligibility-check` を呼び、同一基準で採点する。
+Judgment of whether a new skill is needed is centralized in `.claude/skills/skill-eligibility-check/SKILL.md`.
+This file remains a reference for knowledge consolidation criteria only, and does not duplicate skill-eligibility criteria.
+Both org-retro and org-curate call `skill-eligibility-check` and score against the same criteria.
 
-## curated ファイルの品質基準
+## Quality standards for curated files
 
-- 各知見は独立して読めること（前後の文脈がなくても理解できる）
-- 適用場面が明確であること（「いつ使うか」がわかる）
-- 根拠が記載されていること（なぜその判断なのか）
-- 古くなった知見は削除するか、注記を付ける
+- Each piece of knowledge can be read independently (understandable without surrounding context).
+- The when-to-apply is clear ("when to use it" is evident).
+- The rationale is recorded (why that decision was made).
+- Outdated knowledge is removed, or annotated.

--- a/.claude/skills/org-dashboard/SKILL.md
+++ b/.claude/skills/org-dashboard/SKILL.md
@@ -1,45 +1,45 @@
 ---
 name: org-dashboard
 description: >
-  組織のダッシュボードを更新してブラウザで開く。
-  「ダッシュボード見せて」「状況を可視化して」「プロジェクト一覧見たい」
-  「全体像を見せて」等で発動。
+  Update the organization dashboard and open it in a browser.
+  Triggered by phrases like "show me the dashboard", "visualize the status",
+  "I want to see the project list", or "show me the big picture".
 ---
 
-# org-dashboard: ダッシュボードを開く
+# org-dashboard: Open the dashboard
 
-ライブダッシュボードサーバー（`dashboard/server.py`）を起動してブラウザで開く。
-サーバーが起動中であれば、ブラウザを開くだけでよい。データ生成は不要（サーバーが自動でリアルタイム配信する）。
+Start the live dashboard server (`dashboard/server.py`) and open it in a browser.
+If the server is already running, just opening the browser is enough. No data generation is needed (the server streams in real time automatically).
 
-## Step 1: サーバー状態確認
+## Step 1: Check server status
 
 ```bash
 cat .state/dashboard.pid 2>/dev/null && kill -0 $(cat .state/dashboard.pid) 2>/dev/null && echo "running" || echo "stopped"
 ```
 
-- `running` → Step 2 へ
-- `stopped` → Step 1.5 へ
+- `running` → go to Step 2
+- `stopped` → go to Step 1.5
 
-## Step 1.5: サーバー起動（停止中の場合のみ）
+## Step 1.5: Start the server (only if stopped)
 
 ```bash
 python3 dashboard/server.py &   # Mac/Linux
 py -3 dashboard/server.py &     # Windows
 ```
 
-起動後、`http://localhost:8099` でアクセス可能になる。
+Once started, it becomes accessible at `http://localhost:8099`.
 
-## Step 2: ブラウザで開く
+## Step 2: Open in browser
 
 ```bash
 open http://localhost:8099    # Mac
 start http://localhost:8099   # Windows
 ```
 
-ユーザーには「ダッシュボードを開きました → http://localhost:8099」と案内する。
+Tell the user: "Opened the dashboard → http://localhost:8099".
 
-## 補足
+## Notes
 
-- ダッシュボードはリアルタイムで状態を反映する（.state/ ファイルの変更を自動検知）
-- data.json の手動生成は不要。サーバーが /api/state で同等データを配信する
-- サーバーは org-start で自動起動、org-suspend で自動停止される
+- The dashboard reflects state in real time (it auto-detects changes to `.state/` files).
+- Manual generation of `data.json` is unnecessary. The server serves equivalent data via `/api/state`.
+- The server is started automatically by org-start and stopped automatically by org-suspend.

--- a/.claude/skills/org-resume/SKILL.md
+++ b/.claude/skills/org-resume/SKILL.md
@@ -1,65 +1,65 @@
 ---
 name: org-resume
 description: >
-  中断された組織を再開する。.state/org-state.md が存在し Status: SUSPENDED のとき、
-  「再開」「続きから」「前回どこまでやった？」と言われたときに使う。
-  起動時の自動ブリーフィングにも対応。
+  Resume a suspended organization. Use when .state/org-state.md exists with Status: SUSPENDED,
+  or when told "resume", "continue from where we left off", or "what did we do last time?".
+  Also handles automatic briefing on startup.
 ---
 
-# org-resume: 組織の再開
+# org-resume: Resume the organization
 
-中断された組織の状態を読み込み、人間にブリーフィングし、再開する。
+Read the state of a suspended organization, brief the human, and resume.
 
-## Phase 1: 状態読み込みとブリーフィング
+## Phase 1: Load state and brief
 
-1. `.state/org-state.md` を読む
-2. 人間に簡潔なサマリーを提示する:
-   - 全体の目標
-   - 各作業アイテムの状態（完了/進行中/保留/ブロック）
-   - 中断時刻
-3. `.state/journal.jsonl` が存在すれば、org-state.md の Updated 以降のエントリを確認し、
-   スナップショット後に起きたイベントがあれば補足する
+1. Read `.state/org-state.md`.
+2. Present a concise summary to the human:
+   - The overall goal
+   - The state of each work item (completed / in progress / pending / blocked)
+   - The time of suspension
+3. If `.state/journal.jsonl` exists, check entries since the `Updated` timestamp in org-state.md,
+   and add any events that happened after the snapshot.
 
-## Phase 2: 現実との照合
+## Phase 2: Reconcile with reality
 
-各作業アイテムについて、実際のファイルシステムの状態を確認する:
+For each work item, check the actual filesystem state:
 
-1. `.state/workers/` 内の各ワーカー状態ファイルを読む
-2. 各ワーカーの作業ディレクトリで以下を確認:
-   - ディレクトリが存在するか
-   - `git status` — 未コミットの変更があるか
-   - `git log --oneline -5` — 最後のコミットは状態ファイルと一致するか
-   - ブランチは状態ファイルの記述と一致するか
-3. `knowledge/raw/` に未整理のファイルがあるか確認
-4. 差異があれば人間に報告する（例: 「状態ファイルではOAuth 60%完了とありますが、実際にはファイルが存在しません」）
+1. Read each Worker state file under `.state/workers/`.
+2. In each Worker's working directory, check:
+   - Whether the directory exists
+   - `git status` — whether there are uncommitted changes
+   - `git log --oneline -5` — whether the last commit matches the state file
+   - Whether the branch matches what is described in the state file
+3. Check whether there are un-curated files in `knowledge/raw/`.
+4. If there are discrepancies, report them to the human (e.g. "The state file says OAuth is 60% complete, but the actual file does not exist.").
 
-## Phase 3: 再開計画の提案
+## Phase 3: Propose a resume plan
 
-状態に応じて提案を分ける:
+Branch the proposal by state:
 
-- **COMPLETED**: 結果を報告するのみ
-- **IN_PROGRESS（中断済み）**: 「未コミットの変更があります。ワーカーを派遣して続行しますか？」
-- **PENDING**: ブロッカーの状態を確認し、実行可能か判断
-- **BLOCKED**: ブロッカーの解消状況を確認
+- **COMPLETED**: just report the result
+- **IN_PROGRESS (suspended)**: "There are uncommitted changes. Shall I dispatch a Worker to continue?"
+- **PENDING**: check the blocker state and judge whether it is actionable
+- **BLOCKED**: check whether the blocker has been resolved
 
-**重要: 人間の確認を待ってから行動すること。勝手にワーカーを派遣しない。**
+**Important: wait for the human's confirmation before acting. Do not dispatch Workers on your own.**
 
-## Phase 4: 組織の再構築
+## Phase 4: Rebuild the organization
 
-人間が承認した作業について:
+For work the human has approved:
 
-1. `/org-delegate` スキルでワーカーを派遣
-2. 新ワーカーには前回のワーカー状態ファイル（`.state/workers/worker-{id}.md`）の内容をコンテキストとして渡す
-3. `org-state.md` の Status を `ACTIVE` に更新
-4. JSON スナップショットを再生成する:
+1. Dispatch a Worker via the `/org-delegate` skill.
+2. Pass the contents of the previous Worker state file (`.state/workers/worker-{id}.md`) as context to the new Worker.
+3. Update Status in `org-state.md` to `ACTIVE`.
+4. Regenerate the JSON snapshot:
 
    ```bash
    py -3 dashboard/org_state_converter.py    # Windows
    python3 dashboard/org_state_converter.py   # Mac/Linux
    ```
 
-5. フォアマン・キュレーターペインの起動は /org-start が担当するため、ここでは行わない
-6. `journal.jsonl` に resume イベントを追記:
+5. Starting the Dispatcher and Curator panes is /org-start's responsibility, so do not do it here.
+6. Append a resume event to `journal.jsonl`:
    ```json
    {"ts":"<ISO timestamp>","event":"resume","resumed_items":["blog-redesign","data-analysis"]}
    ```

--- a/.claude/skills/org-retro/SKILL.md
+++ b/.claude/skills/org-retro/SKILL.md
@@ -1,125 +1,125 @@
 ---
 name: org-retro
 description: >
-  委譲プロセスの振り返り。ワーカーへの作業委譲が完了したとき、
-  委譲の進め方自体を振り返り、プロセス改善の知見を記録する。
-  さらに、完了タスクの作業パターンをwork-skillとして蓄積すべきか判断する。
-  実作業の技術的な振り返りはワーカーが自動的に行うため、ここでは扱わない。
+  Retrospective on the delegation process. After a delegation of work to a Worker is complete,
+  reflect on how the delegation itself went, and record process-improvement knowledge.
+  In addition, judge whether the work pattern of the completed task should be accumulated as a work-skill.
+  Technical retrospectives on the actual work are done by the Worker automatically and are not handled here.
 ---
 
-# org-retro: 委譲プロセスの振り返り
+# org-retro: Delegation-process retrospective
 
-ワーカーへの委譲が完了した後、委譲プロセス自体を振り返り改善する。
-加えて、完了タスクの作業パターンがwork-skillとして再利用可能か判断する。
+After a delegation to a Worker is complete, reflect on and improve the delegation process itself.
+In addition, judge whether the completed task's work pattern is reusable as a work-skill.
 
-**注意**: 実作業の技術的な知見（はまりポイント、API の癖等）はワーカーが CLAUDE.md の指示に従い
-自動的に `knowledge/raw/` に記録する。ここでは扱わない。
+**Note**: Technical knowledge from the actual work (gotchas, API quirks, etc.) is recorded automatically
+to `knowledge/raw/` by the Worker per the instructions in CLAUDE.md. It is not handled here.
 
-## Step 1: 委譲プロセスの振り返り
+## Step 1: Retrospective on the delegation process
 
-以下を整理する:
-- **タスク分解は適切だったか**: 粒度が大きすぎ/小さすぎなかったか
-- **指示は明確だったか**: ワーカーが迷わず作業できたか、質問が多くなかったか
-- **プロジェクト選定は正しかったか**: 正しいディレクトリで作業できたか
-- **並列度は適切だったか**: ワーカー数が多すぎ/少なすぎなかったか
-- **完了報告は十分だったか**: ワーカーからの報告で人間に説明するのに足りたか
+Sort through:
+- **Was the task breakdown appropriate?**: Was the granularity too large or too small?
+- **Were the instructions clear?**: Could the Worker work without confusion? Did they ask many questions?
+- **Was the project selection correct?**: Could they work in the correct directory?
+- **Was the parallelism appropriate?**: Were there too many or too few Workers?
+- **Was the completion report sufficient?**: Was the Worker's report enough to explain to the human?
 
-## Step 2: 改善すべき知見の判断
+## Step 2: Decide which knowledge to improve
 
-以下の基準で「記録すべきか」を判断する:
+Use the following criteria to decide "should this be recorded":
 
-**記録する**:
-- 同じ種類の委譲で再び遭遇しそうなパターン
-- 指示テンプレートの改善につながる気づき
-- プロジェクト固有の制約で次回も影響しそうなもの
-- ワーカーの振り返り記録が不十分/過剰だった場合の改善点
+**Record**:
+- A pattern likely to be encountered again in the same kind of delegation
+- An insight that leads to improving the instruction template
+- A project-specific constraint that will affect us next time
+- Improvement points where the Worker's retrospective record was insufficient/excessive
 
-**記録しない**:
-- タスク固有の一度きりの問題
-- ワーカーが既に技術的知見として記録済みのこと
+**Do not record**:
+- Task-specific one-off problems
+- Things the Worker has already recorded as technical knowledge
 
-## Step 3: 記録
+## Step 3: Record
 
-知見がある場合、以下のパスにファイルを作成する:
+If you have knowledge worth recording, create a file at the following path:
 
-- パス: `knowledge/raw/{YYYY-MM-DD}-delegation-{topic}.md`
-- `{topic}` は英語 kebab-case（例: `delegation-task-granularity`, `delegation-frontend-instructions`）
-- プレフィックスに `delegation-` を付けて、ワーカーの技術的知見と区別する
+- Path: `knowledge/raw/{YYYY-MM-DD}-delegation-{topic}.md`
+- `{topic}` is English kebab-case (e.g. `delegation-task-granularity`, `delegation-frontend-instructions`)
+- Prefix with `delegation-` to distinguish from the Worker's technical knowledge
 
-### ファイルフォーマット
+### File format
 
-`.claude/skills/org-curate/references/knowledge-standards.md` の「記録フォーマット」を参照すること。
+See "Recording format" in `.claude/skills/org-curate/references/knowledge-standards.md`.
 
-## Step 4: work-skill 化の判定
+## Step 4: Judging work-skill creation
 
-完了したタスクの作業パターンについて `skill-eligibility-check` を呼び出し、
-work-skill として蓄積すべきか判定する。
+Call `skill-eligibility-check` for the work pattern of the completed task and judge
+whether it should be accumulated as a work-skill.
 
-判断基準の実体は `.claude/skills/skill-eligibility-check/references/signals.md` に集約されており、
-org-retro と org-curate の両方が同じ基準を参照する（判定の乖離を防ぐため）。
+The substance of the criteria is centralized in `.claude/skills/skill-eligibility-check/references/signals.md`,
+and both org-retro and org-curate reference the same criteria (to prevent divergence in judgment).
 
-### Step 4.1: skill-eligibility-check を呼ぶ
+### Step 4.1: Call skill-eligibility-check
 
-以下の入力を組み立てて呼び出す:
+Build the following input and call:
 
 ```yaml
 context: post_retro
-pattern_name: <推定される skill 名、kebab-case>
-summary: <何を再利用できるかの 1-2 文>
-task_ids: [<今回の task_id>]
-raw_files: <ワーカーが記録した knowledge/raw/ のパス配列>
+pattern_name: <inferred skill name, kebab-case>
+summary: <1-2 sentences on what is reusable>
+task_ids: [<this task_id>]
+raw_files: <array of knowledge/raw/ paths recorded by the Worker>
 steps_outline:
-  - <主要手順 1>
-  - <主要手順 2>
+  - <main step 1>
+  - <main step 2>
   - ...
-trigger_description: <このパターンが適用される状況>
-decision_criteria: <判断基準や閾値>
-output_format: <成果物の構造>
+trigger_description: <situations where this pattern applies>
+decision_criteria: <decision criteria or thresholds>
+output_format: <structure of the deliverables>
 ```
 
-スキルは 5 シグナルで採点し、`decision` を返す:
-- `skill_recommend`（3 点以上）
-- `candidate_queue`（2 点）
-- `curated_only`（1 点以下）
+The skill scores against 5 signals and returns a `decision`:
+- `skill_recommend` (3 points or more)
+- `candidate_queue` (2 points)
+- `curated_only` (1 point or fewer)
 
-`skill_recommend` の場合は `knowledge/skill-candidates.md` への追記もスキル側で実施される。
+For `skill_recommend`, appending to `knowledge/skill-candidates.md` is also handled by the skill.
 
-### Step 4.2: decision に応じて分岐
+### Step 4.2: Branch by decision
 
 #### decision == skill_recommend
 
-1. 人間に提案する:
+1. Propose to the human:
    ```
-   [work-skill 提案] このタスクの作業パターンはwork-skillとして記録すると再利用できそうです。
-   - スキル名案: {proposed_skill_name}
-   - 理由: {matched_signals} （合計 {score}/5 点）
-   - 概要: {何を再利用できるか}
+   [work-skill proposal] The work pattern of this task looks reusable as a work-skill.
+   - Proposed skill name: {proposed_skill_name}
+   - Reason: {matched_signals} (total {score}/5)
+   - Summary: {what is reusable}
 
-   記録しますか？
+   Shall I record it?
    ```
-2. 人間が承認した場合:
-   - `.claude/skills/{skill-name}/SKILL.md` を作成する
-   - テンプレート: `.claude/skills/org-retro/references/work-skill-template.md` のフォーマットに従う
-   - ワーカーの成果物（コード、レポート、設定等）から手順を抽出・汎化する
-   - タスク固有の値（ブランド名、ファイルパス等）はプレースホルダーに置換する
-   - `knowledge/skill-candidates.md` の該当エントリの status を `approved` に更新し決定日を記入
-3. 人間が却下した場合:
-   - 理由を `knowledge/raw/` に記録し、次回の判断に活かす
-   - `knowledge/skill-candidates.md` の該当エントリの status を `rejected` に更新し却下理由を追記
+2. If the human approves:
+   - Create `.claude/skills/{skill-name}/SKILL.md`
+   - Template: follow the format of `.claude/skills/org-retro/references/work-skill-template.md`
+   - Extract and generalize the procedure from the Worker's deliverables (code, reports, configs, etc.)
+   - Replace task-specific values (brand names, file paths, etc.) with placeholders
+   - Update the corresponding entry in `knowledge/skill-candidates.md`: status to `approved` and fill in the decision date
+3. If the human rejects:
+   - Record the reason in `knowledge/raw/` to inform future judgments
+   - Update the corresponding entry in `knowledge/skill-candidates.md`: status to `rejected` and append the rejection reason
 
 #### decision == candidate_queue
 
-候補止まり。次回同パターンが raw に再出現すれば raw_reappearance シグナルが立つため、
-この段階では skill 化しない。`knowledge/raw/` への技術的知見記録は通常どおり（ワーカー記録済みならスキップ）。
+Stop at candidate. If the same pattern reappears in raw next time, the raw_reappearance signal will fire,
+so do not create a skill at this stage. Recording technical knowledge to `knowledge/raw/` proceeds as usual (skip if the Worker has already recorded it).
 
 #### decision == curated_only
 
-`knowledge/raw/` への技術的知見記録で十分（ワーカーが既に記録している場合はスキップ）。
-報告は不要。
+Recording technical knowledge to `knowledge/raw/` is sufficient (skip if the Worker has already recorded it).
+No report needed.
 
-## Step 5: 報告
+## Step 5: Report
 
-人間に簡潔に報告する:
-- 知見を記録した場合: 「委譲プロセスについて{topic}の学びを記録しました」
-- work-skill 化を提案する場合: Step 4.2 の `skill_recommend` フォーマットで提案
-- `candidate_queue` / `curated_only` の場合: 報告不要（黙って次に進む）
+Briefly report to the human:
+- If you recorded knowledge: "I recorded a learning about {topic} for the delegation process."
+- If proposing a work-skill: propose using the `skill_recommend` format from Step 4.2
+- For `candidate_queue` / `curated_only`: no report needed (silently move on)

--- a/.claude/skills/org-retro/references/work-skill-template.md
+++ b/.claude/skills/org-retro/references/work-skill-template.md
@@ -1,77 +1,77 @@
 ---
 name: "{skill-name}"
 description: >
-  {1行の説明。このスキルが何をするか、どんなタスクで使えるか。
-  org-delegate がタスク内容とマッチングする際にこの description を参照する。}
+  {One-line description. What this skill does, and on what kind of tasks it can be used.
+  org-delegate references this description when matching a task.}
 type: "{implementation | testing | debugging | analysis | infrastructure}"
 triggers:
-  - "{このスキルが適用される状況1（例: Excel形式のアンケートデータを分析する）}"
-  - "{このスキルが適用される状況2}"
+  - "{Situation 1 where this skill applies (e.g. analyze Excel-format survey data)}"
+  - "{Situation 2 where this skill applies}"
 origin:
-  task_id: "{初めてこのパターンが使われたタスクID（例: data-analysis）}"
+  task_id: "{Task ID where this pattern was first used (e.g. data-analysis)}"
   date: "{YYYY-MM-DD}"
 ---
 
-# {skill-name}: {スキルのタイトル}
+# {skill-name}: {Skill title}
 
-{このスキルが何を実現するか、1-2文で概要を記述。}
+{1-2 sentences describing what this skill achieves.}
 
-## 背景
+## Background
 
-{このパターンが生まれた経緯。どんなタスクで初めて使われたか。
-なぜこのアプローチが有効だったか。}
+{The context in which this pattern emerged. What kind of task it was first used on.
+Why this approach was effective.}
 
-## 前提条件
+## Prerequisites
 
-{このスキルを適用するために必要な条件をリストアップ。}
+{List the conditions required to apply this skill.}
 
-- {前提条件1（例: Python 3.8+ がインストールされていること）}
-- {前提条件2（例: 入力データが特定のフォーマットであること）}
+- {Prerequisite 1 (e.g. Python 3.8+ is installed)}
+- {Prerequisite 2 (e.g. the input data is in a specific format)}
 
-## 手順
+## Procedure
 
-### Step 1: {最初のステップ名}
+### Step 1: {First step name}
 
-{具体的な手順を記述。コマンド例やコードスニペットがあれば含める。}
+{Concrete procedure. Include command examples or code snippets if relevant.}
 
 ```{language}
-{コード例}
+{code example}
 ```
 
-### Step 2: {次のステップ名}
+### Step 2: {Next step name}
 
-{手順の記述。判断基準がある場合は明確にする。}
+{Procedure description. Make decision criteria explicit if any.}
 
-### Step 3: {次のステップ名}
+### Step 3: {Next step name}
 
-{手順の記述。}
+{Procedure description.}
 
-## 成果物
+## Deliverables
 
-{このスキルを実行した結果、何が生成されるか。}
+{What is produced as a result of running this skill.}
 
-- {成果物1（例: `report.md` — 分析レポート）}
-- {成果物2（例: `analyze.py` — 分析スクリプト）}
+- {Deliverable 1 (e.g. `report.md` — analysis report)}
+- {Deliverable 2 (e.g. `analyze.py` — analysis script)}
 
-## 判断基準・閾値
+## Decision criteria / thresholds
 
-{スキル内で使われる判断基準や閾値があれば記述。
-定量的な基準は具体的な数値を含める。}
+{Document any decision criteria or thresholds used inside the skill.
+For quantitative criteria, include concrete numbers.}
 
-| 基準 | 値 | 根拠 |
+| Criterion | Value | Rationale |
 |---|---|---|
-| {基準名} | {値} | {なぜその値か} |
+| {criterion name} | {value} | {why this value} |
 
-## 応用・バリエーション
+## Variations / applications
 
-{このスキルを別の文脈で応用する場合のガイダンス。}
+{Guidance for applying this skill in a different context.}
 
-- **{バリエーション1}**: {どう変えるか}
-- **{バリエーション2}**: {どう変えるか}
+- **{Variation 1}**: {how to change}
+- **{Variation 2}**: {how to change}
 
-## 注意点
+## Caveats
 
-{このスキルを使う際の注意点やよくある落とし穴。}
+{Caveats and common pitfalls when using this skill.}
 
-- {注意点1}
-- {注意点2}
+- {Caveat 1}
+- {Caveat 2}

--- a/.claude/skills/org-suspend/SKILL.md
+++ b/.claude/skills/org-suspend/SKILL.md
@@ -1,95 +1,95 @@
 ---
 name: org-suspend
 description: >
-  組織を中断し、全状態をディスクに保存する。「中断」「保存して終了」
-  「閉じたい」「一旦やめる」「今日は終わり」と言われたときに使う。
+  Suspend the organization, saving all state to disk. Use when told "suspend",
+  "save and exit", "I want to close", "let's stop for now", or "we're done for today".
 ---
 
-# org-suspend: 組織の中断
+# org-suspend: Suspend the organization
 
-全ワーカーの状態を収集し、ディスクに保存し、全ペインを停止する。
+Collect all Worker state, save it to disk, and stop all panes.
 
-ペイン操作は `mcp__renga-peers__*` MCP ツール経由で行う（renga 0.18.0+ 前提）。pane_exited
-相当の lifecycle イベントは `mcp__renga-peers__poll_events` で long-poll、画面スクレイプ
-は `mcp__renga-peers__inspect_pane` で取得、raw キー入力は `mcp__renga-peers__send_keys`。
+Pane operations go through the `mcp__renga-peers__*` MCP tools (renga 0.18.0+ is required). pane_exited
+and equivalent lifecycle events are long-polled via `mcp__renga-peers__poll_events`, screen scraping
+is done with `mcp__renga-peers__inspect_pane`, and raw key input via `mcp__renga-peers__send_keys`.
 
-## Phase 1: ワーカー状態収集
+## Phase 1: Collect Worker state
 
-1. `mcp__renga-peers__list_peers` で稼働中のピアを列挙する
-2. 自分自身とキュレーターを除いた全ピアに `mcp__renga-peers__send_message` で以下を送信:
+1. Enumerate live peers with `mcp__renga-peers__list_peers`.
+2. Send the following to all peers except yourself and the Curator via `mcp__renga-peers__send_message`:
    ```
-   SUSPEND: 現在の状態を報告してください。
-   1. これまでに完了したこと
-   2. 変更したファイル（コミット済み/未コミット）
-   3. 次にやろうとしていたこと
-   4. ブロッカーや未解決の問題
+   SUSPEND: please report your current state.
+   1. What you have completed so far
+   2. Files you changed (committed / uncommitted)
+   3. What you were going to do next
+   4. Blockers or unresolved issues
    ```
-3. 30 秒間 `mcp__renga-peers__check_messages` で応答を待つ（5 秒間隔でポーリング）
-4. 応答があったワーカーの報告を記録する
+3. Wait 30 seconds for replies via `mcp__renga-peers__check_messages` (poll every 5 seconds).
+4. Record the reports from Workers that responded.
 
-## Phase 2: 未応答ワーカーのスクレイプ
+## Phase 2: Scrape unresponsive Workers
 
-応答がなかったワーカーについて:
+For Workers that did not respond:
 
-1. `.state/workers/` から該当ワーカーの状態ファイルを読み、Pane Name と Directory を取得
-2. 画面内容スクレイプで最新のコンソール出力を読む:
+1. Read the Worker's state file under `.state/workers/` and obtain the Pane Name and Directory.
+2. Read the latest console output via screen content scrape:
    ```
    mcp__renga-peers__inspect_pane(target="worker-{task_id}", format="text")
    ```
-   画面表示だけでは不十分な場合は、次の Step 3 の git 情報で補完する
-3. ワーカーの作業ディレクトリで以下を実行:
+   If the screen content alone is insufficient, supplement with the git information in Step 3.
+3. In the Worker's working directory, run:
    - `git status`
    - `git diff --stat`
    - `git log --oneline -5`
-4. これらの情報からワーカーの状態を推定する
+4. Estimate the Worker's state from this information.
 
-## Phase 3: 状態書き込み
+## Phase 3: Write state
 
-1. 既存の `org-state.md` を `org-state.prev.md` にコピー（バックアップ）
-2. `org-state.md` を更新:
-   - Status を `SUSPENDED` に変更
-   - Updated を現在時刻に更新
-   - 各 Work Item の状態を収集した情報で更新
-   - Resume Instructions に再開時の注意事項を記載
-3. JSON スナップショットを再生成する:
+1. Copy the existing `org-state.md` to `org-state.prev.md` (backup).
+2. Update `org-state.md`:
+   - Change Status to `SUSPENDED`
+   - Update Updated to the current time
+   - Update each Work Item's state from the collected information
+   - Note any caveats for resume in Resume Instructions
+3. Regenerate the JSON snapshot:
 
    ```bash
    py -3 dashboard/org_state_converter.py    # Windows
    python3 dashboard/org_state_converter.py   # Mac/Linux
    ```
 
-4. 各ワーカーの `.state/workers/worker-{id}.md` を更新:
-   - Current State at Suspend セクションを追加/更新
-   - Progress Log に中断時の状態を追記
-5. `journal.jsonl` に suspend イベントを追記:
+4. Update each Worker's `.state/workers/worker-{id}.md`:
+   - Add/update a Current State at Suspend section
+   - Append the suspend-time state to Progress Log
+5. Append a suspend event to `journal.jsonl`:
    ```json
    {"ts":"<ISO timestamp>","event":"suspend","reason":"user_requested","active_workers":["worker-xxx"],"pending_items":["blog-redesign"]}
    ```
 
-## Phase 3.5: ダッシュボードサーバー停止
+## Phase 3.5: Stop the dashboard server
 
 ```bash
 kill $(cat .state/dashboard.pid 2>/dev/null) 2>/dev/null || true
 ```
 
-## Phase 4: 全ペイン停止
+## Phase 4: Stop all panes
 
-停止順序が重要。ワーカー → フォアマン → キュレーターの順で停止する。
+The order matters. Stop in the order: Workers → Dispatcher → Curator.
 
-1. `mcp__renga-peers__list_peers` で稼働中のピアを列挙
-2. **ワーカーを先に停止**: 全ワーカーピアに `mcp__renga-peers__send_message` で終了を指示:
-   「SHUTDOWN: 作業を終了してください。」
-3. **ワーカーペインが閉じたことを確認** — 2-pass 構造で実施:
+1. Enumerate live peers with `mcp__renga-peers__list_peers`.
+2. **Stop Workers first**: instruct all Worker peers to terminate via `mcp__renga-peers__send_message`:
+   "SHUTDOWN: please end your work."
+3. **Confirm Worker panes have closed** — perform with a 2-pass structure:
 
-   **Pass 1 (polite shutdown の観察、最大 10 秒)**:
+   **Pass 1 (observe polite shutdown, up to 10 seconds)**:
 
-   `mcp__renga-peers__poll_events` で `pane_exited` を long-poll する。`types=["pane_exited"]` フィルタで他 type を除外しつつ、deadline 内でループして待機対象が全て閉じたら break:
+   Long-poll `pane_exited` via `mcp__renga-peers__poll_events`. Use the `types=["pane_exited"]` filter to exclude other types, and loop within the deadline; break once all targets have closed:
    ```
-   pending_workers = {全ワーカーの name set}
-   cursor = None                           # 初回は since 省略
-   deadline = now + 10 秒
+   pending_workers = {set of all Worker names}
+   cursor = None                           # omit since on first call
+   deadline = now + 10 seconds
    while pending_workers not empty and now < deadline:
-       remaining_ms = (deadline - now) ミリ秒
+       remaining_ms = (deadline - now) milliseconds
        result = mcp__renga-peers__poll_events(
            since=cursor,
            timeout_ms=min(remaining_ms, 10000),
@@ -99,40 +99,38 @@ kill $(cat .state/dashboard.pid 2>/dev/null) 2>/dev/null || true
        for ev in result.events:
            if ev.role == "worker" and ev.name in pending_workers:
                pending_workers.remove(ev.name)
-   # deadline 到達 or pending_workers が空で抜ける
+   # exit when deadline reached or pending_workers is empty
    ```
-   - 初回 `since` 省略で「今以降のイベントだけ」セマンティクス（過去の pane_exited を replay しない）
-   - `types=["pane_exited"]` filter は cursor を全 type で advance させるので重複 scan なし
-   - filter 不一致イベント到着で long-poll が early return (`events:[]` + advanced cursor) するため、空応答時は deadline までループ継続
-   - 10 秒以内に閉じなかった残留ワーカーは Pass 2 へ
+   - With `since` omitted on the first call, the semantics are "events from now on" (no replay of past pane_exited).
+   - The `types=["pane_exited"]` filter advances the cursor across all types, so there is no duplicate scan.
+   - When a non-matching event arrives the long-poll early-returns (`events:[]` + advanced cursor), so the loop continues until the deadline on empty responses.
+   - Workers that did not close within 10 seconds advance to Pass 2.
 
-   **Pass 2 (残留ワーカーへのフォールバック + 再確認、最大 5 秒)**:
-   - Pass 1 で閉じていないワーカーそれぞれに対して:
+   **Pass 2 (fallback for stragglers + reconfirm, up to 5 seconds)**:
+   - For each Worker that did not close in Pass 1:
      ```
      mcp__renga-peers__close_pane(target="worker-{task_id}")
      ```
-     でペインを明示破棄する。成功時は `"Closed pane id=N."` テキストが返る。`[pane_not_found]` / `[pane_vanished]` は既に閉じた扱いで skip（`references/renga-error-codes.md` 参照）。`[last_pane]` はワーカー停止段階では通常発生しない（窓口/フォアマン/キュレーターが残っているため）
-   - その後、同じ `poll_events` ループを `timeout_ms=5000` / deadline 5 秒で再度回し、close_pane 由来の `pane_exited` を消化する
-   - Pass 2 後もまだ閉じていないワーカーは `mcp__renga-peers__list_panes` で生存確認し、残存なら journal に記録して人間に報告（強制終了は現状未サポート）
+     to explicitly destroy the pane. On success, the text `"Closed pane id=N."` is returned. `[pane_not_found]` / `[pane_vanished]` are treated as already-closed and skipped (see `references/renga-error-codes.md`). `[last_pane]` does not normally occur at the Worker stop stage (because the Lead/Dispatcher/Curator are still alive).
+   - Then run the same `poll_events` loop again with `timeout_ms=5000` / a 5-second deadline to consume the `pane_exited` events triggered by close_pane.
+   - Workers that are still not closed after Pass 2 are checked for liveness with `mcp__renga-peers__list_panes`; if any remain, log to journal and report to the human (forced termination is currently unsupported).
 
-4. **フォアマンを停止**: フォアマンに `mcp__renga-peers__send_message` で終了を指示:
-   「SHUTDOWN: 作業を終了してください。」
-5. **キュレーターを停止**: キュレーターに `mcp__renga-peers__send_message` で終了を指示:
-   「SHUTDOWN: 作業を終了してください。」
-6. フォアマン・キュレーターも (3) と同じ 2-pass 構造で確認（`pending = {"dispatcher", "curator"}` を集合に入れ、`role == "dispatcher"` または `role == "curator"` の `pane_exited` を待つ）:
-   - Pass 1: `poll_events(types=["pane_exited"], timeout_ms=10000)` 相当ループ
-   - Pass 2: 残った pane に `mcp__renga-peers__close_pane(target="dispatcher")` / `mcp__renga-peers__close_pane(target="curator")` を送り、`poll_events` ループ (timeout_ms=5000) で再確認
+4. **Stop the Dispatcher**: instruct the Dispatcher to terminate via `mcp__renga-peers__send_message`:
+   "SHUTDOWN: please end your work."
+5. **Stop the Curator**: instruct the Curator to terminate via `mcp__renga-peers__send_message`:
+   "SHUTDOWN: please end your work."
+6. Confirm Dispatcher / Curator with the same 2-pass structure as in (3) (put `pending = {"dispatcher", "curator"}` into the set, and wait for `pane_exited` with `role == "dispatcher"` or `role == "curator"`):
+   - Pass 1: an equivalent `poll_events(types=["pane_exited"], timeout_ms=10000)` loop
+   - Pass 2: send `mcp__renga-peers__close_pane(target="dispatcher")` / `mcp__renga-peers__close_pane(target="curator")` to any remaining panes, and reconfirm via the `poll_events` loop (timeout_ms=5000)
 
-**最後のペイン (窓口) の扱い**: フォアマン・キュレーターを閉じた時点でタブに残るのは窓口
-ペインのみになる。窓口が自分自身を `mcp__renga-peers__close_pane(target="secretary")` で
-閉じようとすると `[last_pane]` (唯一のタブの唯一のペイン) が返るので、**窓口は自分自身で
-`exit` して自然終了させる** (人間が端末を閉じる、または `/exit` でシェルに戻る)。
-org-suspend は窓口ペインを閉じる責任を負わない。
+**Handling the last pane (Lead)**: once the Dispatcher and Curator are closed, the only pane remaining in the tab is the Lead pane.
+If the Lead tries to close itself with `mcp__renga-peers__close_pane(target="secretary")`, `[last_pane]` (the only pane in the only tab) is returned, so **the Lead exits naturally on its own with `exit`** (the human closes the terminal, or returns to the shell with `/exit`).
+org-suspend takes no responsibility for closing the Lead pane.
 
-7. 人間に報告:
+7. Report to the human:
    ```
-   組織を中断しました。
-   - 保存済み: {N}件の作業アイテム
-   - 状態ファイル: .state/org-state.md
-   /org-start で再開できます。
+   The organization has been suspended.
+   - Saved: {N} work items
+   - State file: .state/org-state.md
+   You can resume with /org-start.
    ```


### PR DESCRIPTION
## Summary

Wave B-runtime PR-9 of the 5-Wave plan for claude-org-ja#110.

Translates 7 files (B2 structure-preserving):
- `.claude/skills/org-curate/SKILL.md` + `references/knowledge-standards.md`
- `.claude/skills/org-resume/SKILL.md`
- `.claude/skills/org-suspend/SKILL.md`
- `.claude/skills/org-retro/SKILL.md` + `references/work-skill-template.md`
- `.claude/skills/org-dashboard/SKILL.md`

Glossary terms locked. Code blocks, frontmatter, paths preserved.

## Intentional non-translations

- `target="secretary"` and equivalent literal pane identifiers (`dispatcher`, `curator`, `worker-{task_id}`) are kept verbatim. They are renga-peers code literals, not narrative role names. Glossary-locked role nouns in narrative are all rendered as `Lead` / `Dispatcher` / `Curator` / `Worker`.

## Codex review

Round 1 raised one Blocker (the `secretary` literal above — judged false positive) and Codex display-layer mojibake on `→` / `—` characters. Files are UTF-8-correct on disk; mojibake is a PowerShell rendering issue in the Codex output capture.

## Manifest entries

- `.claude/skills/org-curate/SKILL.md` | translated
- `.claude/skills/org-curate/references/knowledge-standards.md` | translated
- `.claude/skills/org-resume/SKILL.md` | translated
- `.claude/skills/org-suspend/SKILL.md` | translated
- `.claude/skills/org-retro/SKILL.md` | translated
- `.claude/skills/org-retro/references/work-skill-template.md` | translated
- `.claude/skills/org-dashboard/SKILL.md` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] No remaining ja-glossary terms in narrative
- [x] Code-literal pane identifiers preserved
- [x] Frontmatter / heading structure preserved
- [ ] CI green