### PR TITLE
Wave B-runtime PR-10: skill cluster 3 + testing / verification (B2)

### DIFF
--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -1,115 +1,132 @@
 ---
 name: skill-audit
 description: >
-  skill の棚卸し（廃止候補 / 重複統合 / owner 明記チェック）。
-  状態ベースで発火する: 候補キュー knowledge/skill-candidates.md の pending が 5 件以上、
-  または .claude/skills/ 配下の work-skill 数（org-* を除く）が 20 以上になった場合のみ実行。
-  時間ベースの /loop では起動しない（変化の無い日に raw ログを汚す副作用を避けるため）。
+  Skill inventory audit (deprecation candidates / merge candidates / owner-missing check).
+  Fires on a state-based trigger: only runs when the candidate queue
+  knowledge/skill-candidates.md has 5 or more pending entries, or when the
+  number of work-skills under .claude/skills/ (excluding org-*) reaches 20 or more.
+  Does not fire on time-based /loop (avoids polluting raw logs on days with no change).
 ---
 
-# skill-audit: skill 棚卸し
+# skill-audit: skill inventory audit
 
-skill 数の増加に伴って `org-delegate` の work-skill 検索にノイズが増えるのを防ぐため、
-定期的ではなく **状態ベース**で棚卸しを行う。
+To prevent noise in `org-delegate`'s work-skill search as the skill count grows,
+the inventory is audited on a **state-based** trigger rather than periodically.
 
-skill 数増加そのものよりも「検索面のノイズ」が本丸。
-本スキルは 3 つの観点（廃止 / 重複統合 / owner 明記）を機械的にチェックし、
-変更提案を窓口 Claude にまとめて送る。自動で skill を削除・変更することはしない。
+The real concern is not the skill count itself, but "noise on the search surface."
+This skill mechanically checks three angles (deprecation / merge / owner-missing)
+and sends consolidated change proposals to the Lead's Claude.
+It never deletes or modifies skills automatically.
 
-## Step 1: 発火条件チェック（状態ベース）
+## Step 1: Trigger condition check (state-based)
 
-以下をいずれも満たさない場合は **即終了**（ログも残さない）。
+Exit immediately (without leaving a log) unless one of the following holds.
 
 ```bash
-# 候補キュー pending エントリ数
+# Number of pending entries in the candidate queue
 cand_count=$(grep -c '^- \*\*status\*\*: pending' knowledge/skill-candidates.md 2>/dev/null || echo 0)
 
-# work-skill 数（org-* は除外。ノイズ源となる work-skill 検索対象に合わせる）
+# Number of work-skills (excludes org-*; aligns with the work-skill search target that produces noise)
 work_skill_count=$(find .claude/skills -maxdepth 2 -name SKILL.md \
   | grep -v '/org-' | wc -l)
 ```
 
-- `cand_count >= 5` **または** `work_skill_count >= 20` なら続行
-- どちらも満たさなければ終了（このとき報告は不要）
+- Continue if `cand_count >= 5` **or** `work_skill_count >= 20`
+- Exit otherwise (no report needed in this case)
 
-数値の根拠: N=5 / M=20 をデフォルトとする。実運用で重くなれば PR で調整。
-`org-*` を除外する理由: ノイズ源は `org-delegate` の work-skill 検索であり、
-`org-*` の増減は検索ノイズに直接影響しない。
+Rationale for the numbers: defaults are N=5 / M=20. Adjust via PR if they
+become heavy in actual operation.
+Rationale for excluding `org-*`: the noise source is `org-delegate`'s work-skill
+search, and the size of `org-*` does not directly affect that search noise.
 
-## Step 2: 廃止候補の洗い出し
+## Step 2: Identify deprecation candidates
 
-各 skill について以下を評価する。**現時点で観測可能な項目のみ**を機械判定に使い、
-観測不能な項目は「要確認」として人間判定に委ねる。詳細は `references/audit-checklist.md` を参照。
+For each skill, evaluate the following. **Use only currently observable items**
+for mechanical judgment; treat unobservable items as "needs review" and leave
+them to human judgment. See `references/audit-checklist.md` for details.
 
-観測可能（機械判定に使える）:
-- description と `SKILL.md` 本文 Step 群の内容に明らかな乖離がある（本文内で完結）
-- `knowledge/curated/` / `knowledge/raw/` / `.state/workers/` を `{skill-name}` で grep し、
-  直近 90 日の言及が 0 件（本プロジェクト内の観測範囲に限る）
+Observable (usable for mechanical judgment):
+- A clear divergence between the description and the Step contents in `SKILL.md`
+  body (assessable from inside the file).
+- Grep `knowledge/curated/` / `knowledge/raw/` / `.state/workers/` for `{skill-name}`
+  and find zero mentions in the last 90 days (within this project's observation
+  scope only).
 
-観測不能（「要確認」扱い、廃止判定には使えない）:
-- `org-delegate` は work-skill を指示に埋め込むだけで「実際に採用されたか」を永続化しない
-  → 言及検索は「検索で引っかかった」程度の情報にしかならない
-- 既存 skill の多くが `origin.task_id` を持たず、再利用判定の起点がない
-  → origin 付き skill のみ「再利用なし」判定に使い、origin 無しは除外
+Unobservable (treated as "needs review"; cannot be used for deprecation):
+- `org-delegate` only embeds work-skills into instructions and does not persist
+  whether they were "actually adopted." Mention searches therefore yield only
+  "matched in search" information.
+- Many existing skills lack `origin.task_id`, so reuse-judgment has no anchor.
+  Use only origin-tagged skills for the "no reuse" judgment; skip origin-less ones.
 
-**廃止決定はしない。提案リストに載せるだけ**で、最終判断は人間に委ねる。
-audit-checklist.md の 1.1 / 1.2 / 1.3 も同方針で詳細化済み。
+**No deprecation decision is made. Items only get added to the proposal list**;
+final judgment is left to a human. Sections 1.1 / 1.2 / 1.3 of audit-checklist.md
+follow the same policy in detail.
 
-## Step 3: 重複統合候補の洗い出し
+## Step 3: Identify merge candidates
 
-skill ペアを総当たりして以下を確認する:
+Pair-wise across skills, check for the following:
 
-- description の主題語（動詞・目的語）が重複している
-- triggers（または description 中の発動条件）が重なる
-- 片方がもう一方の特殊化であり、パラメータ差し替えで兼用できる
+- Subject words (verb / object) overlap in the descriptions
+- Triggers (or fire conditions inside descriptions) overlap
+- One is a specialization of the other and could be subsumed by parameter
+  substitution
 
-重複の疑いがあるペアは「統合候補」としてリストアップする。
-実際の統合判断は人間が行うので、ここでは候補提示のみ。
+Pairs with merge suspicion are listed as "merge candidates."
+The actual merge decision is made by a human, so this step only proposes.
 
-## Step 4: owner 未明記の洗い出し
+## Step 4: Identify owner-missing skills
 
-全 skill の SKILL.md frontmatter を読み、以下を確認する:
+Read every skill's SKILL.md frontmatter and check:
 
-- `owner:` または `maintainer:` フィールドが無い skill
-- あっても空文字列のもの
+- Skills with no `owner:` or `maintainer:` field
+- Or where the field is an empty string
 
-これらは「owner 未明記」としてリストアップ。
-本プロジェクトの既存 skill 全てが現時点で owner 未記載である点は想定内で、
-最初の監査実行では一括提案になる見込み。
+These are listed as "owner missing."
+It is expected that all existing skills in this project currently lack an owner;
+the first audit run will likely produce a bulk proposal.
 
-## Step 5: 報告
+## Step 5: Report
 
-`renga-peers` の `send_message(to_id="secretary", ...)` で窓口 Claude に送る。
+Send to the Lead's Claude via `renga-peers` `send_message(to_id="secretary", ...)`.
 
 ```
-[skill-audit] 棚卸し結果
-- 廃止候補: {n} 件 ({skill-name} 一覧)
-- 統合候補: {m} ペア ({skill-a} × {skill-b} 一覧)
-- owner 未明記: {k} 件 ({skill-name} 一覧)
+[skill-audit] Inventory result
+- Deprecation candidates: {n} ({skill-name} list)
+- Merge candidates: {m} pairs ({skill-a} × {skill-b} list)
+- Owner missing: {k} ({skill-name} list)
 
-発火条件: cand_count={cand_count} / skill_count={skill_count}
-詳細: 判定根拠は本メッセージ末尾の一覧を参照。
+Trigger condition: cand_count={cand_count} / skill_count={skill_count}
+Details: see the appended list at the end of this message for the rationale.
 
-人間承認後に削除・統合・owner 追記を実施してください。自動変更はしていません。
+After human approval, please carry out the deletion / merge / owner addition.
+No automatic changes have been made.
 ```
 
-候補が 0 件（クリーンな状態）だった場合も報告する: 「棚卸し実行、変更提案なし」。
-次回は次の閾値超過まで実行されないので、0 件でも実行した事実を残す意味がある。
+Even when there are zero candidates (a clean state), still report:
+"audit ran, no change proposals." Since the next run will not happen until the
+threshold is exceeded again, recording the fact that the audit ran has value
+even at zero.
 
-## トリガー経路
+## Trigger paths
 
-このスキルは自律的に走らない。以下のいずれかで起動する:
+This skill never runs autonomously. It is invoked via one of the following:
 
-1. `org-curate` Step 6（skill 棚卸しの発火チェック）で閾値を満たせば呼び出される（推奨経路）
-2. 窓口が `skill-candidates.md` を見て手動で起動する
-3. 人間が「棚卸しして」と依頼
+1. `org-curate` Step 6 (skill-audit firing check) calls it when thresholds are
+   met (recommended path)
+2. The Lead manually invokes it after looking at `skill-candidates.md`
+3. A human asks "do an inventory audit"
 
-`/loop` などの時間ベース起動はしない。
+Time-based starts such as `/loop` are not used.
 
-## 自動変更を避ける理由
+## Why automatic changes are avoided
 
-- 廃止の誤判断は `org-delegate` 側で「使える skill が無い」状態を生む（委譲精度の低下）
-- 統合は description・triggers・手順の擦り合わせを要し、機械的にはできない
-- owner 追記は人間確認が最も軽い運用（ここだけ自動化しても効果小）
+- A wrong deprecation produces a "no usable skill" state on the `org-delegate`
+  side (degrading dispatch precision).
+- A merge requires reconciling description / triggers / steps and cannot be
+  done mechanically.
+- For owner addition, manual confirmation is the lightest workflow (automating
+  it brings little benefit).
 
-したがって本スキルは**提案までに留め**、変更は人間承認を経て窓口が手動で行う。
+For these reasons, this skill **stops at proposal**, and changes are made
+manually by the Lead after human approval.

--- a/.claude/skills/skill-audit/references/audit-checklist.md
+++ b/.claude/skills/skill-audit/references/audit-checklist.md
@@ -1,105 +1,117 @@
-# skill-audit チェックリスト
+# skill-audit checklist
 
-`skill-audit` が 3 観点で使う具体的な判定手順。
+The concrete judgment procedures used by `skill-audit` for the three angles.
 
-## 1. 廃止候補チェック
+## 1. Deprecation candidate check
 
-各 skill について以下を順に確認する。
+For each skill, check the following in order.
 
-### 1.1 言及検索（観測可能）
-- `knowledge/raw/` および `knowledge/curated/` を `{skill-name}` で grep
-- `.state/workers/` 配下のタスクログを `{skill-name}` で grep
-- **90 日以内の言及が 1 件も無ければ**「言及なし」フラグ
+### 1.1 Mention search (observable)
+- Grep `knowledge/raw/` and `knowledge/curated/` for `{skill-name}`
+- Grep task logs under `.state/workers/` for `{skill-name}`
+- **If there is not a single mention within the last 90 days**, set the "no mention" flag
 
-注意: `org-delegate` は work-skill 検索でマッチしたら指示に埋め込むが、
-「実際にワーカーが採用したか / 使い切ったか」は永続化していない。
-したがってここで検出できるのは「直近で検索候補にすら挙がっていない skill」までで、
-「挙がったが使われなかった skill」は観測不能。この弱さは受け入れる（観測ログを
-追加するまでは）。
+Note: `org-delegate` embeds work-skills into instructions on a search match,
+but does not persist whether "the worker actually adopted / fully used it."
+Therefore what is detectable here is only "skills that did not even surface
+as search candidates recently"; skills that "surfaced but went unused" are
+not observable. This weakness is accepted (until observation logging is added).
 
-### 1.2 origin.task_id の再利用状況（origin 付き skill のみ）
-- SKILL.md frontmatter に `origin.task_id` があるか確認
-- **無い場合はこの項目をスキップ**（既存 skill の多くに該当）
-- ある場合: `origin.task_id` 以降で類似タスクが `knowledge/raw/` または `.state/workers/` にあるか
-- **1 件も無い**なら「再利用されていない」フラグ
+### 1.2 origin.task_id reuse status (origin-tagged skills only)
+- Check whether SKILL.md frontmatter has `origin.task_id`
+- **If absent, skip this item** (applies to many existing skills)
+- If present: check whether any similar task after `origin.task_id` exists in
+  `knowledge/raw/` or `.state/workers/`
+- **If there is not a single match**, set the "not reused" flag
 
-### 1.3 description と実装の乖離（観測可能）
-- frontmatter の `description` が要約する機能と、`SKILL.md` 本文 Step 群の内容が一致するか
-- 以下のいずれかがあれば「乖離あり」フラグ:
-  - description が触れている手順が本文に無い
-  - 本文の Step 群が description の触れない別機能を追加している
-  - 具体例・ツール・ライブラリが description と本文で矛盾している
+### 1.3 Divergence between description and implementation (observable)
+- Check whether the function summarized in the frontmatter `description` matches
+  the contents of the Step group in the body of `SKILL.md`
+- Set the "divergence" flag if any of the following holds:
+  - The description references a procedure that does not appear in the body
+  - The Step group in the body adds a separate function that the description
+    does not mention
+  - Concrete examples / tools / libraries contradict between description and body
 
-### 廃止候補の判定
-1.1 / 1.2 / 1.3 のうち **1 つ以上に該当**すれば「廃止候補」としてリストアップ。
-ただし **決定はしない**。人間が最終判断する前提で、各フラグの根拠を添えて報告する。
-1.2 が skip された skill は、1.1 / 1.3 のみの評価結果で候補化する。
+### Deprecation candidate judgment
+List as a "deprecation candidate" if **one or more** of 1.1 / 1.2 / 1.3 applies.
+However **no decision is made**. Report each candidate with its flag rationale
+on the assumption that a human makes the final call.
+For skills where 1.2 is skipped, list candidacy based only on the 1.1 / 1.3 results.
 
-## 2. 重複統合候補チェック
+## 2. Merge candidate check
 
-### 2.1 description 類似度
-2 つの skill description をペアで比較:
+### 2.1 Description similarity
+Compare two skill descriptions pairwise:
 
-- 動詞が一致（「判定する」vs「判定する」「分析する」vs「解析する」等）
-- 目的語が重なる（扱う対象・出力物が類似）
-- 修飾語のみ違う（「X の」「Y の」で主機能が同じ）
+- Verbs match (e.g. "judge" vs "judge", "analyze" vs "analyze")
+- Objects overlap (the targets / outputs handled are similar)
+- Only the modifiers differ ("of X" / "of Y" with the same main function)
 
-該当すれば「description 重複」フラグ。
+If applicable, set the "description overlap" flag.
 
-### 2.2 triggers 重複
-frontmatter の `triggers:` がある skill 同士で:
+### 2.2 Triggers overlap
+Among skills that have `triggers:` in frontmatter:
 
-- トリガー条件の語彙が 50% 以上重なる
-- 同じ入力形式（Excel, PDF, CSV 等）を対象としている
-- 同じ場面（タスク完了時、エラー発生時、定期実行等）で発動する
+- Trigger-condition vocabulary overlaps by 50% or more
+- Targets the same input format (Excel, PDF, CSV, etc.)
+- Fires in the same situation (task completion, error occurrence, scheduled run, etc.)
 
-該当すれば「triggers 重複」フラグ。
+If applicable, set the "triggers overlap" flag.
 
-### 2.3 特殊化・汎化関係
-- 片方の skill が他方に**パラメータ**を足せば実行できる
-- 片方が他方の**特定ブランド・特定データ**への適用に過ぎない
+### 2.3 Specialization / generalization relationship
+- One skill could run with **parameters** added on top of the other
+- One is just the application of the other to a **specific brand or specific
+  data set**
 
-該当すれば「統合可能性あり」フラグ。
+If applicable, set the "merge feasibility" flag.
 
-### 統合候補の判定
-上記 3 項目のうち **2 つ以上に該当**するペアのみ統合候補とする。
-1 項目だけでは「似ている」程度で統合判断には弱い。
+### Merge candidate judgment
+Only list pairs where **two or more** of the three items above apply as merge
+candidates. A single hit is "they look similar" and is too weak to support a
+merge decision.
 
-## 3. owner 未明記チェック
+## 3. Owner-missing check
 
-### 3.1 frontmatter 読み取り
-各 skill の `SKILL.md` の先頭 YAML frontmatter を読む。
+### 3.1 Read frontmatter
+Read the leading YAML frontmatter of each skill's `SKILL.md`.
 
-### 3.2 フィールド確認
-以下のいずれかのフィールドがあり、非空値を持つこと:
+### 3.2 Field check
+Either of the following fields must be present with a non-empty value:
 
 - `owner:`
 - `maintainer:`
 
-### 3.3 リストアップ
-上記いずれも持たない / 値が空 / 値が `TBD` 等のプレースホルダなら「owner 未明記」。
+### 3.3 Listing
+If neither is present / the value is empty / the value is a placeholder such
+as `TBD`, mark as "owner missing."
 
-## 報告フォーマット
+## Report format
 
-`SKILL.md` Step 5 のメッセージテンプレに従うが、各候補の後ろに判定根拠を添える:
+Follow the message template from `SKILL.md` Step 5, but append the rationale
+after each candidate:
 
 ```
-## 廃止候補
-- `example-skill`: 呼び出し履歴なし（90 日内 0 件）、origin 再利用なし
+## Deprecation candidates
+- `example-skill`: no call history (0 in 90 days), no origin reuse
 - ...
 
-## 統合候補
-- `skill-a` × `skill-b`: description 重複 + 特殊化関係
+## Merge candidates
+- `skill-a` × `skill-b`: description overlap + specialization relationship
 - ...
 
-## owner 未明記
+## Owner missing
 - `skill-c`, `skill-d`, ...
 ```
 
-## 判定しきい値のメモ
+## Notes on judgment thresholds
 
-- **90 日**: 呼び出し履歴の観察窓。本プロジェクトの活動頻度で調整可。
-- **50%**: triggers 語彙重複。厳しくし過ぎると偽陰性、緩すぎると偽陽性。
-- **2 つ以上 / 3 項目中**: 統合判定の閾値。1 つでも該当なら候補にすると誤検出が増える。
+- **90 days**: observation window for call history. Tunable for this project's
+  activity rate.
+- **50%**: triggers vocabulary overlap. Too strict gives false negatives, too
+  lax gives false positives.
+- **2 of 3**: merge judgment threshold. A single hit produces too many false
+  detections.
 
-上記数値は運用で乖離が見えたら調整し、`knowledge/raw/` に「audit 運用の学び」として記録する。
+If divergences appear in operation, adjust the numbers above and record the
+adjustment in `knowledge/raw/` as "audit operation lessons."

--- a/.claude/skills/skill-eligibility-check/SKILL.md
+++ b/.claude/skills/skill-eligibility-check/SKILL.md
@@ -1,130 +1,151 @@
 ---
 name: skill-eligibility-check
 description: >
-  作業パターンを skill 化すべきか判定する共通スキル。org-retro と org-curate から呼ばれ、
-  「skill 化推奨 / 候補止まり / curated ノートのまま」の 3 値と根拠を返す。
-  自動 skill 化はせず、推奨は knowledge/skill-candidates.md に追記し、
-  窓口が候補キューが溜まった時点でバッチで人間に問い合わせる二段構え。
+  Common skill for judging whether a work pattern should be promoted to a skill.
+  Called from org-retro and org-curate; returns a 3-value verdict
+  (skill_recommend / candidate_queue / curated_only) with rationale.
+  Does not auto-create skills: a recommendation is appended to
+  knowledge/skill-candidates.md, and the Lead asks the human in batch once the
+  candidate queue has accumulated — a two-stage workflow.
 ---
 
-# skill-eligibility-check: skill 化判定
+# skill-eligibility-check: skill promotion judgment
 
-作業パターンが新規 work-skill として切り出す価値があるかを 5 シグナルで採点し、
-3 値（skill_recommend / candidate_queue / curated_only）で返す。
-このスキル自体は skill 生成も人間問い合わせもしない — 判定専用。
+Score a work pattern across 5 signals to decide whether it is worth carving out
+as a new work-skill, returning a 3-value verdict
+(skill_recommend / candidate_queue / curated_only).
+This skill itself does not generate skills nor query humans — judgment only.
 
-## なぜ共通スキルか
+## Why a common skill
 
-判定基準が org-retro と org-curate の 2 箇所に分散すると必ず乖離するため。
-このスキルを single source of truth として双方から呼ぶ。
+If the judgment criteria were split between org-retro and org-curate, they
+would inevitably drift apart. This skill is the single source of truth invoked
+from both.
 
-## 入力契約
+## Input contract
 
-呼び出し元は以下の構造を渡す:
+The caller passes the following structure:
 
 ```yaml
 context: post_retro | curation
-pattern_name: <kebab-case の候補 skill 名>
-summary: <何を再利用できるかの 1-2 文>
-task_ids: [<関連タスク ID>, ...]          # optional。post_retro は通常 1 件、curation は空配列可
-raw_files: [<knowledge/raw/ のファイルパス>, ...]
-steps_outline:                              # 主要手順の箇条書き
+pattern_name: <kebab-case candidate skill name>
+summary: <1-2 sentences on what is reusable>
+task_ids: [<related task id>, ...]          # optional. post_retro is usually 1 entry; curation may pass an empty list
+raw_files: [<knowledge/raw/ file path>, ...]
+steps_outline:                              # bullet list of major steps
   - <step 1>
   - <step 2>
   - ...
-trigger_description: <このパターンが適用される状況を言語化できるか / できないなら空>
-decision_criteria: <判断基準や閾値があるか / できないなら空>
-output_format: <成果物の再利用可能フォーマット / なければ空>
+trigger_description: <can the situation where this pattern applies be articulated? empty if not>
+decision_criteria: <are there judgment criteria or thresholds? empty if not>
+output_format: <reusable artifact format / empty if none>
 ```
 
-**必須は `context` / `pattern_name` / `summary` / `raw_files` / `steps_outline` のみ**。
-`task_ids` は raw ノートの標準スキーマに含まれないため curation 文脈では空配列でよい。
-`trigger_description` / `decision_criteria` / `output_format` は採点対象そのもので、
-空のまま渡すと該当シグナルが 0 点になる。
+**Required fields are only `context` / `pattern_name` / `summary` / `raw_files`
+/ `steps_outline`**.
+`task_ids` is not part of the standard schema for raw notes, so an empty list
+is fine in the curation context.
+`trigger_description` / `decision_criteria` / `output_format` are themselves
+the subjects of scoring; passing them empty makes the corresponding signal
+score 0.
 
-## Step 1: 5 シグナル評価
+## Step 1: Score the 5 signals
 
-`references/signals.md` の定義に従い、各シグナル 0 点 / 1 点で採点する。
+Score each signal as 0 or 1 following the definitions in `references/signals.md`.
 
-| シグナル | 1 点の条件 |
+| Signal | Condition for 1 point |
 |---|---|
-| raw_reappearance | 同パターンの raw 記録が 3 件以上ある |
-| steps_complexity | `steps_outline` が 3 項目以上かつ非自明な判断を含む |
-| trigger_articulable | `trigger_description` が具体的かつ検索可能な語彙で書ける |
-| criteria_articulable | `decision_criteria` に定量閾値または分類ルールがある |
-| reusable_output | `output_format` が他タスクで転用可能な構造を持つ |
+| raw_reappearance | Three or more raw records exist for the same pattern |
+| steps_complexity | `steps_outline` has 3 or more items and includes non-trivial judgment |
+| trigger_articulable | `trigger_description` can be written in concrete, searchable vocabulary |
+| criteria_articulable | `decision_criteria` has a quantitative threshold or a classification rule |
+| reusable_output | `output_format` has a structure transferable to other tasks |
 
-詳細な判定手順は `references/signals.md` を参照。
+For detailed judgment procedures, see `references/signals.md`.
 
-## Step 2: 合計点から 3 値に分岐
+## Step 2: Branch from total score into 3 values
 
-| 合計点 | 判定 | 意味 |
+| Total | Verdict | Meaning |
 |---|---|---|
-| 3 点以上 | `skill_recommend` | skill 化推奨。候補キューに追加 |
-| 2 点 | `candidate_queue` | 候補止まり。raw に追記し次回の raw_reappearance を待つ |
-| 1 点以下 | `curated_only` | curated ノートのままで十分 |
+| 3 or more | `skill_recommend` | Skill recommended. Add to candidate queue |
+| 2 | `candidate_queue` | Stays a candidate. Append to raw and wait for the next raw_reappearance |
+| 1 or fewer | `curated_only` | A curated note is sufficient |
 
-閾値を 3 点に置いた根拠: org-retro 旧版の「2 つ以上で推奨」よりやや保守的にし、
-候補止まり層を明示的に作ることで、「skill 検索面のノイズ」を予防する。
+Rationale for the threshold of 3: slightly more conservative than the previous
+"2-or-more recommends" of org-retro, intentionally creating an explicit
+"candidate-only" tier to prevent "noise on the skill search surface."
 
-## Step 3: 出力
+## Step 3: Output
 
-以下の構造を呼び出し元に返す:
+Return the following structure to the caller:
 
 ```yaml
 decision: skill_recommend | candidate_queue | curated_only
 score: 0-5
-matched_signals: [<1 点が付いたシグナル名>, ...]
-rationale: <1-2 行の根拠文>
-proposed_skill_name: <pattern_name>    # skill_recommend / candidate_queue のみ
+matched_signals: [<signal name that scored 1>, ...]
+rationale: <1-2 line rationale>
+proposed_skill_name: <pattern_name>    # only for skill_recommend / candidate_queue
 ```
 
-## Step 4: 候補キュー書き込み（skill_recommend の場合のみ）
+## Step 4: Write to candidate queue (skill_recommend only)
 
-`knowledge/skill-candidates.md` に以下のエントリを追記する。
-`candidate_queue` / `curated_only` の場合は書き込まない。
+Append the following entry to `knowledge/skill-candidates.md`.
+Do not write for `candidate_queue` / `curated_only`.
 
 ```markdown
 ### {YYYY-MM-DD} {pattern-name}
-- **判定スコア**: {score}/5
-- **該当シグナル**: {matched_signals}
-- **根拠**: {rationale}
-- **関連タスク**: {task_ids、curation 文脈では空 "[]" 可}
-- **関連 raw ファイル**: {raw_files}
-- **呼び出し元**: {context}
-- **提案 skill 名**: {proposed_skill_name}
+- **Score**: {score}/5
+- **Matched signals**: {matched_signals}
+- **Rationale**: {rationale}
+- **Related tasks**: {task_ids; "[]" allowed in the curation context}
+- **Related raw files**: {raw_files}
+- **Caller**: {context}
+- **Proposed skill name**: {proposed_skill_name}
 - **status**: pending
-- **決定日**: 未定
-- **却下理由**: （status が rejected に遷移したとき記入、それ以外は省略）
-- **統合先**: （status が merged-into-* のとき記入、それ以外は省略）
+- **Decision date**: undecided
+- **Reject reason**: (fill in when status transitions to rejected; otherwise omit)
+- **Merged into**: (fill in when status is merged-into-*; otherwise omit)
 ```
 
-書き込み後も呼び出し元には出力 YAML を返す（キュー追記は副作用として完了）。
+The output YAML is still returned to the caller after writing
+(the queue append completes as a side effect).
 
-## 呼び出し元の責務
+## Caller responsibilities
 
-このスキルは判定とキュー追記だけを行う。以降のアクションは呼び出し元の責務:
+This skill performs only the judgment and the queue append. Subsequent actions
+are the caller's responsibility:
 
-- **org-retro（post_retro）**:
-  - `skill_recommend` → 人間に提案し、承認なら work-skill-template.md で skill 新規作成
-  - `candidate_queue` → raw/ に技術的知見のみ記録
-  - `curated_only` → raw/ への記録で十分（報告不要）
+- **org-retro (post_retro)**:
+  - `skill_recommend` → propose to the human; on approval, create a new
+    work-skill using work-skill-template.md
+  - `candidate_queue` → record only the technical knowledge in raw/
+  - `curated_only` → recording in raw/ is sufficient (no report needed)
 
-- **org-curate（curation）**: decision 値に関わらず通常の Step 3 で curated/ 統合 + Step 4 で `<!-- curated -->` 付与を行う（skill 化と curated ノート化は両立）。
-  - `skill_recommend` → 候補キュー追記のみ（skill 側で自動書き込み済み）。
-    人間への問い合わせは窓口の役目で、キュー閾値 N=5 に達したら窓口が行う
-  - `candidate_queue` → 追加アクションなし（次回の raw_reappearance を待つのはシグナル上の話であり、raw を未整理のまま残すことではない）
-  - `curated_only` → 追加アクションなし
+- **org-curate (curation)**: regardless of the decision value, the normal
+  Step 3 carries out the curated/ integration and Step 4 attaches the
+  `<!-- curated -->` marker (skill promotion and curated-note creation
+  coexist).
+  - `skill_recommend` → only the candidate queue append (already written by
+    this skill). The query to the human is the Lead's job, performed when the
+    queue threshold N=5 is reached
+  - `candidate_queue` → no additional action (waiting for the next
+    raw_reappearance is a signal-level matter, not a license to leave raw
+    unprocessed)
+  - `curated_only` → no additional action
 
-## 重複呼び出しの扱い
+## Handling duplicate calls
 
-同一 `pattern_name` が既に `knowledge/skill-candidates.md` に `status: pending` で
-存在する場合、Step 4 では新規エントリを追加せず既存エントリの `関連タスク`・`関連 raw ファイル` を
-追記マージする。status が `approved` / `rejected` / `merged-into-*` になっているエントリは
-履歴として保持し、新しいエントリを別日付で追加する（過去の却下理由を失わない）。
+When the same `pattern_name` already exists in `knowledge/skill-candidates.md`
+with `status: pending`, Step 4 does not add a new entry — it merges the new
+`Related tasks` / `Related raw files` into the existing entry.
+Entries whose status is `approved` / `rejected` / `merged-into-*` are kept as
+history, and a new entry is added under a different date (so the past reject
+reason is not lost).
 
-## スキルを呼ばないケース
+## When not to call this skill
 
-- ワーカーが単に「便利だった関数」をメモするだけ → これは `knowledge/raw/` の記録で十分で、
-  本スキルの入力 5 項目（特に `steps_outline` と `trigger_description`）が埋まらない
-- 一度きりの調査・デバッグ → パターン化する見込みがなく、判定コストの無駄
+- A worker simply jotting down "a useful function" → this is sufficient as a
+  `knowledge/raw/` record; the 5 input items required by this skill (especially
+  `steps_outline` and `trigger_description`) cannot be filled in
+- A one-off investigation / debugging session → no expectation of pattern
+  emergence, so the judgment cost is wasted

--- a/.claude/skills/skill-eligibility-check/references/signals.md
+++ b/.claude/skills/skill-eligibility-check/references/signals.md
@@ -1,80 +1,92 @@
-# 昇格シグナル定義
+# Promotion signal definitions
 
-`skill-eligibility-check` が参照する 5 シグナルの採点基準。
-いずれも 0 点 / 1 点の二値で採点し、合計点で 3 値分岐する。
+Scoring criteria for the 5 signals referenced by `skill-eligibility-check`.
+All are scored as 0 or 1, and the total decides the 3-value branch.
 
-## 1. raw_reappearance（raw 再出現）
+## 1. raw_reappearance
 
-**1 点の条件**: 同じパターンに関する記録が `knowledge/raw/` に **3 件以上**ある。
+**Condition for 1 point**: there are **3 or more** records of the same pattern
+in `knowledge/raw/`.
 
-**判定手順**:
-1. 入力の `raw_files` と、`pattern_name` を既存 raw/ 中で grep した結果をマージ
-2. 同パターンを扱う独立したファイルが 3 件以上あるか確認
-3. 同一タスクの連続記録（同 task_id 由来）は 1 件として数える
+**Procedure**:
+1. Merge the input `raw_files` with the result of grepping existing raw/ for
+   `pattern_name`.
+2. Confirm there are 3 or more independent files covering the same pattern.
+3. Successive records from a single task (with the same task_id) count as one.
 
-**根拠**: 3 件あればパターン化したと言える（`knowledge-standards.md` と同基準）。
-2 件以下だと偶然の一致の可能性が残る。
+**Rationale**: with 3 entries we can call it a pattern (same baseline as
+`knowledge-standards.md`). At 2 or fewer, coincidence remains plausible.
 
-## 2. steps_complexity（手順の複雑さ）
+## 2. steps_complexity
 
-**1 点の条件**: `steps_outline` が **3 項目以上** かつ非自明な判断を含む。
+**Condition for 1 point**: `steps_outline` has **3 or more items** AND includes
+non-trivial judgment.
 
-**判定手順**:
-1. `steps_outline` の項目数をカウント（3 未満なら 0 点で確定）
-2. 各ステップが「IDE やドキュメントを読めば誰でも再現できる」範囲か確認
-3. 1 つ以上のステップに以下が含まれれば 1 点:
-   - 条件分岐（「エラー A なら B、エラー C なら D」等）
-   - ツール選定の根拠
-   - 他の手段では失敗する理由
+**Procedure**:
+1. Count items in `steps_outline` (fewer than 3 ⇒ confirmed 0 points).
+2. Check whether each step is "reproducible by anyone reading the IDE or
+   documentation."
+3. Score 1 point if at least one step contains:
+   - Conditional branching ("if error A then B, if error C then D", etc.)
+   - Rationale for tool selection
+   - Reasons why other approaches fail
 
-**根拠**: 単なる手順列は README で十分。skill として切り出す価値は「判断の結晶化」にある。
+**Rationale**: a plain procedure list is fine in a README. The value of carving
+out a skill lies in "crystallizing judgment."
 
-## 3. trigger_articulable（トリガー条件明文化）
+## 3. trigger_articulable
 
-**1 点の条件**: `trigger_description` が具体的かつ検索可能な語彙で書ける。
+**Condition for 1 point**: `trigger_description` can be written in concrete,
+searchable vocabulary.
 
-**判定手順**:
-1. `trigger_description` が空 / 「必要なとき」「適切な場面」等の曖昧表現のみなら 0 点
-2. 具体物（ファイル形式、タスク種別、入力パターン）で書かれていれば 1 点
-3. `org-delegate` の work-skill 検索で他の skill の description と区別がつく語彙か確認
+**Procedure**:
+1. 0 points if `trigger_description` is empty / contains only vague phrases
+   like "when needed" or "in suitable situations."
+2. 1 point if written in concrete terms (file format, task type, input pattern).
+3. Verify the vocabulary is distinguishable from other skills' descriptions in
+   `org-delegate`'s work-skill search.
 
-**根拠**: 発見されない skill は無いのと同じ。「検索面のノイズ」を
-増やさないためには、triggers が具体的で重ならないことが前提。
+**Rationale**: a skill that is never discovered may as well not exist. To avoid
+adding "noise on the search surface," triggers must be concrete and
+non-overlapping.
 
-## 4. criteria_articulable（判断基準明文化）
+## 4. criteria_articulable
 
-**1 点の条件**: `decision_criteria` に定量閾値または分類ルールがある。
+**Condition for 1 point**: `decision_criteria` has a quantitative threshold or
+a classification rule.
 
-**判定手順**:
-1. 空または「適切に判断する」等の曖昧表現のみなら 0 点
-2. 以下のいずれかがあれば 1 点:
-   - 数値閾値（「95% 以上」「3 回以上」等）
-   - 明示的分類（「A / B / C のいずれか」）
-   - 優先順位ルール（「X が X' より優先」）
+**Procedure**:
+1. 0 points if empty or only a vague phrase like "judge appropriately."
+2. 1 point if any of the following exists:
+   - Numeric threshold ("95% or higher", "3 or more times", etc.)
+   - Explicit classification ("one of A / B / C")
+   - Priority rule ("X has priority over X'")
 
-**根拠**: 判断基準が言語化できないスキルは人間が読んでも再現できず、
-curated ノート（参考情報）で十分。
+**Rationale**: a skill whose judgment criteria cannot be put into words cannot
+be reproduced by a human reader either, so a curated note (reference
+information) is enough.
 
-## 5. reusable_output（成果物フォーマット再利用可能）
+## 5. reusable_output
 
-**1 点の条件**: `output_format` が他タスクで転用可能な構造を持つ。
+**Condition for 1 point**: `output_format` has a structure transferable to
+other tasks.
 
-**判定手順**:
-1. `output_format` が空なら 0 点
-2. 以下のいずれかがあれば 1 点:
-   - セクション構成が定義されている（「背景 / 判断 / 根拠」等）
-   - スキーマが定義されている（表・YAML・JSON 等）
-   - 命名規則が明示されている
+**Procedure**:
+1. 0 points if `output_format` is empty.
+2. 1 point if any of the following exists:
+   - A defined section structure ("Background / Decision / Rationale", etc.)
+   - A defined schema (table, YAML, JSON, etc.)
+   - An explicit naming convention
 
-**根拠**: 成果物が毎回バラバラだと後続タスクで比較・引用できず、
-skill 化しても再利用が発生しない。
+**Rationale**: if outputs vary every time, downstream tasks cannot compare or
+cite them, so even after promotion to a skill no reuse occurs.
 
-## 採点結果の扱い
+## Handling of scoring results
 
-- 3 点以上: `skill_recommend`
-- 2 点: `candidate_queue`
-- 1 点以下: `curated_only`
+- 3 or more: `skill_recommend`
+- 2: `candidate_queue`
+- 1 or fewer: `curated_only`
 
-各シグナルの 0/1 は `matched_signals` として呼び出し元に返し、
-候補キュー `knowledge/skill-candidates.md` にも残る。
-これにより後の棚卸し（`skill-audit`）で「どのシグナルが弱かったか」を追跡できる。
+The 0/1 of each signal is returned to the caller as `matched_signals` and
+also remains in the candidate queue `knowledge/skill-candidates.md`.
+This lets a later inventory audit (`skill-audit`) trace "which signal was weak."

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,63 +1,67 @@
 # Automated Tests
 
-Python ベースのパーサー/コンバーター回帰検知テストと、Bash ベースの hook 回帰検知テストをまとめた実行ガイド。
+Run guide bundling the Python-based parser/converter regression tests and the
+Bash-based hook regression tests.
 
-## 対象
+## Coverage
 
-| 関数 | 内容 |
+| Function | Description |
 |------|------|
-| `_parse_org_state` | org-state.md のステータス・目的・作業項目を解析 |
-| `_parse_journal` | journal.jsonl のイベントログを解析 |
-| `_parse_projects` | projects.md のマークダウンテーブルを解析 |
-| `_parse_workers` | worker-*.md ファイル群を解析 |
-| `_parse_knowledge` | curated/*.md の H2 セクション数をカウント |
-| `org_state_converter.py` | org-state Markdown -> JSON 変換とダッシュボード JSON 読み込み |
-| `.hooks/*.sh` | worker boundary / claude-org structure / git push block の回帰検知 |
+| `_parse_org_state` | Parses org-state.md status, purpose, and work items |
+| `_parse_journal` | Parses the journal.jsonl event log |
+| `_parse_projects` | Parses the markdown table in projects.md |
+| `_parse_workers` | Parses the worker-*.md files |
+| `_parse_knowledge` | Counts H2 sections in curated/*.md |
+| `org_state_converter.py` | org-state Markdown → JSON conversion and dashboard JSON loading |
+| `.hooks/*.sh` | Worker boundary / claude-org structure / git push block regression detection |
 
-## 実行方法
+## How to run
 
 ```bash
-# Python テスト
-# Windows (py -3 が使えない場合は python でも可)
+# Python tests
+# Windows (use python if py -3 is unavailable)
 python -m unittest discover -s tests -v
 
 # Mac / Linux
 python3 -m unittest discover -s tests -v
 
-# Shell hook テスト
+# Shell hook tests
 bash tests/run-all.sh
 ```
 
-プロジェクトルートで実行してください。外部ライブラリは不要ですが、shell hook テストには `bash` と `jq` が必要です。
+Run from the project root. No external libraries are required, but the shell
+hook tests need `bash` and `jq`.
 
-日常運用では、Python テストだけでなく `bash tests/run-all.sh` まで含めて成功として扱ってください。
+In daily operation, treat success as "Python tests AND `bash tests/run-all.sh`
+both pass," not just the Python tests.
 
-## テスト構成
+## Test layout
 
 ```
 tests/
-  __init__.py              # パッケージ初期化（空）
-  test_parsers.py          # dashboard/server.py のパーサーテスト
+  __init__.py              # Package init (empty)
+  test_parsers.py          # Parser tests for dashboard/server.py
   test_org_state_converter.py
-  run-all.sh               # shell hook テストランナー
+  run-all.sh               # Shell hook test runner
   test-block-git-push.sh
   test-block-org-structure.sh
   test-check-worker-boundary.sh
   fixtures/
-    org-state-sample.md    # org-state パーサー用サンプル
-    journal-sample.jsonl   # journal パーサー用サンプル
-    projects-sample.md     # projects パーサー用サンプル
+    org-state-sample.md    # Sample for the org-state parser
+    journal-sample.jsonl   # Sample for the journal parser
+    projects-sample.md     # Sample for the projects parser
     workers/
-      worker-abc12345.md   # workers パーサー用サンプル
+      worker-abc12345.md   # Sample for the workers parser
     curated/
-      .gitkeep             # スキップ対象の確認用
-      sample-topic.md      # knowledge パーサー用サンプル
+      .gitkeep             # Used to verify skip behavior
+      sample-topic.md      # Sample for the knowledge parser
 ```
 
-## テスト結果の保存
+## Saving test results
 
-テスト結果を記録する場合は `docs/test-results/` に保存してください。
+When recording test results, save them under `docs/test-results/`.
 
 ## CI
 
-GitHub Actions でも同じ 2 系統のテストを実行します。ローカルで再現できない failure を減らすため、PR 前に両方を通してください。
+GitHub Actions runs the same two test suites. To reduce failures that cannot
+be reproduced locally, run both suites before opening a PR.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,111 +1,148 @@
-# 検証方法
+# Verification
 
-各機能の動作確認手順。問題が見つかったらスキルやCLAUDE.mdを修正し、再テストする。
+Procedures for confirming each feature works. When a problem is found, fix the
+skill or CLAUDE.md and retest.
 
-**前提**: renga 0.18.0+ （`npm install -g @suisya-systems/renga@0.18.0` 後、`renga mcp install --force` で `renga-peers` MCP サーバを user-scope 登録済み）。structured `cwd` (0.16.0) / `set_pane_identity` (0.17.0) / `spawn_claude_pane` (0.18.0) すべてを前提とする。
+**Prerequisites**: renga 0.18.0+ (after `npm install -g @suisya-systems/renga@0.18.0`,
+register the `renga-peers` MCP server at user scope with `renga mcp install --force`).
+Assumes structured `cwd` (0.16.0) / `set_pane_identity` (0.17.0) / `spawn_claude_pane` (0.18.0)
+are all available.
 
 ---
 
-## 0. リグレッションチェック（起動テンプレートの退行防止）
+## 0. Regression check (preventing regressions in launch templates)
 
-**目的**: Issue #58 で撤去した `cd X && claude ...` auto-upgrade 迂回パターンがテンプレート / スキル / docs に再導入されていないか検出する。
+**Goal**: detect whether the `cd X && claude ...` auto-upgrade-bypass pattern
+removed in Issue #58 has been reintroduced into templates / skills / docs.
 
-**手順**:
+**Procedure**:
 ```bash
-# (1) spawn_pane / spawn_claude_pane の command 引数に `cd X && claude` を合成している箇所
-#     (禁止: renga の bare-claude auto-upgrade が発動せず channel push が届かない)
+# (1) Spots that synthesize `cd X && claude` into the command argument of
+#     spawn_pane / spawn_claude_pane
+#     (forbidden: renga's bare-claude auto-upgrade does not fire and channel push does not arrive)
 grep -rEn 'command="cd [^"]*&&[[:space:]]*claude' --include="*.md" --include="*.toml" . \
-  && { echo "FAIL: cd&&claude 合成が残っている"; exit 1; } \
+  && { echo "FAIL: cd&&claude synthesis remains"; exit 1; } \
   || echo "OK: no cd&&claude synthesis"
 
-# (2) ops.toml / layout TOML の command 行に `claude --dangerously-load-development-channels` を手書き
-#     (renga 0.16.0+ の bare-claude auto-upgrade / spawn_claude_pane の自動付与で不要)
+# (2) Hand-written `claude --dangerously-load-development-channels` on the
+#     command line of ops.toml / layout TOML
+#     (unnecessary thanks to renga 0.16.0+ bare-claude auto-upgrade / spawn_claude_pane auto-injection)
 grep -En '^[[:space:]]*command[[:space:]]*=.*dangerously-load-development-channels' renga-layouts/*.toml \
-  && { echo "FAIL: layout で dangerously フラグ手書き"; exit 1; } \
+  && { echo "FAIL: dangerously flag hand-written in layout"; exit 1; } \
   || echo "OK: no explicit flag in layout TOML"
 ```
 
-**期待結果**:
-- (1) は 0 件（prose 内での解説的な言及は引用符／記法が異なるためヒットしない）
-- (2) は `renga-layouts/*.toml` で 0 件
+**Expected result**:
+- (1) returns 0 hits (descriptive mentions in prose use different quoting / notation and do not match)
+- (2) returns 0 hits in `renga-layouts/*.toml`
 
-**失敗時の対処**:
-- ヒットした場合は `spawn_claude_pane` の構造化フィールド (`cwd` / `permission_mode` / `model`) に書き換える。詳細は `.claude/skills/org-start/SKILL.md`「ClaudeCode 起動コマンド（役割別）」セクションと `.claude/skills/org-delegate/references/pane-layout.md` を参照
+**Recovery on failure**:
+- Rewrite hits to use the structured fields of `spawn_claude_pane` (`cwd` /
+  `permission_mode` / `model`). For details, see the "ClaudeCode launch
+  command (per role)" section of `.claude/skills/org-start/SKILL.md` and
+  `.claude/skills/org-delegate/references/pane-layout.md`.
 
-## 0. 互換性プリフライト
+## 0. Compatibility preflight
 
-**目的**: `/org-start` 実行前に renga バージョンと MCP ツール surface が claude-org の要件を満たすか確認する（Issue #61）。
+**Goal**: confirm that, before running `/org-start`, the renga version and MCP
+tool surface meet claude-org's requirements (Issue #61).
 
-**手順**:
+**Procedure**:
 ```bash
 py -3 tools/check_renga_compat.py            # Windows
 python3 tools/check_renga_compat.py          # macOS / Linux
-py -3 tools/check_renga_compat.py --json     # 機械可読出力
+py -3 tools/check_renga_compat.py --json     # Machine-readable output
 ```
 
-**期待結果**: `Result: OK` で終了コード 0。renga バージョン・`renga-peers` MCP 登録・必須 14 ツールすべてが揃っていれば合格。
+**Expected result**: exits with `Result: OK` and exit code 0. Pass criteria:
+renga version, `renga-peers` MCP registration, and all 14 required tools are
+present.
 
-**失敗パターン**:
-- renga バージョン不足 → `npm update -g @suisya-systems/renga`
-- MCP 未登録 → `renga mcp install`
-- ツール欠如 → `renga mcp install --force` で stale 登録を更新
+**Failure patterns**:
+- renga version too old → `npm update -g @suisya-systems/renga`
+- MCP not registered → `renga mcp install`
+- Tools missing → `renga mcp install --force` to refresh stale registrations
 
-このスクリプトは live renga セッションを必要としない（`renga mcp-peer` stdio 経由で tools/list を取得する静的 probe）。
-
----
-
-## 1. 基本起動テスト
-
-**目的**: clone先でClaudeCodeを起動し、CLAUDE.mdとスキルが正しく読み込まれるか確認。
-
-**手順**:
-1. 任意の場所に本リポジトリを `git clone`
-2. clone先で `renga --layout ops` を実行 (窓口ペインが立ち上がる)
-3. 窓口の Claude Code で `mcp__renga-peers__list_panes` が疎通するか確認（Step 0 の MCP 有効性 chk）
-4. 窓口の Claude Code で `/org-start` を実行
-
-**期待結果**:
-- `.state/org-state.md` が存在しないので、初回起動と判断される
-- `mcp__renga-peers__spawn_pane` でフォアマンペインが窓口の下に開き、その右にキュレーターペインが開く
-- Dispatcher / Curator 起動直後の「開発チャネル確認プロンプト」を `mcp__renga-peers__send_keys(target=<pane>, enter=true)` で Enter 注入して通過している（`org-start` SKILL Step 2 / Step 3 の手順）
-- キュレーターに `mcp__renga-peers__send_message` 経由で `/loop 30m /org-curate` の実行が指示される
-- 「初回起動です。何をしましょうか？」と報告される
-
-**失敗パターンと対処**:
-- CLAUDE.mdが読み込まれない → `.claude/` ディレクトリ配置を確認
-- スキルが認識されない → `.claude/skills/*/SKILL.md` のfrontmatter形式を確認
-- `/org-start` が発動しない → スキル名の競合やdescriptionを確認
-- `mcp__renga-peers__list_panes` で error → `renga mcp install --force` を再実行、`claude mcp list` で登録確認
-- `send_keys(enter=true)` が Enter 注入に失敗 → Dispatcher / Curator ペインが「Load development channel?」プロンプトで止まっているか確認、手動で Enter
+This script does not require a live renga session (it is a static probe that
+fetches tools/list via `renga mcp-peer` stdio).
 
 ---
 
-## 2. org-delegate テスト（ワーカー派遣）
+## 1. Basic launch test
 
-**目的**: ワーカーが正しく派遣され、作業を完了し、結果が報告されるか確認。
+**Goal**: launch ClaudeCode at the clone destination and confirm CLAUDE.md
+and skills are loaded correctly.
 
-**前提**: `renga --layout ops` で起動していること、`renga-peers` MCP が有効なこと（`claude mcp list` で Connected 確認）。テスト1で `/org-start` 済み。
+**Procedure**:
+1. `git clone` this repository into any location
+2. Run `renga --layout ops` at the clone destination (a Lead pane comes up)
+3. Confirm `mcp__renga-peers__list_panes` is reachable from the Lead's Claude
+   Code (Step 0 MCP-availability check)
+4. Run `/org-start` in the Lead's Claude Code
 
-**手順**:
-1. 窓口Claudeにタスクを依頼する（例:「ブログに新しい記事を追加して」）
-2. 新規プロジェクトの場合、通称・パス・説明の確認が入るので回答する
-3. 窓口が `/org-delegate` でワーカーを派遣するのを確認
+**Expected result**:
+- `.state/org-state.md` does not exist, so it is judged as a first-time launch
+- `mcp__renga-peers__spawn_pane` opens the Dispatcher pane below the Lead, and
+  the Curator pane to its right
+- The "load development channel?" prompt that appears immediately after
+  Dispatcher / Curator launch is bypassed by injecting Enter via
+  `mcp__renga-peers__send_keys(target=<pane>, enter=true)` (per the
+  `org-start` SKILL Step 2 / Step 3 procedure)
+- The Curator is instructed via `mcp__renga-peers__send_message` to run
+  `/loop 30m /org-curate`
+- Reports "First launch. What shall we do?"
 
-**期待結果**:
-- プロジェクトが `registry/projects.md` に自動登録される
-- 窓口がフォアマンに DELEGATE メッセージを送信し、すぐにユーザーとの対話に戻る
-- フォアマンが `mcp__renga-peers__spawn_pane` で同一タブ内にワーカーペインを派生する（`name="worker-{task_id}"`、balanced split 戦略は `pane-layout.md` に従う）
-- フォアマンが `mcp__renga-peers__poll_events(types=["pane_started"])` で起動完了を確認
-- ワーカー起動直後の「開発チャネル確認プロンプト」を `mcp__renga-peers__send_keys(target="worker-{task_id}", enter=true)` で Enter 注入して通過（`org-delegate` SKILL Step 3-2）
-- フォアマンが `mcp__renga-peers__send_message` 経由でワーカーに作業指示を送信する
-- フォアマンが `.state/workers/worker-{id}.md` を作成する
-- `.state/org-state.md` が作成/更新される
-- `.state/journal.jsonl` にイベントが記録される
-- ワーカー完了後、`renga-peers` 経由で**窓口に**報告が届く（フォアマンではなく窓口）
-- 窓口が結果を業務言語で人間に伝える（技術用語を避ける）
-- 窓口がフォアマンにペインクローズを依頼する（フォアマンは `mcp__renga-peers__close_pane(target="worker-{task_id}")` で破棄）
+**Failure patterns and recovery**:
+- CLAUDE.md is not loaded → check the layout of the `.claude/` directory
+- Skills are not recognized → check the frontmatter format of
+  `.claude/skills/*/SKILL.md`
+- `/org-start` does not fire → check for skill-name conflicts or the description
+- `mcp__renga-peers__list_panes` errors → re-run `renga mcp install --force`,
+  verify with `claude mcp list`
+- `send_keys(enter=true)` fails to inject Enter → verify the Dispatcher /
+  Curator pane is stuck on the "Load development channel?" prompt; press
+  Enter manually
 
-**確認コマンド**:
+---
+
+## 2. org-delegate test (worker dispatch)
+
+**Goal**: confirm a worker is correctly dispatched, completes its task, and
+reports the result.
+
+**Prerequisites**: launched with `renga --layout ops`, `renga-peers` MCP is
+active (verify Connected with `claude mcp list`). Test 1 has run `/org-start`.
+
+**Procedure**:
+1. Ask the Lead Claude for a task (e.g. "add a new article to the blog")
+2. For a new project, the Lead asks for nickname / path / description; answer
+3. Confirm the Lead dispatches a worker via `/org-delegate`
+
+**Expected result**:
+- The project is auto-registered in `registry/projects.md`
+- The Lead sends a DELEGATE message to the Dispatcher and immediately returns
+  to the user dialogue
+- The Dispatcher derives a worker pane in the same tab via
+  `mcp__renga-peers__spawn_pane` (`name="worker-{task_id}"`; the balanced split
+  strategy follows `pane-layout.md`)
+- The Dispatcher confirms launch completion via
+  `mcp__renga-peers__poll_events(types=["pane_started"])`
+- The "load development channel?" prompt right after worker launch is bypassed
+  by `mcp__renga-peers__send_keys(target="worker-{task_id}", enter=true)`
+  (per `org-delegate` SKILL Step 3-2)
+- The Dispatcher sends the task instruction to the worker via
+  `mcp__renga-peers__send_message`
+- The Dispatcher creates `.state/workers/worker-{id}.md`
+- `.state/org-state.md` is created/updated
+- Events are recorded in `.state/journal.jsonl`
+- After the worker finishes, the report arrives **at the Lead** via
+  `renga-peers` (not the Dispatcher)
+- The Lead conveys the result to the human in business language (avoiding
+  technical jargon)
+- The Lead asks the Dispatcher to close the pane (the Dispatcher disposes of
+  it via `mcp__renga-peers__close_pane(target="worker-{task_id}")`)
+
+**Verification commands**:
 ```bash
 cat .state/org-state.md
 cat .state/journal.jsonl
@@ -113,399 +150,520 @@ ls .state/workers/
 cat registry/projects.md
 ```
 
-ペイン状態の確認は MCP ツールで:
+Pane state is checked via the MCP tool:
 ```
-mcp__renga-peers__list_panes    # 現在のペイン一覧
+mcp__renga-peers__list_panes    # Current pane list
 ```
 
-**失敗パターンと対処**:
-- ペインが開かない → `mcp__renga-peers__list_panes` で現在のペイン状態を確認、tool result の `[split_refused]` / `[pane_not_found]` を `references/renga-error-codes.md` で分岐
-- renga-peers で通信できない → `claude mcp list` で `renga-peers` が Connected か確認、`list_peers` で peer ID（`worker-{task_id}` / `dispatcher` / `curator` / `secretary`）を確認
-- 状態ファイルが作成されない → org-delegateスキルの手順を見直し
-- ワーカーが指示を理解しない → instruction-template.md の記述を改善
-- プロジェクト名前解決が動かない → org-delegate Step 0 を見直し
+**Failure patterns and recovery**:
+- Pane does not open → check current pane state with
+  `mcp__renga-peers__list_panes`; branch on `[split_refused]` /
+  `[pane_not_found]` in the tool result via `references/renga-error-codes.md`
+- Cannot communicate via renga-peers → confirm `renga-peers` is Connected with
+  `claude mcp list`, check peer IDs (`worker-{task_id}` / `dispatcher` /
+  `curator` / `secretary`) with `list_peers`
+- State file not created → revisit the org-delegate skill steps
+- Worker does not understand the instruction → improve the wording in
+  instruction-template.md
+- Project name resolution does not work → revisit org-delegate Step 0
 
-### 2.1 balanced split スケール検証（4 並列 / 8 並列）
+### 2.1 Balanced-split scale verification (4-way / 8-way)
 
-**目的**: org-delegate Step 3 の rect ベース balanced split が、4 並列・8 並列いずれも `[split_refused]` を発生させずに期待通りの tree を生成することを実機確認する。
+**Goal**: confirm in real hardware that the rect-based balanced split in
+org-delegate Step 3 produces the expected tree without `[split_refused]` for
+both 4-way and 8-way concurrency.
 
-**前提**: テスト 2 が通っていること。ターミナル幅 `W ≥ 160 cols`（`tput cols` で確認）。`pane-layout.md` の「ワーカーの balanced split 戦略」セクションを手元で開いておく。
+**Prerequisites**: Test 2 passing. Terminal width `W ≥ 160 cols` (verify with
+`tput cols`). Have the "Worker balanced split strategy" section of
+`pane-layout.md` open at hand.
 
-**手順**:
-1. `tput cols` を実行し W を記録。160 未満なら検証不能としてスキップ or ターミナルを広げる。
-2. 窓口に互いに独立な 8 タスク（ダミーで良い。例: `echo-1` 〜 `echo-8` のような軽量タスク）を順次依頼。k=1〜8 それぞれが以下を満たすことを確認:
-   - a. フォアマンの `mcp__renga-peers__spawn_pane` 呼び出し結果テキストに `[split_refused]` が含まれない
-   - b. Step 3-1b のアルゴリズムが選出した `target` / `direction` が、`list_panes` の直前スナップショットから rect ベースで再現可能
-   - c. 起動直後の `mcp__renga-peers__list_panes` を **別ログファイル (例: `.state/verification/balanced-split-{timestamp}.log`)** に保存するか、その場で `role == "worker"` の `name` / `id` を記録し、`.state/journal.jsonl` の `worker_spawned` イベントと事後照合する
-3. 各 k 到達時点でペイン配置を `list_panes` で取得し、Step 3-1b のアルゴリズム（curator 特定 → role filter → dispatcher-curator 隣接判定 → direction 判定 → `new_w / new_h` 計算 → MIN_PANE 制約 → SECRETARY 保険条項 → metric sort）をスナップショットに対して手計算で再現できることを確認する。`pane-layout.md` の「ワーカーの balanced split 戦略」で述べている通り、rect ベース動的配置なので 2×2 や 2×4 のような固定グリッド形状は成功基準にしない。
-4. 9 人目のダミータスクを試し、フォアマンが `renga-peers` で窓口に `SPLIT_CAPACITY_EXCEEDED` を送信することを確認。**当該 9 人目のワーカーのみ派遣を中止し、フォアマン本体の監視ループは継続稼働**すること（`spawn_pane` は発行されず、`exit` などでフォアマンが落ちない）。
+**Procedure**:
+1. Run `tput cols` and record W. If under 160, mark unverifiable and skip, or
+   widen the terminal.
+2. Ask the Lead 8 mutually independent tasks in sequence (dummies are fine,
+   e.g. lightweight tasks like `echo-1` ... `echo-8`). Confirm each k = 1..8
+   satisfies:
+   - a. The text result of the Dispatcher's `mcp__renga-peers__spawn_pane`
+        call does not contain `[split_refused]`
+   - b. The `target` / `direction` selected by the Step 3-1b algorithm can be
+        reproduced rect-wise from the immediately preceding `list_panes`
+        snapshot
+   - c. Save `mcp__renga-peers__list_panes` taken just after launch to a
+        **separate log file (e.g. `.state/verification/balanced-split-{timestamp}.log`)**,
+        or record the `name` / `id` of `role == "worker"` on the spot, and
+        cross-check after the fact against the `worker_spawned` events in
+        `.state/journal.jsonl`
+3. At each k, fetch the pane layout with `list_panes` and confirm that the
+   Step 3-1b algorithm (curator identification → role filter →
+   dispatcher-curator adjacency check → direction decision → `new_w / new_h`
+   calculation → MIN_PANE constraint → SECRETARY safety clause → metric sort)
+   can be hand-reproduced against the snapshot. As stated in the "Worker
+   balanced split strategy" section of `pane-layout.md`, this is rect-based
+   dynamic placement, so fixed grid shapes such as 2×2 or 2×4 are not used as
+   success criteria.
+4. Try a 9th dummy task and confirm the Dispatcher sends
+   `SPLIT_CAPACITY_EXCEEDED` to the Lead via `renga-peers`. **Only the 9th
+   worker dispatch is canceled; the Dispatcher's monitoring loop itself
+   continues to run** (no `spawn_pane` is issued and the Dispatcher does not
+   fall over via `exit` etc.).
 
-> **注**: `.state/verification/balanced-split-{timestamp}.log` 等の検証用ログは一時ファイルなのでコミット対象外。`.state/*` は既存の `.gitignore` で除外済み。
+> **Note**: verification logs such as
+> `.state/verification/balanced-split-{timestamp}.log` are temporary and not
+> committed. `.state/*` is already excluded by the existing `.gitignore`.
 
-**期待結果**:
-- k=1〜8 で `[split_refused]` ゼロ
-- 各 k の配置が Step 3-1b の判定結果と一致（固定グリッド形状は要求しない、rect 動的配置が正しく動くこと）
-- MIN_PANE 制約（`new_w ≥ 20` / `new_h ≥ 5`）に触れない範囲で候補が空にならない
-- k=9 で明示的 escalate（silently fail しない）
+**Expected result**:
+- Zero `[split_refused]` for k=1..8
+- Each k's layout matches the Step 3-1b decision (no fixed grid shape required;
+  the rect dynamic placement works correctly)
+- Within the MIN_PANE constraint (`new_w ≥ 20` / `new_h ≥ 5`), the candidate
+  set does not become empty
+- At k=9, an explicit escalate (no silent failure)
 
-**確認コマンド**:
+**Verification commands**:
 ```bash
-tput cols                                # ターミナル幅の記録
+tput cols                                # Record terminal width
 cat .state/journal.jsonl | grep worker_spawned
 ```
 
-ペイン状態は MCP で:
+Pane state via MCP:
 ```
-mcp__renga-peers__list_panes             # 各 k 到達時のスナップショット
+mcp__renga-peers__list_panes             # Snapshot at each k
 ```
 
-**失敗パターンと対処**:
-- k=4 で `[split_refused]` → `tput cols` の値を確認。W < 160 なら balanced split の要件未満。ターミナル拡大で再試行
-- k=3 で既に `[split_refused]` → dispatcher 直下に file-tree / preview が居座っていないか確認（これらが表示中だと `W_f` が 20〜40 cols 目減りする）
-- 配置が期待と乖離 → 前タスクで閉じ残ったワーカーの `close_pane` 忘れ。`list_panes` で role=worker の active が 0 からスタートしているか確認
-- k=9 で silently 動く → Step 3-1c (`SPLIT_CAPACITY_EXCEEDED` escalate) の分岐が発火していない。Step 3-1b の判定ロジックが「候補空」を正しく返しているか確認
+**Failure patterns and recovery**:
+- `[split_refused]` at k=4 → check the value of `tput cols`. If W < 160 the
+  balanced-split prerequisite is not met. Retry after widening the terminal
+- Already `[split_refused]` at k=3 → check whether file-tree / preview is
+  squatting directly under the Dispatcher (these eat 20-40 cols of `W_f` while
+  visible)
+- Layout differs from expected → forgot `close_pane` for a leftover worker
+  from a previous task. Verify role=worker active starts from 0 in `list_panes`
+- k=9 silently succeeds → the Step 3-1c (`SPLIT_CAPACITY_EXCEEDED` escalate)
+  branch did not fire. Confirm the Step 3-1b decision logic correctly returns
+  "candidate empty"
 
 ---
 
-## 3. org-suspend テスト（中断）
+## 3. org-suspend test (suspend)
 
-**目的**: 組織の状態が正しく保存され、全ペインが停止するか確認。
+**Goal**: confirm the org's state is correctly saved and all panes stop.
 
-**前提**: テスト2でワーカーが稼働中（または完了直後）の状態。
+**Prerequisites**: a worker is running (or has just finished) from Test 2.
 
-**手順**:
-1. 窓口Claudeに「中断して」と伝える
-2. `/org-suspend` が発動するのを確認
+**Procedure**:
+1. Tell the Lead Claude "suspend"
+2. Confirm `/org-suspend` fires
 
-**期待結果**:
-- `mcp__renga-peers__send_message` 経由でワーカーに SUSPEND メッセージが送信される
-- ワーカーが `renga-peers` 経由で状態を報告する。未応答ワーカーは `mcp__renga-peers__inspect_pane(target="worker-{task_id}", format="text")` で画面内容を読み、git 状態と組み合わせて推定する
-- `.state/org-state.md` の Status が `SUSPENDED` になる
-- `.state/org-state.prev.md` にバックアップが作成される
-- `mcp__renga-peers__send_message` で全ピアに SHUTDOWN が送信される
-- `mcp__renga-peers__poll_events(types=["pane_exited"], timeout_ms=10000)` で pane_exited を待機、`role == "worker"` をまとめて消化
-- 残留ワーカーは `mcp__renga-peers__close_pane(target="worker-{task_id}")` でフォールバッククローズ
-- 全ワーカーペインが先に閉じられ、次にフォアマン、最後にキュレーターが閉じられる
-- 窓口が中断完了を報告する
+**Expected result**:
+- A SUSPEND message is sent to the worker via `mcp__renga-peers__send_message`
+- The worker reports state via `renga-peers`. For unresponsive workers, use
+  `mcp__renga-peers__inspect_pane(target="worker-{task_id}", format="text")`
+  to read the screen contents and infer state combined with the git status
+- `.state/org-state.md` Status becomes `SUSPENDED`
+- A backup is created in `.state/org-state.prev.md`
+- A SHUTDOWN is sent to all peers via `mcp__renga-peers__send_message`
+- Wait for pane_exited via
+  `mcp__renga-peers__poll_events(types=["pane_exited"], timeout_ms=10000)` and
+  drain `role == "worker"` in bulk
+- Stragglers are fall-back closed via
+  `mcp__renga-peers__close_pane(target="worker-{task_id}")`
+- All worker panes close first, then the Dispatcher, then the Curator
+- The Lead reports completion of the suspend
 
-**確認コマンド**:
+**Verification commands**:
 ```bash
-cat .state/org-state.md | head -5  # Status: SUSPENDED を確認
-cat .state/journal.jsonl | tail -1  # suspend イベントを確認
+cat .state/org-state.md | head -5  # Confirm Status: SUSPENDED
+cat .state/journal.jsonl | tail -1  # Confirm the suspend event
 ```
 
-**失敗パターンと対処**:
-- ワーカーがSUSPENDに応答しない → `inspect_pane` で画面内容を確認、Phase 2 のスクレイプが機能するか確認
-- ペインが閉じない → `close_pane(target="X")` の結果テキストをチェック。`[pane_not_found]` / `[pane_vanished]` は skip 扱い
-- `[last_pane]` が出た → 最後の窓口ペインは自己 exit で自然終了させる（org-suspend は閉じない）
-- 状態ファイルが不完全 → org-suspendの手順を見直し
+**Failure patterns and recovery**:
+- Worker does not respond to SUSPEND → check screen contents with
+  `inspect_pane`, verify the Phase 2 scrape works
+- Pane does not close → check the result text of `close_pane(target="X")`.
+  Treat `[pane_not_found]` / `[pane_vanished]` as skip
+- `[last_pane]` appears → let the final Lead pane exit naturally via self-exit
+  (org-suspend does not close it)
+- State file incomplete → revisit the org-suspend procedure
 
 ---
 
-## 4. org-resume テスト（再開）
+## 4. org-resume test (resume)
 
-**目的**: 中断後に再起動し、前回の状態が正しく復元されるか確認。
+**Goal**: confirm that on relaunch after suspend, the previous state is
+correctly restored.
 
-**前提**: テスト3で中断済み。
+**Prerequisites**: suspended in Test 3.
 
-**手順**:
-1. 窓口Claudeの端末を**完全に閉じる**
-2. clone先で再度 `renga --layout ops` で起動する
-3. `/org-start` を実行する
+**Procedure**:
+1. **Completely close** the Lead Claude's terminal
+2. Re-launch with `renga --layout ops` at the clone destination
+3. Run `/org-start`
 
-**期待結果**:
-- `/org-start` が `.state/org-state.md` を検出し、Status: SUSPENDED を確認
-- `/org-resume` の手順に従い、前回の状態サマリーが表示される
-- 各作業ディレクトリのgit状態との照合結果が報告される
-- 再開計画が提案される
-- 人間の承認を待つ（勝手にワーカーを派遣しない）
-- フォアマンとキュレーターペインが `mcp__renga-peers__spawn_pane` 経由で再起動される
+**Expected result**:
+- `/org-start` detects `.state/org-state.md` and confirms Status: SUSPENDED
+- Following the `/org-resume` procedure, a summary of the previous state is shown
+- A reconciliation report against each working directory's git state is shown
+- A resume plan is proposed
+- Waits for human approval (does not dispatch workers on its own)
+- Dispatcher and Curator panes are relaunched via
+  `mcp__renga-peers__spawn_pane`
 
-**確認ポイント**:
-- ブリーフィング内容が `.state/org-state.md` と一致するか
-- git状態の照合が正確か
-- フォアマンとキュレーターペインが起動しているか（`mcp__renga-peers__list_panes` で確認）
+**Verification points**:
+- Briefing contents match `.state/org-state.md`
+- Git-state reconciliation is accurate
+- Dispatcher and Curator panes are running (verify with
+  `mcp__renga-peers__list_panes`)
 
-**失敗パターンと対処**:
-- `/org-start` が状態を読まない → org-start スキルの Step 1 を見直し
-- 状態が不正確 → org-state.md のフォーマットまたはorg-suspendの書き込みを見直し
-- キュレーターが起動しない → org-start Step 3 の `send_message` / `spawn_pane` を確認
-
----
-
-## 5. 突然の終了テスト（クラッシュリカバリ）
-
-**目的**: org-suspendを実行せずに端末を閉じた場合、どこまで復元できるか確認。
-
-**手順**:
-1. テスト2の状態（ワーカー稼働中）で、**suspendせずに**端末を閉じる
-2. 再度 `renga --layout ops` で起動する
-3. `/org-start` を実行する
-
-**期待結果**:
-- `/org-start` が `.state/org-state.md` を検出し、Status が ACTIVE のままであることを確認
-- 前回のセッションが突然終了したと判断し、各ワーカーディレクトリのgit状態を確認
-- `.state/journal.jsonl` からスナップショット以降のイベントが補完される
-- 現状を報告する
-
-**許容される劣化**:
-- ワーカーの自己申告による詳細な進捗情報は失われる
-- journal.jsonl の最後のエントリ以降の情報は失われる
-- git commitされていない作業は状態が不明確になる可能性がある
-- Dispatcher の `poll_events` cursor (`.state/dispatcher-event-cursor.txt`) 消失時は過去 5 秒分のイベントを取りこぼす可能性があるが、`list_panes` 突き合わせで回復可能
-
-**失敗パターンと対処**:
-- org-state.md が古すぎる → 定期スナップショットの頻度を上げる（org-delegateの進捗管理を強化）
-- journal.jsonl がない → ジャーナリングの実装を確認
+**Failure patterns and recovery**:
+- `/org-start` does not read state → revisit Step 1 of the org-start skill
+- State is inaccurate → revisit org-state.md format or the org-suspend write
+- Curator does not start → verify `send_message` / `spawn_pane` in org-start Step 3
 
 ---
 
-## 6. org-retro テスト（振り返り）
+## 5. Sudden-exit test (crash recovery)
 
-**目的**: タスク完了後に学びが正しく記録されるか確認。
+**Goal**: confirm how much can be restored when the terminal is closed
+without running org-suspend.
 
-**手順**:
-1. ワーカーが何らかのタスクを完了する
-2. 窓口が `/org-retro` を実行するのを確認
+**Procedure**:
+1. From the Test 2 state (worker running), close the terminal **without
+   suspending**
+2. Re-launch with `renga --layout ops`
+3. Run `/org-start`
 
-**期待結果**:
-- 再利用可能な知見があれば `knowledge/raw/YYYY-MM-DD-{topic}.md` が作成される
-- フォーマットが「事実→判断→根拠→適用場面」に従っている
-- 記録不要と判断された場合は何も作成されない（正しい判断）
+**Expected result**:
+- `/org-start` detects `.state/org-state.md` and confirms Status remains ACTIVE
+- Concludes the previous session ended abruptly and inspects each worker
+  directory's git state
+- Backfills events after the snapshot from `.state/journal.jsonl`
+- Reports the current state
 
-**確認コマンド**:
+**Acceptable degradation**:
+- Detailed self-reported worker progress is lost
+- Information after the last entry in journal.jsonl is lost
+- Work that was not git-committed may end up in an unclear state
+- If the Dispatcher's `poll_events` cursor (`.state/dispatcher-event-cursor.txt`)
+  is lost, up to ~5 seconds of past events may be missed, but recoverable via
+  `list_panes` reconciliation
+
+**Failure patterns and recovery**:
+- org-state.md is too stale → increase periodic snapshot frequency (strengthen
+  org-delegate progress tracking)
+- journal.jsonl is missing → check the journaling implementation
+
+---
+
+## 6. org-retro test (retrospective)
+
+**Goal**: confirm that after a task completes, learnings are correctly recorded.
+
+**Procedure**:
+1. A worker completes some task
+2. Confirm the Lead runs `/org-retro`
+
+**Expected result**:
+- If reusable knowledge exists,
+  `knowledge/raw/YYYY-MM-DD-{topic}.md` is created
+- Format follows "fact → decision → rationale → applicable situation"
+- If recording is judged unnecessary, nothing is created (a correct judgment)
+
+**Verification commands**:
 ```bash
 ls knowledge/raw/
-cat knowledge/raw/*.md  # フォーマット確認
+cat knowledge/raw/*.md  # Format check
 ```
 
 ---
 
-## 7. org-curate テスト（知見整理 + 自己成長ループ）
+## 7. org-curate test (knowledge curation + self-improvement loop)
 
-**目的**: キュレーターが知見を整理し、改善提案ができるか確認。
+**Goal**: confirm the Curator organizes knowledge and can make improvement
+proposals.
 
-**前提**: `knowledge/raw/` に5件以上の未整理ファイルがあること。
+**Prerequisites**: 5 or more unprocessed files exist in `knowledge/raw/`.
 
-**手順**:
-1. テスト用に `knowledge/raw/` に5件以上のダミー知見ファイルを作成
-2. 手動で `/org-curate` を実行（またはキュレーターの /loop を待つ）
+**Procedure**:
+1. For testing, create 5+ dummy knowledge files in `knowledge/raw/`
+2. Run `/org-curate` manually (or wait for the Curator's /loop)
 
-**期待結果**:
-- rawファイルがテーマ別に分類される
-- `knowledge/curated/{theme}.md` にテーマ別ファイルが作成される
-- 処理済みrawファイルの先頭に `<!-- curated -->` が追記される
-- 改善提案がある場合、`renga-peers` で窓口に通知される
+**Expected result**:
+- Raw files are categorized by theme
+- Per-theme files are created at `knowledge/curated/{theme}.md`
+- A `<!-- curated -->` marker is prepended at the top of processed raw files
+- If improvement proposals exist, the Lead is notified via `renga-peers`
 
-**確認コマンド**:
+**Verification commands**:
 ```bash
 ls knowledge/curated/
 cat knowledge/curated/*.md
-head -1 knowledge/raw/*.md  # <!-- curated --> マーカー確認
+head -1 knowledge/raw/*.md  # Check <!-- curated --> marker
 ```
 
-**自己成長の確認**:
-- 改善提案の内容が具体的か
-- 提案が人間の承認なしに実行されていないか
+**Self-improvement check**:
+- Improvement proposals are concrete
+- Proposals are not executed without human approval
 
 ---
 
-## 8. フォアマン・キュレーターペインテスト
+## 8. Dispatcher / Curator pane test
 
-**目的**: フォアマンとキュレーターが専用ペインで正しく起動し機能するか確認。
+**Goal**: confirm the Dispatcher and Curator launch correctly in their
+dedicated panes and function.
 
-**手順**:
-1. `/org-start` を実行し、フォアマンとキュレーターのペインが起動されるか確認
-2. フォアマンが `mcp__renga-peers__send_message` 経由で役割指示を受け取っているか確認
-3. キュレーターが `mcp__renga-peers__send_message` 経由で `/loop 30m /org-curate` を実行しているか確認
-4. `knowledge/raw/` に閾値未満のファイルを置き、キュレーターがスキップするか確認
-5. 閾値以上に増やし、次の /loop サイクルで実行されるか確認
+**Procedure**:
+1. Run `/org-start` and confirm the Dispatcher and Curator panes launch
+2. Confirm the Dispatcher receives role instructions via
+   `mcp__renga-peers__send_message`
+3. Confirm the Curator runs `/loop 30m /org-curate` via
+   `mcp__renga-peers__send_message`
+4. Place fewer than the threshold in `knowledge/raw/` and confirm the Curator
+   skips
+5. Increase to at or above the threshold and confirm it runs in the next
+   /loop cycle
 
-**期待結果**:
-- `/org-start` 実行後に窓口の下にフォアマンとキュレーターが横並びで開く（`mcp__renga-peers__list_panes` で確認）
-- フォアマンが DELEGATE メッセージを待ち受ける状態になる
-- キュレーターが `/loop` を開始する
-- 30分ごとに org-curate が発動する
-- 閾値未満ではスキップ、閾値以上で実行
+**Expected result**:
+- After `/org-start` runs, the Dispatcher and Curator open side by side below
+  the Lead (verify with `mcp__renga-peers__list_panes`)
+- The Dispatcher enters a state of waiting for DELEGATE messages
+- The Curator starts `/loop`
+- org-curate fires every 30 minutes
+- Skips below threshold; runs at or above threshold
 
-**失敗パターンと対処**:
-- ペインは開くが指示を受け取らない → `renga-peers` のピア検出タイミングを調整（`list_peers` のリトライ、pane_started イベント待ちの延長）
-- フォアマンが DELEGATE に反応しない → フォアマンへの初期メッセージの内容を見直し
-- /loop が実行されない → キュレーターへのメッセージ内容を見直し
-
----
-
-## 9. org-dashboard テスト（ダッシュボード）
-
-**目的**: ダッシュボードのライブサーバー起動とブラウザ表示が正しく動作するか確認。
-
-**前提**: テスト2でワーカー派遣とプロジェクト登録が完了していること。
-
-**手順**:
-1. 窓口に「ダッシュボード見せて」と伝える
-2. `/org-dashboard` が発動するのを確認
-
-**期待結果**:
-- `dashboard/server.py` が起動し `http://localhost:8099` でサーバーが立ち上がる
-- ブラウザで `http://localhost:8099` が開かれる
-- プロジェクト一覧、作業状況、アクティビティ、知見が表示される
-- `/api/state` のレスポンスが実際の状態と一致する
-
-**失敗パターンと対処**:
-- サーバーが起動しない → `dashboard/server.py` のエラー出力を確認
-- ブラウザでデータが表示されない → `http://localhost:8099` が応答しているか `curl` で確認
-- データが更新されない → SSEの接続状態（`/api/events`）を確認
+**Failure patterns and recovery**:
+- Pane opens but does not receive instructions → adjust `renga-peers` peer
+  detection timing (retry `list_peers`, extend the wait for `pane_started`)
+- Dispatcher does not respond to DELEGATE → revisit the initial message to the
+  Dispatcher
+- /loop does not run → revisit the message content to the Curator
 
 ---
 
-## 10. E2Eテスト（全サイクル）
+## 9. org-dashboard test (dashboard)
 
-**目的**: 起動→作業→中断→再開→知見整理の全サイクルが機能するか確認。
+**Goal**: confirm the dashboard live-server launch and browser display work
+correctly.
 
-**手順**:
-1. clone先でClaudeCodeを起動（`renga --layout ops`）
-2. `/org-start` を実行（初回起動）
-3. タスクを3つ依頼（ワーカー派遣が発生するもの）
-4. 各タスク完了後に振り返りが記録されることを確認
-5. 「ダッシュボード見せて」で全体像を確認
-6. `/org-suspend` で中断
-7. 端末を完全に閉じる
-8. 再度起動 → `/org-start` → 前回の状態が報告される
-9. 再開を承認 → ワーカーが再派遣される
-10. `knowledge/raw/` が閾値に達したらキュレーションが動くか確認
-11. curated知見をgit commit → push できるか確認
+**Prerequisites**: worker dispatch and project registration completed in Test 2.
 
-**成功基準**:
-- 全ステップが人間の介入なし（指示と承認以外）で完了する
-- 状態の損失がない
-- 知見が蓄積・整理される
-- ダッシュボードで全体像が確認できる
+**Procedure**:
+1. Tell the Lead "show the dashboard"
+2. Confirm `/org-dashboard` fires
+
+**Expected result**:
+- `dashboard/server.py` starts and serves at `http://localhost:8099`
+- A browser opens `http://localhost:8099`
+- Project list, work status, activity, and knowledge are displayed
+- The `/api/state` response matches actual state
+
+**Failure patterns and recovery**:
+- Server does not start → check error output of `dashboard/server.py`
+- Data is not displayed in the browser → verify `http://localhost:8099`
+  responds with `curl`
+- Data does not refresh → check the SSE connection state (`/api/events`)
 
 ---
 
-## 10.1. sandbox.denyRead / denyWrite 実機検証（Phase 2a, Issue #79）
+## 10. E2E test (full cycle)
 
-**目的**: `.claude/settings.json` の `sandbox.filesystem.denyRead` / `denyWrite` が Windows + Git Bash 環境で期待通り機能し、Claude Code の Bash ツール経由で `.env` 等の秘密情報ファイルが読めないことを確認する。
+**Goal**: confirm the full cycle of launch → work → suspend → resume →
+knowledge curation works.
 
-**前提**:
-- 本リポジトリを clone し Claude Code が起動できる状態
-- 検証対象リポジトリ直下にダミー `.env`（例: `FAKE_TOKEN=dummy-not-a-real-secret`）を用意（`.gitignore` 対象のため commit されない）
-- 既知バグ [anthropics/claude-code#32226](https://github.com/anthropics/claude-code/issues/32226) により denyRead が期待通り効かないケースが報告されているため、**必ず実機で挙動を確認**する
+**Procedure**:
+1. Launch ClaudeCode at the clone destination (`renga --layout ops`)
+2. Run `/org-start` (first launch)
+3. Request 3 tasks (ones that trigger worker dispatch)
+4. Confirm a retrospective is recorded after each task completes
+5. With "show the dashboard," confirm the overall picture
+6. Suspend with `/org-suspend`
+7. Completely close the terminal
+8. Re-launch → `/org-start` → previous state is reported
+9. Approve the resume → workers are redispatched
+10. Confirm curation runs once `knowledge/raw/` reaches the threshold
+11. git commit → push curated knowledge
 
-**手順**:
-1. 窓口 Claude に `cat .env` を実行するよう依頼する（Bash ツール経由）
-2. `grep -r FAKE_TOKEN .` のように `.env` を読み出すコマンドを依頼する
-3. `~/.ssh/id_rsa` を読み出そうとするコマンドを依頼する（存在する場合）
-4. `~/.claude/settings.json` の書込を試みるコマンドを依頼する（例: `echo x >> ~/.claude/settings.json`）
+**Success criteria**:
+- All steps complete without human intervention (apart from instructions and approvals)
+- No state loss
+- Knowledge accumulates and is organized
+- The full picture is visible on the dashboard
 
-**期待結果**:
-- 手順 1〜3: sandbox により Bash サブプロセスで denied（`Permission denied` 相当のエラー）。Claude Code が結果を受け取っても内容は空 / エラーになる
-- 手順 4: denyWrite により write 失敗
+---
 
-**失敗パターンと対処**:
-- `.env` の内容が読めてしまう → Claude Code 側のバグの可能性。バージョンと `claude --version` を記録し Issue #32226 のステータスを確認。暫定対応として `permissions.deny` の `Read(./.env)` 追加（Claude Code の Read ツール経路を塞ぐ）
-- Windows で glob (`**/credentials*`) が効かない → forward/backward slash 差異の可能性。glob パターンを `./credentials*` 等に調整して再試行
-- sandbox 自体が発動していない → Claude Code の `sandbox.enabled` デフォルトが OFF の可能性。公式 docs の現行デフォルトを確認
+## 10.1. sandbox.denyRead / denyWrite real-hardware verification (Phase 2a, Issue #79)
 
-**注**: `sandbox.enabled` は本 PR では明示指定していない（Claude Code 側のデフォルトに任せる）。既知バグ #32226 の影響範囲を限定するため段階導入とし、デフォルト挙動で denyRead が無効な環境では別途明示 true 化を検討する。
+**Goal**: confirm that `sandbox.filesystem.denyRead` / `denyWrite` in
+`.claude/settings.json` work as expected on Windows + Git Bash, and that
+secret-information files such as `.env` cannot be read via Claude Code's Bash
+tool.
 
-### 実測結果（2026-04-25, Windows 11 + Git Bash, Claude Code Desktop）
+**Prerequisites**:
+- This repository cloned, and Claude Code can launch
+- A dummy `.env` (e.g. `FAKE_TOKEN=dummy-not-a-real-secret`) is placed at the
+  root of the verification target repository (`.gitignore`'d so not committed)
+- Known bug [anthropics/claude-code#32226](https://github.com/anthropics/claude-code/issues/32226)
+  reports cases where denyRead does not work as expected, so **be sure to
+  verify on real hardware**
 
-| # | 操作 | 結果 |
+**Procedure**:
+1. Ask the Lead Claude to run `cat .env` (via the Bash tool)
+2. Ask for a command that reads `.env`, e.g. `grep -r FAKE_TOKEN .`
+3. Ask for a command attempting to read `~/.ssh/id_rsa` (if it exists)
+4. Ask for a command attempting to write to `~/.claude/settings.json`
+   (e.g. `echo x >> ~/.claude/settings.json`)
+
+**Expected result**:
+- Steps 1-3: denied by sandbox in the Bash subprocess (an error equivalent to
+  `Permission denied`). Even if Claude Code receives a result, the contents
+  are empty / an error
+- Step 4: write fails due to denyWrite
+
+**Failure patterns and recovery**:
+- `.env` contents are readable → possibly a Claude Code bug. Record the
+  version with `claude --version` and check the status of Issue #32226. As a
+  stopgap, add `Read(./.env)` to `permissions.deny` (closes the Read-tool path
+  in Claude Code)
+- Glob (`**/credentials*`) does not work on Windows → may be forward/backward
+  slash differences. Adjust glob patterns to e.g. `./credentials*` and retry
+- The sandbox itself does not fire → Claude Code's `sandbox.enabled` may default
+  to OFF. Check the official docs for the current default
+
+**Note**: this PR does not explicitly set `sandbox.enabled` (leaving it to
+Claude Code's default). To limit the blast radius of known bug #32226, this
+is a staged rollout; in environments where denyRead is ineffective by default,
+explicitly setting it to true should be considered separately.
+
+### Measured results (2026-04-25, Windows 11 + Git Bash, Claude Code Desktop)
+
+| # | Operation | Result |
 |---|---|---|
-| 1 | `cat .env` | 読めた（sandbox 未発火） |
-| 2 | `grep -r FAKE_TOKEN .` | 読めた（sandbox 未発火） |
-| 3 | `cat ~/.ssh/id_rsa` | deny（※ sandbox ではなく Claude Code 組込の credential 保護層による） |
+| 1 | `cat .env` | Read (sandbox did not fire) |
+| 2 | `grep -r FAKE_TOKEN .` | Read (sandbox did not fire) |
+| 3 | `cat ~/.ssh/id_rsa` | Denied (* not by the sandbox but by Claude Code's built-in credential protection layer) |
 
-`sandbox.enabled: true` を明示した状態でも #1 #2 は素通り。公式ドキュメントで Windows native の sandbox enforcement は "planned" 状態（未実装）と確認（https://docs.claude.com/en/docs/claude-code/iam#sandbox）。本設定は **macOS (Seatbelt) / Linux / WSL2 (bubblewrap)** のみで有効。
+Even with explicit `sandbox.enabled: true`, #1 and #2 still pass through. The
+official documentation confirms native sandbox enforcement on Windows is in
+the "planned" state (not yet implemented)
+(https://docs.claude.com/en/docs/claude-code/iam#sandbox).
+This setting works only on **macOS (Seatbelt) / Linux / WSL2 (bubblewrap)**.
 
-### WSL2 実測結果（2026-04-25）
+### WSL2 measured results (2026-04-25)
 
-| 操作 | 結果 |
+| Operation | Result |
 |---|---|
-| `cat .env`（PR branch checkout 上） | 読めた（sandbox disabled） |
-| `grep -r FAKE_TOKEN .` | 読めた |
-| `claude` 起動時の警告 | `⚠ Sandbox disabled: bubblewrap (bwrap) not installed, socat not installed` |
+| `cat .env` (on PR branch checkout) | Read (sandbox disabled) |
+| `grep -r FAKE_TOKEN .` | Read |
+| Warning at `claude` launch | `⚠ Sandbox disabled: bubblewrap (bwrap) not installed, socat not installed` |
 
-**原因**: Claude Code の sandbox は Linux / WSL2 で **`bubblewrap` と `socat`** を runtime dependency として要求するが、Ubuntu / Debian 系の WSL イメージにはデフォルトでは含まれない。
+**Cause**: Claude Code's sandbox requires **`bubblewrap` and `socat`** as
+runtime dependencies on Linux / WSL2, but they are not included by default in
+Ubuntu / Debian-family WSL images.
 
-**対処**: sandbox を実際に発動させたい WSL 環境では以下を実施する:
+**Recovery**: in WSL environments where you actually want the sandbox to fire,
+do the following:
 
 ```bash
 sudo apt install -y bubblewrap socat
-claude  # 警告が消えることを確認
+claude  # Confirm the warning disappears
 ```
 
-これを入れた後、次節の検証手順で改めて `cat .env` 等が deny されることを確認する。
+After installing this, re-run the verification procedure in the next section
+to confirm `cat .env` etc. are denied.
 
-**検出手順**: `claude --version` 直後 / `/sandbox` 実行で sandbox の状態を確認できる（Claude Code 側で警告表示）。CI 環境や Docker コンテナで sandbox を期待する場合は Dockerfile / workflow に `apt install bubblewrap socat` を明示すること。
+**Detection procedure**: the sandbox state can be checked right after
+`claude --version` / by running `/sandbox` (Claude Code shows the warning).
+In CI environments or Docker containers where you expect the sandbox, make
+`apt install bubblewrap socat` explicit in the Dockerfile / workflow.
 
-### WSL2 での検証手順（未実施、人間タスク）
+### WSL2 verification procedure (not yet performed, human task)
 
-1. WSL2 内に本リポジトリを clone もしくは `\\wsl$\...` 経由で Windows 側 worktree を共有
-2. WSL 側で `claude` を起動（wsl 用 Claude Code または `npm install -g` で導入）
-3. 以下を依頼し、それぞれ deny を確認:
-   - `cat .env を実行して` → sandbox denyRead で Permission denied 相当
-   - `grep -r FAKE_TOKEN . を実行して` → 同上
-   - `echo x >> ~/.claude/settings.json.sandbox-test` → denyWrite で書込失敗
-4. 実測結果を本セクションの表に追記（OS 行を増やす形）
+1. Clone this repository inside WSL2, or share the Windows-side worktree via
+   `\\wsl$\...`
+2. Launch `claude` inside WSL (use Claude Code for WSL or install via
+   `npm install -g`)
+3. Ask for the following and verify each is denied:
+   - "Run `cat .env`" → Permission denied equivalent via sandbox denyRead
+   - "Run `grep -r FAKE_TOKEN .`" → ditto
+   - `echo x >> ~/.claude/settings.json.sandbox-test` → write fails via denyWrite
+4. Append the measured results to the table in this section (add an OS row)
 
-WSL で deny されなければ、 (a) Claude Code のバージョンが sandbox 未対応、(b) 設定 syntax の解釈差異、(c) #32226 の別症状、のいずれか。バージョンと Issue #32226 ステータスを記録。
+If WSL does not deny, then either (a) Claude Code's version does not support
+sandbox, (b) a config-syntax interpretation difference, or (c) another symptom
+of #32226. Record the version and the status of Issue #32226.
 
 ---
 
-## 11. MCP 疎通テスト（環境確認）
+## 11. MCP connectivity test (environment check)
 
-**目的**: `renga-peers` MCP サーバが Claude Code に接続済みで、14 ツール全てが tool surface として登録されていることを確認し、副作用なしで呼び出せるツールについてはサンプル呼び出しで応答を検証する。副作用の大きいツール（`send_keys` / `spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` / `set_pane_identity`）の実動作確認は Test 1-10 の E2E フローでカバーされるため、本テストでは登録確認のみに留める。
+**Goal**: confirm the `renga-peers` MCP server is connected to Claude Code,
+that all 14 tools are registered as the tool surface, and that — for
+side-effect-free tools — sample calls return responses correctly. The
+real-behavior check for tools with large side effects (`send_keys` /
+`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab`
+/ `set_pane_identity`) is covered by the Test 1-10 E2E flow, so this test
+limits itself to registration verification only.
 
-**手順**:
+**Procedure**:
 
-### 11-a. 登録確認（14 ツール）
-1. `claude mcp list` で `renga-peers` が Connected を表示することを確認
-2. `renga --version` で 0.18.0 以上であることを確認
-3. 以下 14 ツールが Claude Code の tool surface に出現するか確認（MCP サーバが tools/list で返すツール名と一致する）:
-   - 副作用なし / 軽 side-effect: `list_panes` / `list_peers` / `set_summary` / `check_messages` / `send_message` / `poll_events` / `inspect_pane`
-   - 副作用大（ペイン / PTY 操作）: `spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` / `send_keys` / `set_pane_identity`
+### 11-a. Registration check (14 tools)
+1. Confirm `claude mcp list` shows `renga-peers` as Connected
+2. Confirm `renga --version` is 0.18.0 or higher
+3. Confirm the following 14 tools appear on Claude Code's tool surface
+   (matches the tool names returned by the MCP server's tools/list):
+   - No / light side effects: `list_panes` / `list_peers` / `set_summary` /
+     `check_messages` / `send_message` / `poll_events` / `inspect_pane`
+   - Large side effects (pane / PTY operations): `spawn_pane` /
+     `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` /
+     `send_keys` / `set_pane_identity`
 
-### 11-b. 副作用なしツールの応答確認（7 ツール）
-以下の 7 ツールを順次呼び出し、エラーなく応答が返るか確認:
+### 11-b. Response check for side-effect-free tools (7 tools)
+Call the following 7 tools in sequence and confirm they respond without errors:
 
-| ツール | 呼び出し例 | 期待応答 |
+| Tool | Sample call | Expected response |
 |---|---|---|
-| `list_panes` | 引数なし | 現在のペイン一覧テキスト |
-| `list_peers` | 引数なし | 同タブ内 peer 一覧 or `(no peers — …)` |
+| `list_panes` | No args | Current pane list text |
+| `list_peers` | No args | Same-tab peer list or `(no peers — …)` |
 | `set_summary` | `summary="test"` | `Summary accepted (v1 stub: …)` |
-| `check_messages` | 引数なし | `No queued messages.` |
-| `send_message` | `to_id=<self の pane id or name>, message="ping"` | `Delivered to <target>.` or `(message dropped — …)` |
-| `poll_events` | `timeout_ms=0`（非ブロッキング drain） | `{next_since, events}` の JSON |
-| `inspect_pane` | `target="focused", lines=5, format="text"` | 画面末尾 5 行 + `structuredContent` |
+| `check_messages` | No args | `No queued messages.` |
+| `send_message` | `to_id=<own pane id or name>, message="ping"` | `Delivered to <target>.` or `(message dropped — …)` |
+| `poll_events` | `timeout_ms=0` (non-blocking drain) | JSON of `{next_since, events}` |
+| `inspect_pane` | `target="focused", lines=5, format="text"` | Last 5 screen lines + `structuredContent` |
 
-### 11-c. 副作用大ツールは E2E テストに委譲
-`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` / `set_pane_identity` は Test 1 / 2 / 3 / 4 の中で実動作確認される。`send_keys` は Test 1（開発チャネル確認 Enter 注入）で確認される。
+### 11-c. Side-effect-large tools delegated to E2E tests
+`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` / `new_tab` /
+`set_pane_identity` are exercised in Tests 1 / 2 / 3 / 4. `send_keys` is
+exercised in Test 1 (Enter injection on the development-channel prompt).
 
-**期待結果**:
-- 11-a: `claude mcp list` の出力に `renga-peers: … ✓ Connected` があり、14 ツールすべてが Claude Code の tool list に登録されている
-- 11-b: 7 ツールがすべてエラーなく応答、エラー時は `[<code>] <msg>` 形式のテキストが得られる（例: `list_panes` が renga 未起動なら `[shutting_down]` 等）
-- 11-c: 副作用大ツールは本テストでは実行せず、E2E テストでのカバレッジに委ねる
+**Expected result**:
+- 11-a: `claude mcp list` output contains `renga-peers: … ✓ Connected` and
+  all 14 tools are registered in Claude Code's tool list
+- 11-b: all 7 tools respond without error; on error a `[<code>] <msg>` text
+  is returned (e.g. `list_panes` returns `[shutting_down]` if renga is not
+  running)
+- 11-c: side-effect-large tools are not run in this test; coverage is left to
+  E2E
 
-**失敗パターンと対処**:
-- `claude mcp list` に `renga-peers` が出ない → `renga mcp install --force` 再実行
-- `list_panes` が error → `renga --version` で 0.14.0 以上か確認、古ければ `npm install -g @suisya-systems/renga@0.14.0`
-- `poll_events` が JSON を返さない → `mcp_peer/mod.rs` の実装に不整合、renga バージョン確認
+**Failure patterns and recovery**:
+- `renga-peers` does not appear in `claude mcp list` → re-run
+  `renga mcp install --force`
+- `list_panes` errors → check `renga --version` is 0.14.0+; if older
+  `npm install -g @suisya-systems/renga@0.14.0`
+- `poll_events` does not return JSON → implementation mismatch in
+  `mcp_peer/mod.rs`; check the renga version
 
 ---
 
-## テスト結果の記録
+## Recording test results
 
-各テストの結果は以下のフォーマットで記録する:
+Record each test result in the following format:
 
 ```markdown
-## テスト{N}: {テスト名}
-- 日時: YYYY-MM-DD HH:MM
-- 結果: PASS / FAIL / PARTIAL
-- 問題点: {あれば記述}
-- 対処: {修正内容}
-- 再テスト: 要 / 不要
+## Test {N}: {test name}
+- Date: YYYY-MM-DD HH:MM
+- Result: PASS / FAIL / PARTIAL
+- Issues: {if any}
+- Recovery: {fix details}
+- Retest: required / not required
 ```
 
-`docs/test-results/` ディレクトリに保存する。
+Save under the `docs/test-results/` directory.


### PR DESCRIPTION
## Summary

Wave B-runtime PR-10 of the 5-Wave plan for claude-org-ja#110.

Translates 6 files (B2 structure-preserving):
- `.claude/skills/skill-audit/SKILL.md` + `references/audit-checklist.md`
- `.claude/skills/skill-eligibility-check/SKILL.md` + `references/signals.md`
- `docs/testing.md`
- `docs/verification.md`

`knowledge/curated/` only contains `.gitkeep` in the en repo — `codex-review.md` and `delegation.md` were untracked in the ja source at Wave A bootstrap time and are not in scope.

## Intentional non-translations

- `to_id="secretary"`, peer-id enumerations, and `SECRETARY safety clause` references are kept verbatim. They are renga-peers code literals, consistent with how org-start / org-delegate / org-suspend already handle them. Glossary applies to narrative role nouns only; identifiers are preserved.

## Codex self-review

- Blocker / Nit: 0
- Major: 1 false positive (the `secretary` literal above)
- Minor: 2 source-level inconsistencies that are present verbatim in the JA original (variable-name mismatches in `skill-audit` report template; an internal wording wobble in `skill-eligibility-check`). B2 fidelity preserves them; rewriting them would be a logic change beyond Wave B-runtime scope.

## Manifest entries

- `.claude/skills/skill-audit/SKILL.md` | translated
- `.claude/skills/skill-audit/references/audit-checklist.md` | translated
- `.claude/skills/skill-eligibility-check/SKILL.md` | translated
- `.claude/skills/skill-eligibility-check/references/signals.md` | translated
- `docs/testing.md` | translated
- `docs/verification.md` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] No remaining ja-glossary terms in narrative
- [x] Code-literal identifiers preserved
- [ ] CI green