### PR TITLE
Wave B-runtime PR-8: skill cluster 1 (org-start / org-setup / org-delegate)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -1,481 +1,482 @@
 ---
 name: org-delegate
 description: >
-  ワーカーClaudeを派遣して作業を委譲する。窓口は司令塔であり、
-  手を動かす実作業は原則としてワーカーに任せる。
-  ユーザーから作業の依頼を受けたとき、ファイル編集・実装・調査等の
-  実作業が発生する場合に発動する。
+  Dispatch a Worker Claude and delegate work. The Lead is the command center;
+  hands-on work is, in principle, dispatched to a Worker.
+  Triggered when the user asks for hands-on work such as file edits,
+  implementation, or investigation.
 ---
 
-# org-delegate: ワーカー派遣
+# org-delegate: Worker dispatch
 
-作業をワーカーClaudeに委譲する。窓口はタスク分解と準備だけ行い、
-ペイン起動・指示送信はフォアマンに委託する。これにより窓口のロック時間を最小化する。
+Delegate work to a Worker Claude. The Lead only does task decomposition and
+preparation; pane spawning and instruction sending are entrusted to the
+Dispatcher. This minimizes the time the Lead is locked.
 
-## 窓口とフォアマンの役割分担
+## Lead vs. Dispatcher responsibilities
 
-| 工程 | 担当 |
+| Stage | Owner |
 |---|---|
-| プロジェクト名前解決 | **窓口** |
-| work-skill 検索 | **窓口**（新規追加） |
-| タスク分解 | **窓口** |
-| CLAUDE.md 生成 | **窓口** |
-| フォアマンへの依頼 | **窓口**（ここで窓口は解放される） |
-| ペイン起動 | **フォアマン** |
-| ピア待ち・指示送信 | **フォアマン** |
-| 状態記録 | **フォアマン** |
-| 窓口への派遣完了報告 | **フォアマン** |
-| ワーカーからの進捗/完了報告の受信 | **窓口** |
-| ワーカー完了時のペインクローズ | **フォアマン**（窓口から依頼） |
+| Project name resolution | **Lead** |
+| work-skill search | **Lead** (newly added) |
+| Task decomposition | **Lead** |
+| CLAUDE.md generation | **Lead** |
+| Request to Dispatcher | **Lead** (Lead is released here) |
+| Pane spawning | **Dispatcher** |
+| Wait for peer / send instructions | **Dispatcher** |
+| Record state | **Dispatcher** |
+| Report dispatch completion to Lead | **Dispatcher** |
+| Receive progress / completion reports from Workers | **Lead** |
+| Close pane on Worker completion | **Dispatcher** (requested by Lead) |
 
-## 委譲前チェックリスト（窓口が実行）
+## Pre-dispatch checklist (Lead executes)
 
-タスク分解に入る前に、依頼内容を以下の観点で確認する。該当する場合はユーザーに聞き返す。
+Before entering task decomposition, examine the request from the perspectives below. If any apply, ask the user back.
 
-| チェック項目 | 確認すべき状況 | 例 |
+| Check item | Situation to confirm | Example |
 |---|---|---|
-| **曖昧な用語・略語** | ツール名・サービス名・略語が複数の意味を持ちうる場合 | 「gog」→ Google OAuth? gog CLI? |
-| **OS固有の前提条件** | OS別の成果物を作る場合、デフォルト設定の明示が必要 | Mac=zsh、Windows=py -3、パス区切り |
+| **Ambiguous terms / abbreviations** | Tool / service names / abbreviations that may have multiple meanings | "gog" → Google OAuth? gog CLI? |
+| **OS-specific prerequisites** | When producing OS-specific deliverables, default settings must be made explicit | Mac=zsh, Windows=py -3, path separators |
 
-- 曖昧な用語がある場合: 「○○は△△のことですか？」とユーザーに確認してから進める
-- OS別タスクの場合: Step 1 のタスク分解時に、OS固有の前提条件をワーカーへの指示に含める
+- For ambiguous terms: confirm with the user ("Did you mean ○○ by △△?") before proceeding
+- For OS-specific tasks: include OS-specific prerequisites in the Worker instruction during Step 1 task decomposition
 
-## Step 0: プロジェクト名前解決（窓口が実行）
+## Step 0: Project name resolution (Lead executes)
 
-ユーザーの依頼からプロジェクトを特定する:
+Identify the project from the user's request:
 
-1. `registry/projects.md` を読む
-2. 依頼に含まれるキーワードから該当プロジェクトを特定する（通称・プロジェクト名・説明から照合）
-3. 特定できた場合はそのパスを使う
-4. 特定できない場合は登録済みプロジェクトの通称一覧を提示し、選ばせる
-5. 新規プロジェクトの場合:
-   - パスをユーザーに確認する
-   - 通称・説明・よくある作業例を推定し、ユーザーに確認してから `registry/projects.md` に追記する
+1. Read `registry/projects.md`
+2. From the keywords in the request, identify the matching project (match by nickname, project name, or description)
+3. If identified, use that path
+4. If not identified, present the list of registered project nicknames and have the user choose
+5. For a new project:
+   - Confirm the path with the user
+   - Estimate the nickname / description / typical tasks, confirm with the user, and append to `registry/projects.md`
 
-## Step 0.5: work-skill 検索（窓口が実行）（新規追加）
+## Step 0.5: work-skill search (Lead executes) (newly added)
 
-タスク分解の前に、関連する既存の work-skill がないか検索する。
-マッチした work-skill はワーカーへの指示に参考情報として含める。
+Before task decomposition, search for any existing related work-skill.
+Include any matched work-skill in the Worker instruction as reference.
 
-### 検索手順
+### Search procedure
 
-1. `.claude/skills/` 配下の全 SKILL.md ファイルを列挙する
-2. 各 SKILL.md の frontmatter を読み取る:
-   - `type` フィールドで work-skill を識別する（org- プレフィックスでないもの）
-   - `description` と `triggers` をタスク内容と照合する
-3. マッチング判定:
-   - ユーザーの依頼内容と `description` のキーワードを比較する
-   - `triggers` リストに依頼内容と合致する記述があるか確認する
-   - 完全一致は不要。関連性があれば候補に含める
+1. Enumerate all SKILL.md files under `.claude/skills/`
+2. Read the frontmatter of each SKILL.md:
+   - Identify work-skills via the `type` field (those without the `org-` prefix)
+   - Match `description` and `triggers` against the task content
+3. Matching judgment:
+   - Compare the keywords of the user's request with `description`
+   - Check whether `triggers` lists wording that matches the request
+   - An exact match is not required; if there is relevance, include it as a candidate
 
-### マッチ結果の活用
+### Using the match results
 
-**マッチした場合:**
-- 人間に通知する:
+**On match:**
+- Notify the human:
   ```
-  関連するwork-skillが見つかりました:
-  - {skill-name}: {description の1行目}
-  ワーカーへの指示に参考情報として含めます。
+  Related work-skill(s) found:
+  - {skill-name}: {first line of description}
+  Will include them in the Worker instruction as reference.
   ```
-- Step 1 のタスク分解時に、work-skill の手順を参考にする
-- Step 1.5 の CLAUDE.md 生成時に、以下のセクションを追加する:
+- Refer to the work-skill's procedure during Step 1 task decomposition
+- During Step 1.5 CLAUDE.md generation, add the following section:
   ```markdown
-  ## 参考 work-skill
-  以下の work-skill が参考になる可能性があります。手順や判断基準を参照してください。
-  ただし、タスクの要件に合わない部分は適宜調整すること。
-  
-  - スキル名: {skill-name}
-  - パス: .claude/skills/{skill-name}/SKILL.md
-  - 概要: {description}
+  ## Reference work-skill
+  The following work-skill(s) may be useful. Refer to its procedure and judgment criteria.
+  Adjust as appropriate where it does not fit this task's requirements.
+
+  - Skill name: {skill-name}
+  - Path: .claude/skills/{skill-name}/SKILL.md
+  - Summary: {description}
   ```
-- ワーカーへの指示（instruction-template）にも参考スキルの存在を明記する
+- Also note the existence of the reference skill in the Worker instruction (instruction-template)
 
-**マッチしなかった場合:**
-- 通知不要。そのまま Step 1 に進む
+**On no match:**
+- No notification needed. Proceed to Step 1.
 
-### 検索の注意点
+### Search caveats
 
-- work-skill の手順をそのままコピーしない。参考情報として提示し、ワーカーが判断する
-- 複数マッチした場合は関連度順に全て含める
-- org- プレフィックスのスキル（org-retro, org-delegate 等）は組織運営スキルなので検索対象外
+- Do not copy the work-skill's procedure verbatim. Present it as reference and let the Worker decide
+- If multiple match, include all of them in order of relevance
+- Skills with the `org-` prefix (org-retro, org-delegate, etc.) are organization-management skills and are excluded from the search
 
-## Step 1: タスク分解（窓口が実行）
+## Step 1: Task decomposition (Lead executes)
 
-人間の依頼を分析し、ワーカーに委譲するタスクを定義する:
+Analyze the human's request and define tasks to delegate to Workers:
 
-- 各タスクに一意のIDを振る（依頼内容から連想しやすい英語 kebab-case。例: `data-analysis`, `login-fix`, `dashboard-redesign`）
-  - 既存のIDと重複しないよう `.state/org-state.md` を確認する（重複時はサフィックスで区別: `login-fix-2`）
-- タスクごとに以下を明確にする:
-  - 目的（何を達成するか）
-  - 成果物（何ができあがるか）
-  - 作業ディレクトリ（どのプロジェクトで作業するか）
-  - 制約（ブランチ名、コーディング規約、依存関係等）
-  - **検証深度（`full` / `minimal`）** — 派遣指示には必ずどちらか 1 値を明示する。既定は `full`（コード・挙動の変更を伴うタスクはすべてこちら）。`full` では **codex の有無に関わらず** リポジトリ通常検証（テスト / lint / type-check 等）を green まで実行し通常の完了報告フォーマットで報告するのが必須ゲート。**追加ゲート（任意）** として、codex CLI が available なら commit 完了後に Codex セルフレビュー・同一指摘 3 ラウンド上限のルールが走る（未導入環境では skip）。trivial fix（CI 出力整形 / typo / コメント修正 / 既存テスト形式合わせ等）のみ `minimal` を選択し、ワーカーは `git add` → `git commit` → `done` 報告のみで終わる。詳細は `references/instruction-template.md` の「検証深度」節と `references/worker-claude-template.md` の「Codex セルフレビュー手順」節参照。値の決定は窓口の責任で、ワーカーには判断させない
-  - **ディレクトリパターン（A / B / C）** — 以下の判定基準で決定する
-  - **参考 work-skill**（Step 0.5 でマッチしたもの）
-- 注意: タスク説明にファイルパスを含める場合、それがワーカー作業ディレクトリからの相対パスであることを明記する。registry/projects.md の「パス」列の値をそのまま成果物パスとして指示しない（ワーカーが別の場所にパスを作成する原因になる）
+- Assign each task a unique ID (English kebab-case, easy to associate with the request. e.g. `data-analysis`, `login-fix`, `dashboard-redesign`)
+  - Check `.state/org-state.md` to avoid collisions with existing IDs (on collision, suffix to disambiguate: `login-fix-2`)
+- For each task, make the following clear:
+  - Goal (what to achieve)
+  - Deliverable (what will be produced)
+  - Working directory (which project to work in)
+  - Constraints (branch name, coding conventions, dependencies, etc.)
+  - **Verification depth (`full` / `minimal`)** — the dispatch instruction must always state exactly one of the two values. The default is `full` (any task that changes code or behavior). Under `full`, **regardless of whether codex is available**, the repository's normal verification (tests / lint / type-check, etc.) must be run to green and reported in the normal completion-report format; this is a required gate. As an **additional (optional) gate**, if the codex CLI is available, the rule "Codex self-review with a 3-round cap on identical findings" runs after commit completes (skipped if codex is not installed). Choose `minimal` only for trivial fixes (CI output formatting / typo / comment edits / matching to existing test format), in which case the Worker only does `git add` → `git commit` → `done` report. See the "Verification depth" section in `references/instruction-template.md` and the "Codex self-review procedure" section in `references/worker-claude-template.md` for details. The Lead is responsible for picking the value; the Worker does not decide.
+  - **Directory pattern (A / B / C)** — determined by the criteria below
+  - **Reference work-skill** (if matched in Step 0.5)
+- Note: when the task description includes file paths, make explicit that they are relative to the Worker's working directory. Do not give the value of the "Path" column in registry/projects.md as a deliverable path directly (it will cause the Worker to create paths in unintended locations).
 
-### 事前チェック: 対象ファイルが gitignored か
+### Pre-check: is the target file gitignored?
 
-判定フローに入る前に、編集対象ファイルが `.gitignore` で除外されていないか確認する。
-**「対象ファイル」は窓口がタスク説明から抽出する**（依頼文・Issue 本文・ユーザー発話の中で明示されたパス。機械的判定はしない）。対象ファイルが特定できないタスク（純粋な調査、対象パス未定の新規作成など）はこのチェックをスキップして通常判定に進む。
+Before entering the decision flow, check whether the file to be edited is excluded by `.gitignore`.
+**The "target file" is what the Lead extracts from the task description** (paths explicitly mentioned in the request, the issue body, or the user's utterance; do not infer mechanically). Skip this check for tasks where the target file cannot be identified (pure investigation, new creation with an undecided target path, etc.) and proceed to normal judgment.
 
-#### 適用条件
+#### Applicability
 
-このチェックは **ローカルに git repo が既に存在するプロジェクトでのみ実行する**。具体的には:
+This check is run **only for projects where a git repo already exists locally**. Specifically:
 
-- registry/projects.md の「パス」がローカル絶対パスで、かつ `.git/` を持つディレクトリ（または worktree）として解決できる場合のみ実行
-- パスが URL（未 clone）/ `-` / 解決不能なら **チェック自体をスキップ**して通常判定へ（初回 clone 後の状態は git の通常挙動に従うため、tracked 既存ファイルが gitignored になっているレアケースは別途レビューで拾う）
+- Run only when the "Path" in registry/projects.md is a local absolute path that resolves to a directory (or worktree) with `.git/`
+- If the path is a URL (not yet cloned) / `-` / unresolvable, **skip the check itself** and go to normal judgment (the rare case of a tracked existing file becoming gitignored after first clone is caught separately by review)
 
-#### 判定コマンド
+#### Decision command
 
-ローカル repo root（=「パス」が指す絶対パス）で:
+At the local repo root (= the absolute path the "Path" points to):
 
 ```
 git -C {project_path} check-ignore -q -- <target>
 ```
 
-- 終了コード 1（=ignored ではない）→ tracked または「単に未存在の新規ファイル」。**通常の A / B / C 判定に進む**
-- 終了コード 0（=ignored）→ **Pattern C 強制（gitignored サブモード）**。下記参照
-- 終了コード 128 等（コマンド失敗、repo 未初期化など）→ 適用条件外。スキップして通常判定へ
+- Exit code 1 (= not ignored) → tracked or "merely a non-existent new file". **Proceed to normal A / B / C judgment**
+- Exit code 0 (= ignored) → **Pattern C forced (gitignored submode)**. See below
+- Exit code 128 etc. (command failure, repo not initialized, etc.) → out of applicability. Skip and go to normal judgment
 
-> `git check-ignore` は「現在の `.gitignore` ルールにマッチするか」だけを判定し、ファイルが実在しなくても評価できる。`ls-files --error-unmatch` を使うと「単に未作成の新規ファイル」まで untracked 扱いで Pattern C に落としてしまうため、こちらを使わない。
+> `git check-ignore` only judges "does it match the current `.gitignore` rules"; it can be evaluated even if the file does not exist. Using `ls-files --error-unmatch` would treat "merely a not-yet-created new file" as untracked and drop it into Pattern C, so do not use that.
 
-#### Pattern C 強制（gitignored サブモード）
+#### Pattern C forced (gitignored submode)
 
-通常の Pattern C は `{workers_dir}/{task_id}/` のエフェメラル空ディレクトリだが、gitignored 対象を編集する場合はそれでは対象ファイルに届かない。次の特例運用とする:
+Normal Pattern C uses an ephemeral empty directory at `{workers_dir}/{task_id}/`, but that doesn't reach the target file when editing a gitignored target. Special operation:
 
-- **WORKER_DIR**: 既存ローカル clone の **repo root を直接指定**する（registry の「パス」値そのもの）
-- **CLAUDE.md / settings.local.json の配置先**: その repo root 直下。既に他用途の CLAUDE.md がある場合は `CLAUDE.local.md` に書く（`references/claude-org-self-edit.md` の特例参照）
-- **Worker Directory Registry**: Pattern を `C` として登録、Directory に repo root の絶対パス、Status を `in_use`。完了時はエントリ削除（ディレクトリ自体は元プロジェクトなので保持）
-- **並行作業との競合**: repo root を直接掴むため、同 repo に対する Pattern A / B のワーカーと同時起動はしない（窓口側で順次化する）
-- **窓口メモ**: 「Pattern B 不可: 対象 `<target>` が gitignored。WORKER_DIR=既存 repo root 運用」と一文残す
+- **WORKER_DIR**: directly point at the **repo root of the existing local clone** (the "Path" value from the registry as-is)
+- **Where to place CLAUDE.md / settings.local.json**: directly under that repo root. If a CLAUDE.md is already there for another purpose, write to `CLAUDE.local.md` instead (see the special case in `references/claude-org-self-edit.md`)
+- **Worker Directory Registry**: register Pattern as `C`, Directory as the absolute path of the repo root, Status as `in_use`. On completion, delete the entry (the directory itself is the original project, so it is preserved)
+- **Concurrency**: because we grab the repo root directly, do not start it concurrently with Pattern A / B Workers operating on the same repo (the Lead serializes them)
+- **Lead memo**: leave a one-liner like "Pattern B unavailable: target `<target>` is gitignored. Operating with WORKER_DIR = existing repo root"
 
-#### claude-org 自己編集との関係
+#### Relation to claude-org self-edit
 
-通常のスキル / ドキュメント編集（`.claude/skills/...`, `references/...`）は tracked なので従来どおり Pattern B が選べる。`docs/internal/`, `notes/`, `tmp/` 等の gitignored 内部メモを編集する場合のみ本事前チェックで Pattern C 強制（gitignored サブモード）となる（`references/claude-org-self-edit.md` 参照）。
+Normal skill / doc edits (`.claude/skills/...`, `references/...`) are tracked and can use Pattern B as before. Only when editing internal memos under `docs/internal/`, `notes/`, `tmp/`, etc. that are gitignored does this pre-check force Pattern C (gitignored submode). See `references/claude-org-self-edit.md`.
 
-### ディレクトリパターン判定基準
+### Directory pattern criteria
 
-| パターン | 名称 | 条件 | ディレクトリ |
+| Pattern | Name | Condition | Directory |
 |---|---|---|---|
-| A | プロジェクトディレクトリ | プロジェクトの clone が必要（初回は clone、2回目以降は再利用） | `{workers_dir}/{project_slug}/` |
-| B | worktree | 同一プロジェクトで並行作業が必要（既に別ワーカーが同じプロジェクトディレクトリを使用中） | `{workers_dir}/{project_slug}/.worktrees/{task_id}/` |
-| C | エフェメラル | 成果物を残す必要がない一時作業（調査・検証等） | `{workers_dir}/{task_id}/` |
+| A | Project directory | A clone of the project is needed (clone first time, reuse afterward) | `{workers_dir}/{project_slug}/` |
+| B | worktree | Parallel work on the same project is needed (another Worker is already using the same project directory) | `{workers_dir}/{project_slug}/.worktrees/{task_id}/` |
+| C | Ephemeral | Temporary work where the deliverable does not need to be kept (investigation, verification, etc.) | `{workers_dir}/{task_id}/` |
 
-**判定フロー:**
+**Decision flow:**
 
-0. **事前チェック（対象ファイルが特定でき、かつローカル repo が存在する場合のみ）**: 上記「事前チェック: 対象ファイルが gitignored か」を実行する。ignored でないなら下記 1 へ。ignored なら **パターン C 強制（gitignored サブモード）** で確定し、以降の判定はスキップする。適用条件外（URL のみ・対象未特定など）はチェックを skip して下記 1 から通常判定
-1. プロジェクトの clone が必要な場合（registry/projects.md にパスが登録されているプロジェクト）:
-   a. Worker Directory Registry で同プロジェクトに `in_use` のエントリがある場合 → **パターン B**（worktree で並行作業）
-   b. 同プロジェクトに `available` のエントリがある場合 → **パターン A**（既存ディレクトリを再利用）
-   c. エントリがない場合 → **パターン A**（新規 clone）
-2. 上記に該当しない場合 → **パターン C**
-   - clone 不要の一時作業、成果物不要の調査タスク等
+0. **Pre-check (only when the target file is identified and a local repo exists)**: run "Pre-check: is the target file gitignored?" above. If not ignored, proceed to step 1 below. If ignored, settle on **Pattern C forced (gitignored submode)** and skip the rest. If outside applicability (URL only, target unidentified, etc.), skip the check and go to normal judgment from step 1
+1. When a project clone is needed (the project has a registered path in registry/projects.md):
+   a. If there is an `in_use` entry for the same project in the Worker Directory Registry → **Pattern B** (parallel work via worktree)
+   b. If there is an `available` entry for the same project → **Pattern A** (reuse the existing directory)
+   c. If there is no entry → **Pattern A** (new clone)
+2. Otherwise → **Pattern C**
+   - Temporary work that doesn't need a clone, investigation tasks where no deliverable is needed, etc.
 
-## Step 1.5: ワーカーディレクトリ準備（窓口が実行）
+## Step 1.5: Prepare the Worker directory (Lead executes)
 
-各タスクのワーカー専用ディレクトリを準備し、CLAUDE.md と設定を配置する。
-テンプレートは references/worker-claude-template.md を使用する。
-**パターン（A/B/C）によって手順が異なる。**
+Prepare a dedicated directory for each task and place CLAUDE.md and settings.
+Use the template references/worker-claude-template.md.
+**The procedure differs by pattern (A/B/C).**
 
-> **claude-org 自身を編集するタスクの場合**: 通常手順に加えて `references/claude-org-self-edit.md` の特例手順（block-org-structure.sh hook の除外、CLAUDE.local.md への指示記述、ルート CLAUDE.md を無視する旨の明示）を必ず適用すること。**本セクション以下で「CLAUDE.md を生成 / 配置 / 確認」と書かれている箇所はすべて `CLAUDE.local.md` に読み替える**（ルート CLAUDE.md は Secretary 用なので上書き禁止）。
+> **For tasks that edit claude-org itself**: in addition to the normal procedure, always apply the special procedure in `references/claude-org-self-edit.md` (excluding the block-org-structure.sh hook, writing instructions to CLAUDE.local.md, and explicitly noting that the root CLAUDE.md should be ignored). **In this section and below, wherever it says "generate / place / verify CLAUDE.md", read it as `CLAUDE.local.md`** (the root CLAUDE.md is for the Secretary, so do not overwrite it).
 
-### 共通手順（全パターン）
+### Common procedure (all patterns)
 
-1. `registry/org-config.md` の `workers_dir` を読み、リポジトリルートからの相対パスを絶対パスに解決する
+1. Read `workers_dir` from `registry/org-config.md` and resolve it from a path relative to the repository root to an absolute path
 
-### パターン A: プロジェクトディレクトリ
+### Pattern A: project directory
 
-プロジェクト専用ディレクトリ（`{workers_dir}/{project_slug}/`）を使う。初回は clone、2回目以降は再利用。
+Use a project-dedicated directory (`{workers_dir}/{project_slug}/`). Clone the first time, reuse afterward.
 
-**初回（ディレクトリが存在しない場合）:**
+**First time (directory does not exist):**
 
-1. `git clone {project_path} {workers_dir}/{project_slug}/` を実行
-2. ディレクトリ直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-3. ディレクトリ直下に `.claude/settings.local.json` を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
-4. `.state/org-state.md` の Worker Directory Registry に登録する
+1. Run `git clone {project_path} {workers_dir}/{project_slug}/`
+2. Generate CLAUDE.md directly under the directory (substituting template variables)
+3. Place `.claude/settings.local.json` directly under the directory
+   (see the "Worker" section of org-setup/references/permissions.md for the contents)
+   - Include `permissions.deny` (static blocks for `git push` / `rm -rf` etc.; always effective even in `bypassPermissions` mode)
+   - Embed `{claude_org_path}` and `{worker_dir}` in hook command paths and env values as resolved absolute paths
+   - Keep the quotes inside command paths (`"bash \"{claude_org_path}/...\""`) as-is (to handle spaces)
+4. Register an entry in the Worker Directory Registry of `.state/org-state.md`
 
-**再利用（ディレクトリが存在し、ステータスが `available` の場合）:**
+**Reuse (directory exists and status is `available`):**
 
-1. `git -C {workers_dir}/{project_slug}/ fetch origin` で最新化
-2. CLAUDE.md **のみ**を再生成する（新しいタスクID・タスク説明で上書き）
-   - settings.local.json はそのまま流用（`{worker_dir}` が変わらないため再生成不要）
-3. `.state/org-state.md` の Worker Directory Registry を更新する（新タスクIDを紐付け、ステータスを `in_use` に変更）
+1. Update with `git -C {workers_dir}/{project_slug}/ fetch origin`
+2. Regenerate **only** CLAUDE.md (overwrite with the new task ID and task description)
+   - Reuse settings.local.json as-is (no regeneration needed because `{worker_dir}` does not change)
+3. Update the Worker Directory Registry of `.state/org-state.md` (associate the new task ID, set status to `in_use`)
 
-### パターン B: worktree
+### Pattern B: worktree
 
-同一プロジェクトで並行作業が必要な場合、プロジェクトディレクトリを base clone として worktree を作成する。
+When parallel work on the same project is needed, use the project directory as a base clone and create a worktree.
 
-1. base clone（`{workers_dir}/{project_slug}/`）の存在確認:
-   - 存在しない場合 → `git clone {project_path} {workers_dir}/{project_slug}/` を実行
-   - 既に存在する場合 → `git -C {workers_dir}/{project_slug}/ fetch origin` で最新化
-2. worktree を作成:
-   - `git -C {workers_dir}/{project_slug}/ worktree add .worktrees/{task_id} -b {branch_name}` を実行
-   - `{branch_name}` は Step 1 で決定したブランチ名（指定がなければ `{task_id}` をブランチ名に使う）
-   - ワーカーディレクトリ: `{workers_dir}/{project_slug}/.worktrees/{task_id}/`
-3. worktree 直下に CLAUDE.md を生成する（テンプレートの変数を置換）
-4. worktree 直下に `.claude/settings.local.json` を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
-5. `.state/org-state.md` の Worker Directory Registry に登録する
+1. Confirm the existence of the base clone (`{workers_dir}/{project_slug}/`):
+   - If it doesn't exist → run `git clone {project_path} {workers_dir}/{project_slug}/`
+   - If it already exists → update with `git -C {workers_dir}/{project_slug}/ fetch origin`
+2. Create the worktree:
+   - Run `git -C {workers_dir}/{project_slug}/ worktree add .worktrees/{task_id} -b {branch_name}`
+   - `{branch_name}` is the branch name decided in Step 1 (if unspecified, use `{task_id}` as the branch name)
+   - Worker directory: `{workers_dir}/{project_slug}/.worktrees/{task_id}/`
+3. Generate CLAUDE.md directly under the worktree (substituting template variables)
+4. Place `.claude/settings.local.json` directly under the worktree
+   (see the "Worker" section of org-setup/references/permissions.md for the contents)
+   - Include `permissions.deny` (static blocks for `git push` / `rm -rf` etc.; always effective even in `bypassPermissions` mode)
+   - Embed `{claude_org_path}` and `{worker_dir}` in hook command paths and env values as resolved absolute paths
+   - Keep the quotes inside command paths (`"bash \"{claude_org_path}/...\""`) as-is (to handle spaces)
+5. Register an entry in the Worker Directory Registry of `.state/org-state.md`
 
-### パターン C: エフェメラル
+### Pattern C: ephemeral
 
-成果物を残す必要がない一時作業（調査・検証等）で使用する。
+Use for temporary work where the deliverable does not need to be kept (investigation, verification, etc.).
 
-1. `{workers_dir}/{task_id}/` ディレクトリを作成する（例: `../workers/data-analysis/`）
-2. テンプレートから `{workers_dir}/{task_id}/CLAUDE.md` を生成する
-3. `{workers_dir}/{task_id}/.claude/settings.local.json` にワーカー用の設定を配置する
-   （設定内容は org-setup/references/permissions.md の「ワーカー」セクション参照）
-   - `permissions.deny` を含めること（`git push` / `rm -rf` 等の静的ブロック。`bypassPermissions` モードでも常に有効）
-   - hooks の command パスと env の値には `{claude_org_path}` と `{worker_dir}` を解決済みの絶対パスで埋め込むこと
-   - command パス内のクォート（`"bash \"{claude_org_path}/...\""`）はそのまま維持すること（スペース対策）
-4. `.state/org-state.md` の Worker Directory Registry に登録する
+1. Create the directory `{workers_dir}/{task_id}/` (e.g. `../workers/data-analysis/`)
+2. Generate `{workers_dir}/{task_id}/CLAUDE.md` from the template
+3. Place Worker settings at `{workers_dir}/{task_id}/.claude/settings.local.json`
+   (see the "Worker" section of org-setup/references/permissions.md for the contents)
+   - Include `permissions.deny` (static blocks for `git push` / `rm -rf` etc.; always effective even in `bypassPermissions` mode)
+   - Embed `{claude_org_path}` and `{worker_dir}` in hook command paths and env values as resolved absolute paths
+   - Keep the quotes inside command paths (`"bash \"{claude_org_path}/...\""`) as-is (to handle spaces)
+4. Register an entry in the Worker Directory Registry of `.state/org-state.md`
 
-### 共通手順（全パターン・配置後）
+### Common procedure (all patterns; after placement)
 
-テンプレートの変数を実際の値で置換する:
-- `{project_name}` → registry の通称
-- `{project_description}` → registry の説明
-- `{task_id}` → タスクID（例: `data-analysis`）
-- `{task_description}` → タスクの目的と成果物
-- `{claude_org_path}` → claude-org リポジトリの絶対パス
-- `{worker_dir}` → ワーカーディレクトリの絶対パス（パターンにより異なる、上記参照）
+Substitute the template's variables with actual values:
+- `{project_name}` → registry nickname
+- `{project_description}` → registry description
+- `{task_id}` → task ID (e.g. `data-analysis`)
+- `{task_description}` → task goal and deliverable
+- `{claude_org_path}` → absolute path of the claude-org repository
+- `{worker_dir}` → absolute path of the Worker directory (varies by pattern; see above)
 
-生成した CLAUDE.md に「作業ディレクトリ（最重要制約）」セクションが含まれていることを確認する。含まれていない場合はテンプレート適用ミスのため再生成する
+Verify that the generated CLAUDE.md contains the "Working directory (most important constraint)" section. If it doesn't, the template was not applied correctly — regenerate.
 
-**参考 work-skill がある場合（Step 0.5 でマッチ）:**
+**If a reference work-skill exists (matched in Step 0.5):**
 
-CLAUDE.md に以下のセクションを追加する（「参照すべきファイル」セクションの後に配置）:
+Add the following section to CLAUDE.md (place it after the "Files to refer to" section):
 
 ```markdown
-## 参考 work-skill
-以下の work-skill が参考になる可能性があります。手順や判断基準を参照してください。
-ただし、タスクの要件に合わない部分は適宜調整すること。
+## Reference work-skill
+The following work-skill(s) may be useful. Refer to its procedure and judgment criteria.
+Adjust as appropriate where it does not fit this task's requirements.
 
-- スキル名: {skill-name}
-- パス: {claude_org_path}/.claude/skills/{skill-name}/SKILL.md
-- 概要: {description}
+- Skill name: {skill-name}
+- Path: {claude_org_path}/.claude/skills/{skill-name}/SKILL.md
+- Summary: {description}
 ```
 
-## Step 2: フォアマンへの委託（窓口が実行 → ここで窓口は解放）
+## Step 2: Hand off to the Dispatcher (Lead executes → Lead is released here)
 
-renga-peers の `send_message` でフォアマン（pane name=`dispatcher`）に以下を送信する:
+Send the following via renga-peers `send_message` to the Dispatcher (pane name = `dispatcher`):
 
 ```
-DELEGATE: 以下のワーカーを派遣してください。
+DELEGATE: Please dispatch the following Workers.
 
-タスク一覧:
-- {task_id}: {タスク説明}
-  - ワーカーディレクトリ: {ワーカーディレクトリの絶対パス}（CLAUDE.md・設定配置済み）
-  - ディレクトリパターン: {A: プロジェクトディレクトリ / B: worktree / C: エフェメラル}
-  - プロジェクト: {clone先URL or ローカルパス or 新規作成 or worktree済み or 前タスク引継ぎ}
-  - Permission Mode: {org-config から読んだ default_permission_mode の値}
-  - 検証深度: {full | minimal}（instruction-template の同名行と同じ値を必ず記入。フォアマンはこの値をワーカーへの指示にそのまま転記する）
-  - 指示内容: {instruction-template に基づく指示の要約。「検証深度」行は必ず残したまま転送する}
+Task list:
+- {task_id}: {task description}
+  - Worker directory: {absolute path of the Worker directory} (CLAUDE.md and settings already placed)
+  - Directory pattern: {A: project directory / B: worktree / C: ephemeral}
+  - Project: {clone URL or local path or new creation or worktree-ready or carried over from previous task}
+  - Permission Mode: {value of default_permission_mode read from org-config}
+  - Verification depth: {full | minimal} (must match the same line in instruction-template; the Dispatcher transcribes this value verbatim into the Worker instruction)
+  - Instructions: {summary of the instruction based on instruction-template. Always keep the "Verification depth" line intact when forwarding}
 
-窓口ペイン名: `secretary`（renga layout で登録済み。新規タブ作成時の基準となる）
+Lead pane name: `secretary` (registered by the renga layout; serves as the basis when creating new tabs)
 ```
 
-**窓口はこの送信後すぐにユーザーとの対話に戻れる。**
-ユーザーには「フォアマンに派遣を依頼しました。準備ができ次第報告します。」と伝える。
+**The Lead can return to user dialogue immediately after this send.**
+Tell the user "Dispatch requested to the Dispatcher. I'll report back as soon as it's ready."
 
-> renga では窓口・フォアマン・キュレーター等の「長寿命ペイン」は安定名 (`--id`) で addressable。
-> 窓口 (`secretary`) / フォアマン (`dispatcher`) / キュレーター (`curator`) は `/org-start` で命名済み。
+> In renga, "long-lived panes" like Lead / Dispatcher / Curator are addressable by stable name (`--id`).
+> Lead (`secretary`) / Dispatcher (`dispatcher`) / Curator (`curator`) are named by `/org-start`.
 
-## Step 3: ワーカー起動と指示送信（フォアマンが実行）
+## Step 3: Spawn Workers and send instructions (Dispatcher executes)
 
-フォアマンが以下を実行する:
+The Dispatcher executes the following:
 
-### 3-1. balanced split で target / direction を決める
+### 3-1. Choose target / direction via balanced split
 
-旧設計は序数 `k` ベースの lookup table で target を決めていたが、ワーカーが途中で閉じた後の再派遣や想定外の退役順でテーブル前提と実レイアウトが乖離し、`[split_refused]` を誘発しやすかった。renga-peers MCP の `mcp__renga-peers__list_panes` が各ペインの `id / name / role / focused / x / y / width / height` (cell 単位) を返すため、**現在のレイアウト (rect) から動的に target と direction を選ぶ方式**を取る。詳細ルールは `references/pane-layout.md` の「ワーカーの balanced split 戦略」セクションを参照。
+The old design picked the target via an ordinal-`k`-based lookup table, but during re-dispatch after a Worker closed in the middle, or with unexpected retirement order, the table assumption diverged from the actual layout, easily inducing `[split_refused]`. Since the renga-peers MCP `mcp__renga-peers__list_panes` returns each pane's `id / name / role / focused / x / y / width / height` (in cell units), we use a **scheme that picks target and direction dynamically from the current layout (rect)**. See the "Worker balanced split strategy" section of `references/pane-layout.md` for the detailed rules.
 
-#### 3-1a. レイアウト取得
+#### 3-1a. Get the layout
 
-`mcp__renga-peers__list_panes` を呼び、返却テキストから全ペインの属性を抽出する。各ペインは以下のフィールドを持つ:
+Call `mcp__renga-peers__list_panes` and extract every pane's attributes from the returned text. Each pane has the fields:
 
-- `id`: 整数
-- `name`: 文字列（`spawn_pane` / `new_tab` で明示指定されたペインのみ、未設定なら省略）
-- `role`: 文字列 ("secretary" / "dispatcher" / "curator" / "worker" のいずれか。未設定なら省略)
-- `focused`: bool（出力行に `(focused)` が付くかで判断）
-- `x / y / width / height`: cell 単位の整数
+- `id`: integer
+- `name`: string (only for panes explicitly given a name via `spawn_pane` / `new_tab`; omitted if unset)
+- `role`: string (one of "secretary" / "dispatcher" / "curator" / "worker"; omitted if unset)
+- `focused`: bool (judged by whether `(focused)` appears on the output line)
+- `x / y / width / height`: integers in cell units
 
-#### 3-1b. balanced split アルゴリズム（Claude が判定ロジックを実行）
+#### 3-1b. Balanced split algorithm (Claude executes the decision logic)
 
-**定数**:
-- `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`: renga 側の分割下限（findings: renga-split-inv）
-- `SECRETARY_MIN_WIDTH = 125` / `SECRETARY_MIN_HEIGHT = 45`: secretary を分割候補にしてよい最小幅・最小高さ（保険条項、実運用ではほぼ不発動）
+**Constants**:
+- `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`: renga's split lower bounds (findings: renga-split-inv)
+- `SECRETARY_MIN_WIDTH = 125` / `SECRETARY_MIN_HEIGHT = 45`: minimum width / height for treating secretary as a split candidate (insurance clause; rarely fires in practice)
 
-**Step 1. curator を特定**: `role == "curator"` のペインを 1 つ選ぶ（複数あれば先頭）。以降 `$curator` と呼ぶ。存在しなければ `$curator = null`。
+**Step 1. Identify the curator**: pick one pane with `role == "curator"` (the first if multiple). Henceforth `$curator`. If none exists, `$curator = null`.
 
-**Step 2. 候補を絞り込む**:
-- `role ∈ {"secretary", "dispatcher", "worker"}` のペインのみ候補
-- `role == "dispatcher"` のペインは、**`$curator` と rect 隣接している場合のみ**残す（`$curator = null` なら dispatcher も除外）
-  - rect 隣接の定義（どちらかを満たす）:
-    - **縦辺共有 + y 区間重なり**: `a.x + a.width == b.x` または `b.x + b.width == a.x`、かつ `max(a.y, b.y) < min(a.y + a.height, b.y + b.height)`
-    - **横辺共有 + x 区間重なり**: `a.y + a.height == b.y` または `b.y + b.height == a.y`、かつ `max(a.x, b.x) < min(a.x + a.width, b.x + b.width)`
+**Step 2. Filter candidates**:
+- Candidates are panes with `role ∈ {"secretary", "dispatcher", "worker"}` only
+- Keep `role == "dispatcher"` panes **only if they are rect-adjacent to `$curator`** (if `$curator = null`, exclude dispatchers as well)
+  - Rect adjacency definition (one of the following):
+    - **Vertical-edge shared + y-interval overlap**: `a.x + a.width == b.x` or `b.x + b.width == a.x`, and `max(a.y, b.y) < min(a.y + a.height, b.y + b.height)`
+    - **Horizontal-edge shared + x-interval overlap**: `a.y + a.height == b.y` or `b.y + b.height == a.y`, and `max(a.x, b.x) < min(a.x + a.width, b.x + b.width)`
 
-**Step 3. 各候補に direction / new_w / new_h / metric を付与**:
+**Step 3. Attach direction / new_w / new_h / metric to each candidate**:
 - `direction = (width > height * 2) ? "vertical" : "horizontal"`
-  - ターミナル cell は縦:横 ≈ 2:1（文字が縦長）。`width > height*2` は物理的に横長 → vertical（左右分割）で綺麗に割れる
-  - それ以外は horizontal（上下分割）
+  - Terminal cells are roughly 2:1 height:width (characters are tall). `width > height*2` means physically wide → splits cleanly with vertical (left/right)
+  - Otherwise horizontal (top/bottom)
 - `new_w = (direction == "vertical") ? floor(width / 2) : width`
 - `new_h = (direction == "horizontal") ? floor(height / 2) : height`
-- `metric = (direction == "vertical") ? new_w : new_h`（分割軸方向の新サイズ）
+- `metric = (direction == "vertical") ? new_w : new_h` (new size in the split-axis direction)
 
-**Step 4. MIN_PANE 制約**:
-- `new_w >= MIN_PANE_WIDTH` かつ `new_h >= MIN_PANE_HEIGHT` のペインのみ残す
+**Step 4. MIN_PANE constraint**:
+- Keep only panes with `new_w >= MIN_PANE_WIDTH` and `new_h >= MIN_PANE_HEIGHT`
 
-**Step 5. secretary 保険条項**:
-- `role == "secretary"` のペインは `new_w >= SECRETARY_MIN_WIDTH` **かつ** `new_h >= SECRETARY_MIN_HEIGHT` のときだけ残す（width だけ通っても height が足りなければ除外）
+**Step 5. Secretary insurance clause**:
+- Keep `role == "secretary"` panes only when `new_w >= SECRETARY_MIN_WIDTH` **and** `new_h >= SECRETARY_MIN_HEIGHT` (passing width alone is not enough; height must also pass)
 
-**Step 6. ソート & 選択**:
-- `metric` の降順、tie-break は `id` の昇順
-- 先頭要素の `name` を `$target`、`direction` を `$direction` として使用
+**Step 6. Sort & select**:
+- Descending by `metric`, tie-break by `id` ascending
+- Use the first element's `name` as `$target` and `direction` as `$direction`
 
-初回（ワーカー 0 人）は dispatcher が唯一の候補として残り、direction は dispatcher の aspect ratio から決まる（典型的に横長なので vertical）。
+On the very first dispatch (zero workers), the dispatcher remains as the sole candidate, and direction is determined by the dispatcher's aspect ratio (typically wide → vertical).
 
-#### 3-1c. 候補が空だった場合
+#### 3-1c. When the candidate set is empty
 
-`$target` が空（候補セットが空）の場合、フォアマン Claude は **`spawn_pane` を発行せず**、代わりに renga-peers で窓口 (`secretary`) に escalate メッセージを送信する:
+When `$target` is empty (no candidates), the Dispatcher Claude **does not issue `spawn_pane`**, and instead sends an escalate message to the Lead (`secretary`) via renga-peers:
 
-1. `mcp__renga-peers__send_message(to_id="secretary", message=...)` を呼び、本文を以下にする:
+1. Call `mcp__renga-peers__send_message(to_id="secretary", message=...)` with body:
    ```
-   SPLIT_CAPACITY_EXCEEDED: {task_id} のワーカー分割対象が見つからない。
-   rect ベース balanced split の MIN_PANE / 隣接条件を満たす候補が 0。
-   ターミナルサイズ不足または想定外のレイアウトが疑われる。人間判断が必要です。
+   SPLIT_CAPACITY_EXCEEDED: no Worker split target found for {task_id}.
+   Zero candidates satisfy the rect-based balanced-split MIN_PANE / adjacency conditions.
+   Suspect insufficient terminal size or an unexpected layout. Human judgment required.
    ```
-2. 3-2 以降（`spawn_pane` / 起動確認 / `list_peers` 待ち / instruction 送信）は **skip** する。該当ワーカー 1 件だけ派遣を中止し、フォアマン本体の監視ループは **継続**させる。`exit` / `return` などでフォアマンを落とさないこと
+2. **Skip** 3-2 onward (`spawn_pane` / launch confirmation / `list_peers` wait / instruction send). Cancel only this one Worker dispatch and **continue** the Dispatcher main monitoring loop. Do not let the Dispatcher exit / return.
 
-### 3-2. ワーカーペインを起動する
+### 3-2. Spawn the Worker pane
 
-3-1 で算出した `$target` / `$direction` を使って `mcp__renga-peers__spawn_claude_pane` を呼ぶ。**`$target` が空なら spawn せず 3-1c の escalate 手順に従う**:
+Use `$target` / `$direction` computed in 3-1 to call `mcp__renga-peers__spawn_claude_pane`. **If `$target` is empty, do not spawn; follow the escalate procedure in 3-1c**:
 
 ```
 mcp__renga-peers__spawn_claude_pane(
-  target=$target,                         # 3-1 で算出した既存ペイン名
+  target=$target,                         # existing pane name computed in 3-1
   direction=$direction,                   # "vertical" or "horizontal"
   role="worker",
-  name="worker-{task_id}",                # 後続操作で参照する安定名。英字含む前提
-  cwd="{workers_dir}/{task_id}",          # 絶対パス推奨。相対は caller pane の cwd 基点
+  name="worker-{task_id}",                # stable name referenced by subsequent ops; must contain letters
+  cwd="{workers_dir}/{task_id}",          # absolute path recommended; relative resolves from caller pane's cwd
   permission_mode="{default_permission_mode}",
-  model="opus"                            # 必須。sonnet 禁止（auto classifier が不安定）
+  model="opus"                            # required. sonnet prohibited (auto classifier unstable)
 )
 ```
 
-- **`model="opus"` は必須（sonnet 禁止）。** ワーカーの permission_mode `auto` の safety classifier は Opus でのみ安定動作するため、sonnet だと分類器が誤判定を多発し承認フローが崩れる。フォアマンだけは `bypassPermissions` 固定で分類器非経由のため sonnet 運用で問題ない
-- ペイン配置ルールは `references/pane-layout.md` を参照。rect ベースの target / direction 選出ルールはそちらに集約
-- **同一タブ内 spawn で起動する理由**: renga の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか見えない。`new_tab` で別タブに置くとフォアマンからの監視・指示送信が不能になる（renga 側 issue: suisya-systems/renga#71）
-- `name="worker-{task_id}"`: 後続の `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` や `close_pane(target="worker-{task_id}")` で addressable にする安定名。**全桁数字は id 扱いになる** ので、`worker-` プレフィックス等で英字を必ず含める
-- `role="worker"`: `list_panes` の結果で役割識別（次回以降の balanced split の target 選出にも使われる）
-- `cwd` / `permission_mode` / `model` / `args[]` は `spawn_claude_pane` の構造化フィールド。renga が `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...` を合成する。旧方式（`cd`-プレフィックス付き command 文字列を `spawn_pane` に渡す）は **禁止** — cwd 変更プレフィックスがあると renga の bare-`claude` auto-upgrade が発動せず、channel push が失われる
-- 起動コマンドの仕様は `.claude/skills/org-start/SKILL.md` の「ClaudeCode 起動コマンド（役割別）」セクションを参照
-- `spawn_claude_pane` が内部で `--dangerously-load-development-channels` を付与するため、`Load development channel?` 確認プロンプトが初回表示される。Step 3-3b で `send_keys(enter=true)` による承認が必要
-- **エラーハンドリング**: MCP 結果テキストに `[<code>] <msg>` 形式でエラーが埋まる。主な code:
-  - `[split_refused]` (MAX_PANES / too small): `references/renga-error-codes.md` の手順に従いキュレーター → 窓口に escalate。balanced split は best-effort の配置ヒントであり、想定外のレイアウト（途中でワーカーが閉じた後の再派遣など）では拒否され得る
-  - `[pane_not_found]`: `$target` に選んだ既存ペインが spawn 発行直前に閉じたレース。同じくエラーコード経路で escalate
-  - `[cwd_invalid]`: 指定した cwd が存在しない / ディレクトリでない。ペイン作成前に reject されるので half-mutated layout にはならない。窓口に escalate し、ワーカーディレクトリ準備（org-delegate Step 1.5）が完了しているか確認
-  - `[invalid-params]`: `args[]` に `--permission-mode` / `--model` / `--dangerously-load-development-channels` を含めた場合の拒否。構造化フィールドで渡す
-  - その他の code は `references/renga-error-codes.md` 参照
+- **`model="opus"` is required (sonnet prohibited).** The safety classifier of the Worker's `auto` permission_mode operates reliably only on Opus; with sonnet, misclassifications happen frequently and the approval flow breaks. Only the Dispatcher is fixed at `bypassPermissions` and bypasses the classifier, so sonnet works there.
+- Pane placement rules: see `references/pane-layout.md`. The rect-based target / direction selection rules are consolidated there.
+- **Why we spawn within the same tab**: renga's `list_panes` / `focus_pane` / `send_message` / `inspect` (CLI) can only see panes in the currently focused tab. Putting Workers in a separate tab via `new_tab` makes them invisible to the Dispatcher for monitoring and instruction (renga-side issue: suisya-systems/renga#71)
+- `name="worker-{task_id}"`: stable name that makes the pane addressable for later `mcp__renga-peers__send_message(to_id="worker-{task_id}", ...)` and `close_pane(target="worker-{task_id}")`. **All-digit names are treated as ids**, so always include letters via a `worker-` prefix etc.
+- `role="worker"`: identifies the role in `list_panes` output (also used for target selection in subsequent balanced splits)
+- `cwd` / `permission_mode` / `model` / `args[]` are structured fields of `spawn_claude_pane`. renga composes `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old method (passing a `cd`-prefixed command string to `spawn_pane`) is **prohibited** — a cwd-changing prefix prevents renga's bare-`claude` auto-upgrade from firing, and channel push is lost
+- See the "ClaudeCode launch commands (per role)" section of `.claude/skills/org-start/SKILL.md` for the launch-command spec
+- Because `spawn_claude_pane` internally adds `--dangerously-load-development-channels`, the `Load development channel?` confirmation prompt appears on first launch. Approval via `send_keys(enter=true)` is needed in Step 3-3b
+- **Error handling**: errors are embedded in the MCP result text in `[<code>] <msg>` form. Main codes:
+  - `[split_refused]` (MAX_PANES / too small): follow the procedure in `references/renga-error-codes.md` and escalate Curator → Lead. Balanced split is a best-effort placement hint; in unexpected layouts (e.g. re-dispatch after a Worker closed) it may be refused.
+  - `[pane_not_found]`: race in which the existing pane chosen as `$target` closed just before spawn was issued. Same — escalate via the error-code path.
+  - `[cwd_invalid]`: the specified cwd does not exist / is not a directory. Rejected before pane creation, so no half-mutated layout. Escalate to the Lead and verify Worker directory preparation (Step 1.5 of org-delegate) is complete.
+  - `[invalid-params]`: rejected when `args[]` includes `--permission-mode` / `--model` / `--dangerously-load-development-channels`. Pass via the structured fields.
+  - For other codes, see `references/renga-error-codes.md`.
 
-### 3-3. ペインが起動したことを確認
+### 3-3. Confirm the pane has started
 
-`mcp__renga-peers__poll_events` で `pane_started` イベントを最大 3 秒待つ。target 以外の worker の同時 spawn や filter 不一致イベント到着による early return に備え、**3 秒 deadline 内で再 poll するループ**として書く:
+Wait up to 3 seconds for a `pane_started` event via `mcp__renga-peers__poll_events`. To handle simultaneous spawns of other workers and early returns triggered by filter mismatches, **write it as a re-poll loop within the 3-second deadline**:
 
 ```
-cursor = None                    # 初回は since 省略（「今以降のイベントだけ」セマンティクス）
-deadline = now + 3 秒
+cursor = None                    # first call omits since (= "events from now on" semantics)
+deadline = now + 3 seconds
 while now < deadline:
-    remaining_ms = (deadline - now) ミリ秒
+    remaining_ms = (deadline - now) milliseconds
     result = mcp__renga-peers__poll_events(
-        since=cursor,                                  # 2 回目以降は前回の next_since
+        since=cursor,                                  # use last call's next_since from second iteration onward
         timeout_ms=min(remaining_ms, 3000),
         types=["pane_started"]
     )
-    cursor = result.next_since                          # 次呼び出しで使う
+    cursor = result.next_since                          # use on next call
     for ev in result.events:
         if ev.name == "worker-{task_id}":
-            return OK                                   # 起動確認完了
-# deadline 超過 → 起動イベント未検出
-# mcp__renga-peers__list_panes でペイン存在を再確認、未存在なら窓口にエスカレーション
+            return OK                                   # launch confirmed
+# deadline exceeded → no launch event detected
+# Re-confirm pane existence via mcp__renga-peers__list_panes; if absent, escalate to the Lead
 ```
 
-- 初回 `since` 省略 = `renga events --timeout` と同じ「今以降」セマンティクス（過去の起動イベントを replay しない）
-- `types=["pane_started"]` で他 type（`pane_exited` 等）を除外しつつ、cursor は全 type で advance（重複 scan なし）
-- **filter 不一致イベントが到着すると long-poll が早期終了し `events:[]` + 進んだ cursor が返る**ので、空応答のままループ継続（cursor 保持で重複なし）
-- `name == "worker-{task_id}"` の `pane_started` で break。deadline 超過で未検出なら `list_panes` で pane 存在を再確認
+- Omitting `since` on first call = same "events from now on" semantics as `renga events --timeout` (does not replay past launch events)
+- `types=["pane_started"]` excludes other types (`pane_exited` etc.) while the cursor advances on all types (no duplicate scans)
+- **Filter-mismatching events cause early termination of long-poll, returning `events:[]` + an advanced cursor**, so loop on with empty responses (no duplicates because cursor is preserved)
+- Break on `pane_started` with `name == "worker-{task_id}"`. If deadline exceeds without detection, re-confirm pane existence via `list_panes`
 
-### 3-3b. 「Load development channel?」プロンプトを Enter で承認
+### 3-3b. Approve the "Load development channel?" prompt with Enter
 
-`spawn_claude_pane` は内部で `--dangerously-load-development-channels server:renga-peers` を付与するため、初回起動で Y/n 確認プロンプトが出る。Enter で承認する:
+Because `spawn_claude_pane` internally adds `--dangerously-load-development-channels server:renga-peers`, a Y/n confirmation prompt appears on first launch. Approve with Enter:
 
 ```
 mcp__renga-peers__send_keys(target="worker-{task_id}", enter=true)
 ```
 
-承認しないと `server:renga-peers` チャネルが有効化されず、3-4 の `list_peers` 待ちがタイムアウトし、3-5 の `send_message` も届かない。Enter は CR (0x0D) として PTY に書き込まれる（byte-identical to renga `append_enter`）。
+Without approval, the `server:renga-peers` channel is not enabled, the `list_peers` wait in 3-4 times out, and `send_message` in 3-5 does not arrive. Enter is written to the PTY as CR (0x0D) (byte-identical to renga `append_enter`).
 
-### 3-4. `mcp__renga-peers__list_peers` で新ピア出現を待機
+### 3-4. Wait for the new peer via `mcp__renga-peers__list_peers`
 
-pane は live でも Claude がまだ起動中の場合があるため二重確認。`mcp__renga-peers__list_peers` を呼び、`worker-{task_id}` が peer 一覧に現れるまで短い間隔（例: 2 秒）でリトライする（最大 30 秒程度）。タイムアウトした場合は `list_panes` でペイン状態を再確認し、必要なら窓口に escalate する。
+The pane may be live while Claude is still launching, so do a second confirmation. Call `mcp__renga-peers__list_peers` and retry at short intervals (e.g. 2 seconds) until `worker-{task_id}` appears in the peer list (up to ~30 seconds). On timeout, re-confirm pane state via `list_panes` and escalate to the Lead if necessary.
 
-### 3-5. `mcp__renga-peers__send_message` でワーカーに指示を送信
+### 3-5. Send the instruction to the Worker via `mcp__renga-peers__send_message`
 
-`references/instruction-template.md` のフォーマットに従う。`to_id="worker-{task_id}"` で pane name 指定。
+Follow the format in `references/instruction-template.md`. Specify the pane name with `to_id="worker-{task_id}"`.
 
-### 3-6. 複数ワーカーの順次起動
+### 3-6. Sequential launch of multiple Workers
 
-複数ワーカーがある場合は 3-1〜3-5 を順次繰り返す。`list_panes` の結果が毎回変わるので、**都度再取得して** balanced split 判定をし直す（前ワーカーの起動が完了するのを 3-3 / 3-4 で待ってから次に進むこと）。
+If there are multiple Workers, repeat 3-1 through 3-5 in order. Because the result of `list_panes` changes each time, **re-fetch every time** and redo the balanced-split decision (wait for the previous Worker's launch to complete in 3-3 / 3-4 before moving on).
 
-## Step 4: 状態記録（フォアマンが実行）
+## Step 4: Record state (Dispatcher executes)
 
-各ワーカーについて:
+For each Worker:
 
-1. `.state/workers/worker-{task_id}.md` を作成（renga-peers では pane name `worker-{task_id}` が安定識別子。旧 peer-id は使わない）:
+1. Create `.state/workers/worker-{task_id}.md` (in renga-peers, the pane name `worker-{task_id}` is the stable identifier; the legacy peer-id is no longer used):
    ```markdown
    # Worker: worker-{task_id}
    Task: {task_id}
-   Directory: {作業ディレクトリ}
+   Directory: {working directory}
    Pane ID: {pane_id}
    Started: {ISO timestamp}
 
    ## Assignment
-   {タスクの説明}
+   {task description}
 
    ## Progress Log
-   - [{time}] 派遣完了、作業開始
+   - [{time}] Dispatch complete; work started
    ```
 
-2. `.state/org-state.md` を更新（なければ新規作成）:
-   - Current Objective に人間の依頼を記載
-   - Active Work Items にタスクを追加
+2. Update `.state/org-state.md` (create if missing):
+   - Record the human's request in Current Objective
+   - Add the task to Active Work Items
 
-3. `.state/journal.jsonl` にイベント追記:
+3. Append an event to `.state/journal.jsonl`:
    ```json
    {"ts":"<ISO timestamp>","event":"worker_spawned","worker":"worker-{task_id}","dir":"<dir>","task":"{task_id}"}
    ```
 
-4. `.state/org-state.md` を更新した後、JSON スナップショットを再生成する:
+4. After updating `.state/org-state.md`, regenerate the JSON snapshot:
 
    ```bash
    py -3 dashboard/org_state_converter.py    # Windows
    python3 dashboard/org_state_converter.py   # Mac/Linux
    ```
 
-5. ワーカーペインを監視対象として登録する:
-   - 派遣後、そのペインを監視対象として記録し、`.dispatcher/CLAUDE.md` の「ワーカーペイン監視」に従って定期的に承認待ちを確認する
+5. Register the Worker pane as a monitoring target:
+   - After dispatch, record that pane as a monitoring target and periodically check for pending approvals per the "Worker pane monitoring" section of `.dispatcher/CLAUDE.md`
 
-### Worker Directory Registry（org-state.md 内のセクション定義）
+### Worker Directory Registry (section definition inside org-state.md)
 
-`.state/org-state.md` に以下のセクションを追加・管理する。ワーカーディレクトリの再利用状態を追跡する。
+Add and maintain the following section in `.state/org-state.md` to track Worker-directory reuse status.
 
 ```markdown
 ## Worker Directory Registry
@@ -487,92 +488,92 @@ pane は live でも Claude がまだ起動中の場合があるため二重確�
 | data-analysis | C | /path/to/workers/data-analysis/ | - | in_use |
 ```
 
-**フィールド説明:**
-- **Task ID**: 現在そのディレクトリを使用しているタスクID
-- **Pattern**: A（プロジェクトディレクトリ）/ B（worktree）/ C（エフェメラル）
-- **Directory**: ワーカーディレクトリの絶対パス
-- **Project**: registry/projects.md の通称（エフェメラルで無関係なら `-`）
-- **Status**: `in_use`（作業中）/ `available`（完了済み・再利用可能）
+**Field descriptions:**
+- **Task ID**: the task ID currently using that directory
+- **Pattern**: A (project directory) / B (worktree) / C (ephemeral)
+- **Directory**: absolute path of the Worker directory
+- **Project**: nickname from registry/projects.md (`-` if ephemeral and unrelated)
+- **Status**: `in_use` (in progress) / `available` (completed, reusable)
 
-**運用ルール:**
-- Step 1.5 でディレクトリ準備時にエントリを追加する
-- Step 5 (2b) で人間が承認した際にステータスを更新する（ディレクトリは削除しない）
-- Step 1 の判定フローでこのテーブルを参照し、再利用可能なディレクトリや並行作業の有無を判定する
+**Operational rules:**
+- Add the entry during directory preparation in Step 1.5
+- Update the status when the human approves in Step 5 (2b) (do not delete the directory)
+- The decision flow in Step 1 references this table to determine reusable directories and parallel-work conflicts
 
-5. 窓口 (`secretary`) に renga-peers で派遣完了を報告:
+5. Report dispatch completion to the Lead (`secretary`) via renga-peers:
    ```
-   DELEGATE_COMPLETE: {task_id} のワーカーを派遣しました。
+   DELEGATE_COMPLETE: dispatched the Worker for {task_id}.
    Pane: worker-{task_id} (id={pane_id})
    ```
 
-## Step 5: 進捗管理（窓口が実行）
+## Step 5: Progress management (Lead executes)
 
-### DELEGATE_COMPLETE 受信時
+### On receiving DELEGATE_COMPLETE
 
-フォアマンから派遣完了報告を受け取ったら、各ワーカーに挨拶メッセージを送る:
+When the Lead receives the dispatch-complete report from the Dispatcher, send a greeting message to each Worker:
 ```
 mcp__renga-peers__send_message(
   to_id="worker-{task_id}",
-  message="窓口です。{task_id} の作業をお願いしています。完了・進捗・ブロック、全ての報告は `to_id=\"secretary\"` で renga-peers 送信してください。"
+  message="This is the Lead. You're working on {task_id}. Send all reports — completion, progress, blockers — via renga-peers with `to_id=\"secretary\"`."
 )
 ```
-ワーカー側は worker-claude-template の方針通り pane name `secretary` に固定で送るため、窓口の peer-id を履歴に残す必要はない（この挨拶はあくまで作業開始確認）。
+The Worker side, per the worker-claude-template policy, sends to the fixed pane name `secretary`, so there is no need to keep the Lead's peer-id in history (this greeting is just confirmation that work has started).
 
-### ワーカーからのメッセージ受信時
+### On receiving a message from a Worker
 
-ワーカーから renga-peers でメッセージを受け取ったら:
+When the Lead receives a message from a Worker via renga-peers:
 
-1. 進捗報告の場合:
-   - `.state/workers/worker-{task_id}.md` の Progress Log に追記
-   - `journal.jsonl` にイベント追記
-2a. ワーカーから完了報告を受け取ったら:
-   - `org-state.md` の該当Work Itemを **REVIEW** に更新
-   - `journal.jsonl` にイベント追記
-   - JSON スナップショットを再生成する: `py -3 dashboard/org_state_converter.py`
-   - 結果を人間に報告する
-   - **ペインはまだ閉じない**
+1. For a progress report:
+   - Append to the Progress Log of `.state/workers/worker-{task_id}.md`
+   - Append an event to `journal.jsonl`
+2a. When a completion report is received from a Worker:
+   - Update the corresponding Work Item in `org-state.md` to **REVIEW**
+   - Append an event to `journal.jsonl`
+   - Regenerate the JSON snapshot: `py -3 dashboard/org_state_converter.py`
+   - Report results to the human
+   - **Do not close the pane yet**
 
-2b. 人間が承認した場合（「OK」「確認した」「問題ない」等）:
-   - `org-state.md` の該当Work Itemを **COMPLETED** に更新
-   - ワーカーの状態ファイルを最終更新
-   - `journal.jsonl` にイベント追記
-   - 必要に応じて窓口がプッシュ・PR作成を行う（ワーカーには権限がないため）
-   - フォアマンにペインクローズを依頼:
-     `CLOSE_PANE: {pane_id} のペインを閉じてください。`
-   - **ディレクトリパターンに応じた後処理**:
-     - パターン A（プロジェクトディレクトリ）: ディレクトリは保持する（次タスクで再利用）
-     - パターン B（worktree）: `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}` を実行。ブランチは残す（PR/マージ用）
-     - パターン C（エフェメラル）: ディレクトリは保持する（容量が問題になった場合のみ手動削除を検討）
-   - `.state/org-state.md` の Worker Directory Registry を更新:
-     - パターン A: ステータスを `available` に更新（次タスクで再利用可能）
-     - パターン B: エントリを削除（worktree は除去済み）
-     - パターン C: エントリを削除
-   - JSON スナップショットを再生成する: `py -3 dashboard/org_state_converter.py`
+2b. On human approval ("OK", "looks good", "no problem", etc.):
+   - Update the corresponding Work Item in `org-state.md` to **COMPLETED**
+   - Make the final update to the Worker's state file
+   - Append an event to `journal.jsonl`
+   - The Lead does push / PR creation as needed (the Worker has no permission for these)
+   - Ask the Dispatcher to close the pane:
+     `CLOSE_PANE: please close pane {pane_id}.`
+   - **Post-processing per directory pattern**:
+     - Pattern A (project directory): keep the directory (reuse for the next task)
+     - Pattern B (worktree): run `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}`. Keep the branch (for PR/merge use)
+     - Pattern C (ephemeral): keep the directory (consider manual deletion only when capacity becomes an issue)
+   - Update the Worker Directory Registry of `.state/org-state.md`:
+     - Pattern A: set status to `available` (reusable for the next task)
+     - Pattern B: delete the entry (worktree already removed)
+     - Pattern C: delete the entry
+   - Regenerate the JSON snapshot: `py -3 dashboard/org_state_converter.py`
 
-2c. 人間がフィードバック・修正指示を出した場合:
-   - ワーカーに renga-peers で追加指示を送る (`to_id="worker-{task_id}"`)
-   - 追加指示が trivial fix（CI 出力整形 / typo / コメント修正等）なら **検証深度 `minimal`** を明示し、完了報告は `done: {commit SHA 短縮形} {変更ファイル名}` の 1 行だけで返すよう伝える（フォーマットは `references/instruction-template.md` / `references/worker-claude-template.md` に従う）
-   - `org-state.md` の該当Work Itemを **IN_PROGRESS** に戻す
-   - `journal.jsonl` にイベント追記
-   - JSON スナップショットを再生成する: `py -3 dashboard/org_state_converter.py`
-   - （ペインが生きているのでワーカーはそのまま作業続行）
+2c. When the human gives feedback / a correction directive:
+   - Send an additional instruction to the Worker via renga-peers (`to_id="worker-{task_id}"`)
+   - If the additional instruction is a trivial fix (CI output formatting / typo / comment edits, etc.), explicitly state **verification depth `minimal`** and tell the Worker that the completion report should be the single line `done: {short commit SHA} {changed file name}` (the format follows `references/instruction-template.md` / `references/worker-claude-template.md`)
+   - Revert the corresponding Work Item in `org-state.md` to **IN_PROGRESS**
+   - Append an event to `journal.jsonl`
+   - Regenerate the JSON snapshot: `py -3 dashboard/org_state_converter.py`
+   - (Since the pane is still alive, the Worker continues the work as-is)
 
-### ワーカー監視と介入判定（窓口が実行）
+### Worker monitoring and intervention judgment (Lead executes)
 
-派遣後、ワーカーが深掘り・過剰検証ループに入っていないか定期的に確認する:
+After dispatch, periodically check whether the Worker has fallen into a deep-dive / over-verification loop:
 
-**介入トリガー**（いずれか 1 つ以上該当したら `mcp__renga-peers__inspect_pane` で状況確認する）:
-- 同一タスクで 30 分超経過、かつ同じフェーズ（実装 / レビュー / 検証）に 3 回目以降入っている
-- 1 時間以上進捗報告なしで静穏（入力待ちでもなく、progress ログも出ない）
-- (codex を使っている場合) Codex セルフレビューが 4 ラウンド目以降に入っている（3 ラウンド上限はワーカー側指示だが、window 側でも確認）。codex 未導入環境ではこのトリガーは無関係
+**Intervention triggers** (if any one applies, check the situation via `mcp__renga-peers__inspect_pane`):
+- Same task running for over 30 minutes and entering the same phase (implementation / review / verification) for the 3rd or later time
+- No progress report for over 1 hour in silence (not waiting on input, no progress log either)
+- (When using codex) Codex self-review has entered the 4th round or later (the 3-round cap is a Worker-side directive, but the Lead also checks). Irrelevant in environments where codex is not installed
 
-**介入手順**:
-1. `inspect_pane` で画面を確認（Running / Codex 実行中 / 入力待ちのいずれか判定）
-2. 深掘りと判断したら `send_keys(target="worker-{task_id}", keys=["Escape"])` で中断
-3. `send_message` で tight な修正指示を送る。例:
-   - 「検証深度 minimal に切り替えます。Codex レビュー・追加テスト禁止。いま書いた変更を commit して `done: {commit SHA 短縮形} {変更ファイル名}` の 1 行だけ返してください」
-   - 「Minor は残置で OK。README に既知制限として 1 行追記したら完了報告してください（検証深度 full のままなので通常の完了報告フォーマット）」
+**Intervention procedure**:
+1. Inspect the screen via `inspect_pane` (judge as one of: Running / Codex running / awaiting input)
+2. If judged a deep dive, interrupt with `send_keys(target="worker-{task_id}", keys=["Escape"])`
+3. Send a tight correction instruction via `send_message`. Examples:
+   - "Switching verification depth to minimal. No Codex review or additional tests. Commit what you have and reply with only the single line `done: {short commit SHA} {changed file name}`."
+   - "Minor findings can stay. Add a 1-line note as a known limitation in README, then send the completion report (verification depth stays `full`, so use the normal completion-report format)."
 
-**注意**: 窓口が自らワーカーの worktree で commit を代行することは auto-mode classifier によりブロックされる（スコープ逸脱）。介入はあくまで「指示の再送」で行うこと。
-3. ブロック報告の場合:
-   - 人間に判断を仰ぐ
+**Note**: the Lead committing on behalf of the Worker in the Worker's worktree is blocked by the auto-mode classifier (out of scope). Intervention is always via "re-sending the instruction".
+3. For a blocker report:
+   - Ask the human for judgment

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -180,7 +180,7 @@ Prepare a dedicated directory for each task and place CLAUDE.md and settings.
 Use the template references/worker-claude-template.md.
 **The procedure differs by pattern (A/B/C).**
 
-> **For tasks that edit claude-org itself**: in addition to the normal procedure, always apply the special procedure in `references/claude-org-self-edit.md` (excluding the block-org-structure.sh hook, writing instructions to CLAUDE.local.md, and explicitly noting that the root CLAUDE.md should be ignored). **In this section and below, wherever it says "generate / place / verify CLAUDE.md", read it as `CLAUDE.local.md`** (the root CLAUDE.md is for the Secretary, so do not overwrite it).
+> **For tasks that edit claude-org itself**: in addition to the normal procedure, always apply the special procedure in `references/claude-org-self-edit.md` (excluding the block-org-structure.sh hook, writing instructions to CLAUDE.local.md, and explicitly noting that the root CLAUDE.md should be ignored). **In this section and below, wherever it says "generate / place / verify CLAUDE.md", read it as `CLAUDE.local.md`** (the root CLAUDE.md is for the Lead, so do not overwrite it).
 
 ### Common procedure (all patterns)
 
@@ -335,7 +335,7 @@ Call `mcp__renga-peers__list_panes` and extract every pane's attributes from the
 **Step 4. MIN_PANE constraint**:
 - Keep only panes with `new_w >= MIN_PANE_WIDTH` and `new_h >= MIN_PANE_HEIGHT`
 
-**Step 5. Secretary insurance clause**:
+**Step 5. Lead pane insurance clause**:
 - Keep `role == "secretary"` panes only when `new_w >= SECRETARY_MIN_WIDTH` **and** `new_h >= SECRETARY_MIN_HEIGHT` (passing width alone is not enough; height must also pass)
 
 **Step 6. Sort & select**:

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -1,46 +1,46 @@
-# claude-org 自身を編集するタスクの特例
+# Special handling when editing claude-org itself
 
-> **前提（Pattern 判定）**: 対象ファイルが gitignored（例: `docs/internal/`, `notes/`, `tmp/` 配下の内部メモ）の場合は、SKILL.md Step 1 の「事前チェック: 対象ファイルが git tracked か」により **Pattern C 強制**となる。本ドキュメントの特例（hook 除外・`CLAUDE.local.md`）は Pattern B / C いずれでも適用するが、Pattern C の場合 worktree は作らないため WORKER_DIR は対象ファイルにアクセスできる既存リポジトリ root を指定する。以下は Pattern B（tracked ファイル編集）を主に想定した手順。
+> **Premise (Pattern decision)**: when the target file is gitignored (e.g. internal memos under `docs/internal/`, `notes/`, `tmp/`), the "Pre-check: is the target file git-tracked?" in SKILL.md Step 1 forces **Pattern C**. The special handling in this document (hook exclusion, `CLAUDE.local.md`) applies under both Pattern B and Pattern C, but in Pattern C no worktree is created — instead, set WORKER_DIR to the existing repository root that has access to the target file. The procedure below mainly assumes Pattern B (editing tracked files).
 
-claude-org リポジトリのスキル / ドキュメント / 設定を編集するワーカーを派遣するとき、通常の worktree 準備のままでは以下の事故が発生する:
+When dispatching a Worker that edits the claude-org repository's skills / docs / settings, the normal worktree preparation alone causes the following accidents:
 
-- `block-org-structure.sh` hook が `.claude/skills/` などへの Edit / Write を拒否する（`bypassPermissions` モードでも exit code 2 により確認プロンプトが出る）
-- ルートの `CLAUDE.md` は Secretary（窓口）用の指示なので、ワーカーがこれを読んで「あなたは窓口」と誤認する
+- The `block-org-structure.sh` hook rejects Edit / Write to `.claude/skills/` and similar (a confirmation prompt fires due to exit code 2 even in `bypassPermissions` mode)
+- The root `CLAUDE.md` is the Secretary (Lead) directive, so a Worker reading it would mistakenly conclude "you are the Lead"
 
-このため、claude-org 自己編集タスクでは **Step 1.5 のワーカーディレクトリ準備時に以下 3 点を通常手順に追加する**。
+Therefore, for claude-org self-edit tasks, **the following 3 items are added to the normal procedure during Step 1.5 Worker directory preparation**.
 
-## 1. `block-org-structure.sh` hook を worktree の settings.local.json から除外する
+## 1. Exclude the `block-org-structure.sh` hook from the worktree's settings.local.json
 
-worktree 直下の `.claude/settings.local.json` を配置する際、`hooks.PreToolUse` から `block-org-structure.sh` エントリを **除外**すること。`Edit|Write` matcher と `Bash` matcher の両方で除外する必要がある。
+When placing `.claude/settings.local.json` directly under the worktree, **exclude** the `block-org-structure.sh` entry from `hooks.PreToolUse`. You must exclude it under both the `Edit|Write` matcher and the `Bash` matcher.
 
-他の hook（例: `block-git-push.sh`, `block-workers-delete.sh`, `check-worker-boundary.sh` 等）は通常どおり残してよい。除外対象はあくまで claude-org 構造のブロック hook のみ。
+Other hooks (e.g. `block-git-push.sh`, `block-workers-delete.sh`, `check-worker-boundary.sh`, etc.) may remain as usual. The exclusion target is strictly the claude-org structure-blocking hook only.
 
-## 2. ワーカー指示は `CLAUDE.md` ではなく `CLAUDE.local.md` に書く
+## 2. Write Worker instructions to `CLAUDE.local.md`, not `CLAUDE.md`
 
-ルートの `CLAUDE.md` は Secretary 用の指示なので、ワーカー用 CLAUDE.md で上書きしてはならない（他ロールが壊れる）。
-ワーカーへの指示は worktree 直下の `CLAUDE.local.md` に書く（git 管理外）。
+The root `CLAUDE.md` is the Secretary directive, so do not overwrite it with the Worker's CLAUDE.md (other roles would break).
+Write the Worker instruction to `CLAUDE.local.md` directly under the worktree (untracked by git).
 
-Claude Code は同一ディレクトリの `CLAUDE.md` と `CLAUDE.local.md` の両方を読み込むため、ワーカーには両方が見える。
+Claude Code reads both `CLAUDE.md` and `CLAUDE.local.md` in the same directory, so the Worker can see both.
 
-### 通常手順の読み替え（重要）
+### Re-reading the normal procedure (important)
 
-claude-org 自己編集タスクでは、SKILL.md Step 1.5 および `worker-claude-template.md` / `instruction-template.md` が「CLAUDE.md を生成 / 配置 / 確認」と指示している箇所を、すべて **`CLAUDE.local.md` に読み替える**こと:
+For claude-org self-edit tasks, wherever SKILL.md Step 1.5, `worker-claude-template.md`, or `instruction-template.md` says "generate / place / verify CLAUDE.md", **read it as `CLAUDE.local.md`**:
 
-- Step 1.5 共通手順の「CLAUDE.md を生成する（テンプレートの変数を置換）」 → 生成先を `CLAUDE.local.md` にする。`worker-claude-template.md` の本文をそのままテンプレートとして流用してよい
-- Step 1.5 共通手順（配置後）の「生成した CLAUDE.md に『作業ディレクトリ（最重要制約）』セクションが含まれていることを確認」 → 生成した `CLAUDE.local.md` を対象に確認する
-- `instruction-template.md` の「詳細な行動規範は CLAUDE.md に記載されています」「CLAUDE.md に記載された絶対パス」 → 該当箇所を `CLAUDE.local.md` に書き換えてワーカーへ送信する
-- 参考 work-skill セクション追加先も `CLAUDE.local.md` に向けること
+- "Generate CLAUDE.md (substitute template variables)" in Step 1.5 common procedure → make the generation target `CLAUDE.local.md`. You may reuse the body of `worker-claude-template.md` as the template
+- "Verify the generated CLAUDE.md contains the 'Working directory (most important constraint)' section" in Step 1.5 common procedure (after placement) → verify against the generated `CLAUDE.local.md`
+- "Detailed code of conduct is described in CLAUDE.md" / "absolute path described in CLAUDE.md" in `instruction-template.md` → rewrite those passages to refer to `CLAUDE.local.md` before sending to the Worker
+- The reference work-skill section is also added to `CLAUDE.local.md`
 
-ルートの `CLAUDE.md`（Secretary 指示）はいかなる場合も上書きしない。
+Do not overwrite the root `CLAUDE.md` (Secretary directive) under any circumstances.
 
-## 3. `CLAUDE.local.md` 冒頭で「ルート CLAUDE.md は無視」を明示する
+## 3. Make "ignore the root CLAUDE.md" explicit at the top of `CLAUDE.local.md`
 
-`CLAUDE.local.md` の最初に以下の趣旨を必ず書く:
+Always write the following intent at the top of `CLAUDE.local.md`:
 
-> このワーカーは claude-org リポジトリ自身の worktree で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
+> This Worker operates in a worktree of the claude-org repository itself. Ignore the Secretary directive in `./CLAUDE.md` (the root CLAUDE.md). You are not the Lead — you are a Worker.
 
-この明示がないと、ワーカーがルート CLAUDE.md を先に読んで Secretary として振る舞い始める（/org-start の実行を促す等）。
+Without this notice, the Worker reads the root CLAUDE.md first and starts behaving as the Secretary (e.g. prompting `/org-start`).
 
-## 根拠
+## Rationale
 
-`knowledge/curated/delegation.md` の「claude-org 自身を編集するワーカーは worktree 内の設定を事前に調整する」セクション参照。
+See the section "When dispatching a Worker that edits claude-org itself, adjust the in-worktree settings up front" in `knowledge/curated/delegation.md`.

--- a/.claude/skills/org-delegate/references/claude-org-self-edit.md
+++ b/.claude/skills/org-delegate/references/claude-org-self-edit.md
@@ -5,7 +5,7 @@
 When dispatching a Worker that edits the claude-org repository's skills / docs / settings, the normal worktree preparation alone causes the following accidents:
 
 - The `block-org-structure.sh` hook rejects Edit / Write to `.claude/skills/` and similar (a confirmation prompt fires due to exit code 2 even in `bypassPermissions` mode)
-- The root `CLAUDE.md` is the Secretary (Lead) directive, so a Worker reading it would mistakenly conclude "you are the Lead"
+- The root `CLAUDE.md` is the Lead directive, so a Worker reading it would mistakenly conclude "you are the Lead"
 
 Therefore, for claude-org self-edit tasks, **the following 3 items are added to the normal procedure during Step 1.5 Worker directory preparation**.
 
@@ -17,7 +17,7 @@ Other hooks (e.g. `block-git-push.sh`, `block-workers-delete.sh`, `check-worker-
 
 ## 2. Write Worker instructions to `CLAUDE.local.md`, not `CLAUDE.md`
 
-The root `CLAUDE.md` is the Secretary directive, so do not overwrite it with the Worker's CLAUDE.md (other roles would break).
+The root `CLAUDE.md` is the Lead's directive, so do not overwrite it with the Worker's CLAUDE.md (other roles would break).
 Write the Worker instruction to `CLAUDE.local.md` directly under the worktree (untracked by git).
 
 Claude Code reads both `CLAUDE.md` and `CLAUDE.local.md` in the same directory, so the Worker can see both.
@@ -31,15 +31,15 @@ For claude-org self-edit tasks, wherever SKILL.md Step 1.5, `worker-claude-templ
 - "Detailed code of conduct is described in CLAUDE.md" / "absolute path described in CLAUDE.md" in `instruction-template.md` → rewrite those passages to refer to `CLAUDE.local.md` before sending to the Worker
 - The reference work-skill section is also added to `CLAUDE.local.md`
 
-Do not overwrite the root `CLAUDE.md` (Secretary directive) under any circumstances.
+Do not overwrite the root `CLAUDE.md` (the Lead's directive) under any circumstances.
 
 ## 3. Make "ignore the root CLAUDE.md" explicit at the top of `CLAUDE.local.md`
 
 Always write the following intent at the top of `CLAUDE.local.md`:
 
-> This Worker operates in a worktree of the claude-org repository itself. Ignore the Secretary directive in `./CLAUDE.md` (the root CLAUDE.md). You are not the Lead — you are a Worker.
+> This Worker operates in a worktree of the claude-org repository itself. Ignore the Lead directive in `./CLAUDE.md` (the root CLAUDE.md). You are not the Lead — you are a Worker.
 
-Without this notice, the Worker reads the root CLAUDE.md first and starts behaving as the Secretary (e.g. prompting `/org-start`).
+Without this notice, the Worker reads the root CLAUDE.md first and starts behaving as the Lead (e.g. prompting `/org-start`).
 
 ## Rationale
 

--- a/.claude/skills/org-delegate/references/instruction-template.md
+++ b/.claude/skills/org-delegate/references/instruction-template.md
@@ -1,113 +1,113 @@
-# ワーカーへの指示テンプレート
+# Worker instruction template
 
-renga-peers の send_message（`to_id="worker-{task_id}"`）で送信する、タスク固有の指示。
-権限・報告先・SUSPEND対応・知見記録の指示は worker-claude-template.md（CLAUDE.md経由）に一元化されているため、ここでは繰り返さない。
+The task-specific instruction sent via renga-peers `send_message` (`to_id="worker-{task_id}"`).
+Permissions, reporting destinations, SUSPEND handling, and knowledge recording are consolidated in worker-claude-template.md (via CLAUDE.md), so they are not repeated here.
 
-## テンプレート
+## Template
 
 ```
-以下のタスクを遂行してください。詳細な行動規範は CLAUDE.md に記載されています。
+Please carry out the following task. Detailed code of conduct is described in CLAUDE.md.
 
-## タスク
-{タスクの目的と期待する成果物を具体的に記述}
+## Task
+{Concretely describe the task's goal and the expected deliverable}
 
-## プロジェクトの準備
-重要: あなたの作業ディレクトリは CLAUDE.md に記載された絶対パスです。
-まず `pwd` を実行し、CLAUDE.md の作業ディレクトリと一致することを確認してください。
-全てのファイル作成はこのディレクトリ内に限定。`..` への移動や claude-org 構造の再現は禁止です。
-{ディレクトリパターンに応じて以下のいずれかを指示}
+## Project preparation
+Important: your working directory is the absolute path described in CLAUDE.md.
+First, run `pwd` and confirm it matches the working directory in CLAUDE.md.
+All file creation is restricted to inside that directory. Moving to `..` and reproducing the claude-org structure is prohibited.
+{Choose one of the following based on the directory pattern}
 
-### パターン A（プロジェクトディレクトリ・初回）の場合:
-{以下のいずれかを指示}
-- ローカル既存プロジェクトの場合: カレントディレクトリ内で `git clone {ローカルパス}` を実行してください。
-- リモートリポジトリの場合: カレントディレクトリ内で `git clone {URL}` を実行してください。
-- 新規プロジェクトの場合: カレントディレクトリ（`pwd` の出力パス）で `git init` し、直接ファイルを作成してください。claude-org の構造を真似たディレクトリ（.claude/, .state/ 等）を作らないでください。
+### Pattern A (project directory, first time):
+{Choose one of the following}
+- For an existing local project: run `git clone {local path}` inside the current directory.
+- For a remote repository: run `git clone {URL}` inside the current directory.
+- For a new project: run `git init` in the current directory (the path output by `pwd`) and create files directly. Do not create directories that mimic the claude-org structure (.claude/, .state/, etc.).
 
-### パターン A（プロジェクトディレクトリ・再利用）の場合:
-このディレクトリは以前のタスクで使用されたプロジェクトディレクトリです。既存のファイルとgit履歴が残っています。
-clone は不要です。{引き継ぎ事項があれば記載}
+### Pattern A (project directory, reuse):
+This directory was used by a previous task. Existing files and git history remain.
+No clone is needed. {Note any handoff items}
 
-### パターン B（worktree）の場合:
-このディレクトリは git worktree として準備済みです。ブランチ `{branch_name}` にチェックアウトされています。
-clone は不要です。そのまま作業を開始してください。
+### Pattern B (worktree):
+This directory is prepared as a git worktree, checked out on branch `{branch_name}`.
+No clone is needed. Start working directly.
 
-### パターン C（エフェメラル）の場合:
-{以下のいずれかを指示}
-- 既存リポジトリの場合: カレントディレクトリ内で `git clone {URL}` を実行し、クローンされたディレクトリ内で作業してください
-- ローカル既存プロジェクトの場合: カレントディレクトリ内で `git clone {ローカルパス}` を実行してください
-- 新規プロジェクトの場合: カレントディレクトリ（`pwd` の出力パス）で `git init` し、直接ファイルを作成してください。claude-org の構造を真似たディレクトリ（.claude/, .state/ 等）を作らないでください
+### Pattern C (ephemeral):
+{Choose one of the following}
+- For an existing repository: run `git clone {URL}` inside the current directory and work inside the cloned directory
+- For an existing local project: run `git clone {local path}` inside the current directory
+- For a new project: run `git init` in the current directory (the path output by `pwd`) and create files directly. Do not create directories that mimic the claude-org structure (.claude/, .state/, etc.)
 
-## ブランチ戦略
-{ブランチ名の指定、またはmainで直接作業等}
+## Branch strategy
+{Specify the branch name, or work directly on main, etc.}
 
-## 作業の進め方
-auto モードで直接作業してください。Plan モードは使用しないこと。
+## How to work
+Work directly in auto mode. Do not use Plan mode.
 
-## 制約
-{使用言語、フレームワーク、テスト要件等があれば記載}
+## Constraints
+{Note any language, framework, test requirements, etc.}
 
-## 検証深度: {full | minimal}
-この行はテンプレートから**削除せず必ず送信する**。窓口は 2 値のどちらか 1 つだけを埋める。
-既定は `full`。trivial fix のときのみ `minimal` を窓口側で選択して埋めること。
+## Verification depth: {full | minimal}
+**Do not delete this line**; always send it. The Lead fills in exactly one of the two values.
+The default is `full`. Choose `minimal` only for trivial fixes; the Lead is the one filling it in.
 
-- **full**（新機能実装 / 修正 / リファクタ / テスト追加 / hook・skill・設定編集など、コードまたは挙動の変更を伴うもの）
-  - **codex の有無に関わらず必須**: 既存テストスイート / lint / type-check 等のリポジトリ通常検証を green まで実行し、通常の完了報告フォーマット（成果物説明・残作業・PR 草案 / 振り返り記録）で報告
-  - **追加ゲート（任意）**: commit 完了後に `codex` CLI が available なら `codex exec --skip-git-repo-check` で Codex セルフレビューを実行する
-    - 確認コマンド: `command -v codex`（Bash/zsh）/ `Get-Command codex -ErrorAction SilentlyContinue`（PowerShell）
-    - codex 未導入環境ではセルフレビューを skip し、上記の通常検証だけで完了報告に進む（以下のラウンド規律は適用されない）
-  - **以下は codex を実行した場合のみ適用**:
-    - Blocker / Major は修正コミットを積んでから完了報告
-    - **同一指摘カテゴリ（例: loose match 精緻化 / 型絞り等）で 3 ラウンド消せない場合は設計問題**。即完了報告し、窓口に仕様縮小の判断を仰ぐ（無限ループ防止）
-    - Minor / Nit は原則残置。README / Issue / PR 本文に既知制限として明記する
-    - `codex:rescue` スキルは使用しないこと（18 分超ハング事例あり、`codex exec` 直打ちが安定）
-  - レビュー指示例: `codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"`
+- **full** (new feature implementation / fix / refactor / adding tests / hook / skill / settings edits, etc., anything that changes code or behavior)
+  - **Required regardless of whether codex is available**: run the repository's normal verification (existing test suite / lint / type-check, etc.) to green and report in the normal completion format (deliverable description, remaining work, PR draft / retro record)
+  - **Additional gate (optional)**: after commit completes, if the `codex` CLI is available, run Codex self-review via `codex exec --skip-git-repo-check`
+    - Detection commands: `command -v codex` (Bash/zsh) / `Get-Command codex -ErrorAction SilentlyContinue` (PowerShell)
+    - In environments where codex is not installed, skip the self-review and proceed to the completion report on the normal verification alone (the round discipline below does not apply)
+  - **The following applies only when codex was run**:
+    - Stack a fix commit before the completion report for Blocker / Major
+    - **If the same finding category (e.g. loose-match precision / type narrowing, etc.) cannot be eliminated in 3 rounds, treat it as a design issue**. Send the completion report immediately and ask the Lead for a scope-reduction decision (to prevent infinite loops)
+    - Minor / Nit are left in place by default. Document them as known limitations in README / Issue / PR body
+    - Do not use the `codex:rescue` skill (there are cases of >18-minute hangs; direct `codex exec` is more stable)
+  - Example review instruction: `codex exec --skip-git-repo-check "Review the diff between this branch and main. Classify findings as Blocker/Major/Minor/Nit and add target file:line and the rationale to each, concise in Japanese"`
 
-- **minimal**（trivial fix: CI 出力整形 / typo / コメント修正 / 既存テスト形式合わせ等、指示で変更箇所が 1 ファイル数行に限定されるもの）
-  - 指示された fix を反映 → `git add` → `git commit` 直行
-  - Codex セルフレビュー・追加テスト実行・差分確認を超えた動作検証は**一切禁止**
-  - 完了報告は窓口（`secretary`）に送信する 1 行:
-    - `done: {commit SHA 短縮形} {変更ファイル名}`（例: `done: be8f497 tests/test-block-pretooluse-hooks.sh`）
-    - SHA は `git rev-parse --short HEAD`、ファイル名は単独ファイルなら 1 つ、複数なら空白区切り
-    - これ以外の情報（成果物説明・PR 草案・残論点等）は不要。push / PR 起票は窓口側で実施する
-  - 振り返り記録（`knowledge/raw/`）は minimal では**不要**（trivial fix に再利用可能な学びはない前提）。非自明な発見があれば `full` と同様 1 件作ってよい
+- **minimal** (trivial fixes: CI output formatting / typo / comment edits / matching to existing test format, etc., where the instruction limits changes to a few lines in 1 file)
+  - Apply the requested fix → `git add` → `git commit` straight through
+  - Operational checks beyond Codex self-review / additional test runs / diff inspection are **strictly forbidden**
+  - The completion report is a single line sent to the Lead (`secretary`):
+    - `done: {short commit SHA} {changed file name}` (e.g. `done: be8f497 tests/test-block-pretooluse-hooks.sh`)
+    - SHA is from `git rev-parse --short HEAD`; file name is one if a single file, space-separated if multiple
+    - Other information (deliverable description, PR draft, remaining points, etc.) is unnecessary. push / PR creation are done on the Lead side
+  - Retro record (`knowledge/raw/`) is **not needed** for minimal (trivial fixes are presumed to have no reusable lessons). If you make a non-obvious discovery, you may create one as in `full`
 
-**選択は窓口の責任**。ワーカーは指示に書かれた値（`full` or `minimal`）にそのまま従い、自分で切り替え判断をしないこと。派遣時にこの行自体が送信されなかった・または値が不明瞭だった場合はワーカーから窓口に確認すること（勝手に `full` にフォールバックしない）。
+**Choosing the value is the Lead's responsibility.** The Worker follows the value (`full` or `minimal`) as written in the instruction; do not switch on your own. If this line itself was not sent at dispatch time, or the value is unclear, the Worker should confirm with the Lead (do not silently fall back to `full`).
 ```
 
-## cross-cutting operational change の場合の consistency grep target list
+## Consistency grep target list for cross-cutting operational changes
 
-運用モード・共通設定・命名規約のような **cross-cutting な変更**（1 ファイルに閉じず、複数のロール / skill / 設定 / ドキュメントを横断する変更）を委譲するときは、ワーカー指示の「制約」または「タスク」セクションに、整合性確認のための grep スコープを明示する。スコープを書かないと、ワーカーは目に付いたファイルだけ直して、別ロール側 / docs 側の同名参照を取りこぼす（rename / mode 変更で起きやすい）。
+When delegating a **cross-cutting change** (one that does not stay in a single file but spans multiple roles / skills / settings / docs) — such as operational mode, common settings, naming conventions — explicitly state the grep scope for consistency check in the "Constraints" or "Task" section of the Worker instruction. Without scope, the Worker fixes only the files in front of them and misses the same-name references on the other-role / docs side (often happens with renames / mode changes).
 
-### 「cross-cutting」と判定する例
+### Examples judged as "cross-cutting"
 
-- **運用モード変更**: Plan / auto / `bypassPermissions` 等のデフォルト切り替え
-- **permissions / hook 設定の wholesale 変更**: `.claude/settings*.json` の allow / deny / hooks を横断的に書き換える
-- **communication channel / MCP server 名変更**: renga-peers の peer 名・MCP サーバ名・ロール識別子の rename（例: `foreman` → `dispatcher`）
-- **共通 flag / env var の追加削除**: 全ロール / 複数 skill が読む環境変数や CLI flag
+- **Operational mode change**: switching the default of Plan / auto / `bypassPermissions` etc.
+- **Wholesale change of permissions / hook settings**: cross-cutting rewrites to allow / deny / hooks of `.claude/settings*.json`
+- **Renaming communication channels / MCP server names**: renaming peer names of renga-peers / MCP server names / role identifiers (e.g. `foreman` → `dispatcher`)
+- **Adding / removing common flags / env vars**: environment variables or CLI flags read by all roles or multiple skills
 
-逆に、1 つの skill / 1 つのロール内に閉じる挙動変更（例: `org-retro` 内のフォーマット調整）は cross-cutting ではないので、このセクションは不要。
+Conversely, behavior changes confined to a single skill or role (e.g. format adjustment within `org-retro`) are not cross-cutting, so this section is unneeded.
 
-### 推奨 grep target ディレクトリ
+### Recommended grep target directories
 
-cross-cutting と判定したら、**最低限以下を grep スコープとしてワーカー指示に列挙する**。プロジェクト構成によって存在しないものは適宜削る:
+If judged cross-cutting, **enumerate at least the following as the grep scope** in the Worker instruction. Trim those that don't exist depending on the project layout:
 
-- `.claude/` — skill 本体（`skills/`）に加えて `settings.json` / `settings.local.json` まで含めること。permissions / hook / env 変更は設定本体に残ることが多く、`.claude/skills/` だけ走査すると正典設定を取りこぼす
+- `.claude/` — in addition to skills (`skills/`), include `settings.json` / `settings.local.json`. Permissions / hook / env changes often remain in the settings themselves; scanning only `.claude/skills/` misses the canonical settings
 - `registry/` — projects.md / org-config.md / worker-directory.md
-- `knowledge/curated/` — 蓄積された運用知見（旧名で書かれた pattern が残りやすい）
-- `dashboard/` — JSON 生成スクリプト・テンプレ
-- `.dispatcher/` — フォアマン（dispatcher）ロールの runtime / プロンプト
-- `.curator/` — キュレーターロールの runtime / プロンプト
-- `.hooks/` — PreToolUse / PostToolUse の hook スクリプト本体（hook ファイル名・ロール識別子の参照が残る）
-- `docs/` — 公開ドキュメント
-- `tools/` — チェッカ・補助スクリプト（`check_role_configs.py` 等）
-- `tests/` — hook / runner / checker のテスト（rename / mode 変更で fixture 名が漏れると CI を壊す）
+- `knowledge/curated/` — accumulated operational knowledge (patterns written under old names tend to remain)
+- `dashboard/` — JSON generation scripts and templates
+- `.dispatcher/` — Dispatcher role's runtime / prompt
+- `.curator/` — Curator role's runtime / prompt
+- `.hooks/` — PreToolUse / PostToolUse hook scripts themselves (references to hook file names / role identifiers tend to remain)
+- `docs/` — public documentation
+- `tools/` — checkers / helper scripts (`check_role_configs.py`, etc.)
+- `tests/` — hook / runner / checker tests (missing fixture names from rename / mode changes can break CI)
 
-ワーカー指示の例:
+Example Worker instruction:
 
 ```
-## 制約
-- 旧名 `foo` の参照が以下のディレクトリに残っていないか grep し、見つけたら全て新名 `bar` に置換すること:
-  - .claude/                （settings.json / settings.local.json も含む）
+## Constraints
+- grep for any remaining references to old name `foo` in the following directories, and replace all with the new name `bar` if found:
+  - .claude/                (also include settings.json / settings.local.json)
   - registry/
   - knowledge/curated/
   - dashboard/
@@ -117,13 +117,13 @@ cross-cutting と判定したら、**最低限以下を grep スコープとし�
   - docs/
   - tools/
   - tests/
-- grep コマンド例（Bash / Git Bash / WSL）: `grep -rn "foo" .claude/ registry/ knowledge/curated/ dashboard/ .dispatcher/ .curator/ .hooks/ docs/ tools/ tests/`
-- grep コマンド例（PowerShell）: `Select-String -Path .claude\,registry\,knowledge\curated\,dashboard\,.dispatcher\,.curator\,.hooks\,docs\,tools\,tests\ -Pattern "foo" -Recurse`
+- Example grep command (Bash / Git Bash / WSL): `grep -rn "foo" .claude/ registry/ knowledge/curated/ dashboard/ .dispatcher/ .curator/ .hooks/ docs/ tools/ tests/`
+- Example grep command (PowerShell): `Select-String -Path .claude\,registry\,knowledge\curated\,dashboard\,.dispatcher\,.curator\,.hooks\,docs\,tools\,tests\ -Pattern "foo" -Recurse`
 ```
 
-委譲時点で旧名 / 新名が確定していない場合は、ワーカーに「対象パターンを検出して一覧化 → 窓口に確認 → 置換」の 2 段で動かすこと。
+If the old / new names are not yet decided at delegation time, run the Worker in two steps: "detect the target patterns and list them → confirm with the Lead → replace".
 
-## 使用時の注意
+## Notes on use
 
-- タスクの記述は具体的に。曖昧な指示はワーカーの判断コストを上げる
-- 制約がある場合は必ず明示する
+- Make the task description concrete; ambiguous instructions raise the Worker's judgment cost
+- Always state constraints explicitly when there are any

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -11,7 +11,7 @@ The Lead (`secretary`) / Dispatcher / Curator come up in the same tab; Workers a
 Tab 1: ops (zero workers)
 ┌────────────────────┬────────────────────┐
 │                    │                    │
-│                    │     Secretary      │
+│                    │       Lead         │
 │                    │     (top half)     │
 │                    │                    │
 │                    ├──────────┬─────────┤
@@ -20,7 +20,7 @@ Tab 1: ops (zero workers)
 └────────────────────┴──────────┴─────────┘
 ```
 
-> ※ In practice, `secretary` is sometimes on the left and `dispatcher/curator` occupy the bottom half — initial layout details are entrusted to org-start. The point that matters here is "build the Worker zone via balanced splits from the dispatcher pane's rect".
+> ※ In practice, the Lead pane is sometimes on the left and `dispatcher/curator` occupy the bottom half — initial layout details are entrusted to org-start. The point that matters here is "build the Worker zone via balanced splits from the dispatcher pane's rect".
 
 ## Placement rules
 
@@ -30,7 +30,7 @@ Tab 1: ops (zero workers)
 | Curator | Vertically split the Dispatcher pane and take the right half | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="{default_permission_mode}")` (org-start Step 3) |
 | Each Worker | **Balanced split**: dynamically pick target and direction from the current rect returned by `list_panes`, and stack into the same tab | See "Worker balanced split strategy" below for details. `mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="{default_permission_mode}")` (org-delegate Step 3) |
 
-> **Why we use `spawn_claude_pane`**: structured launch tool added in renga 0.18.0+. Passing `cwd` / `permission_mode` / `model` / `args[]` as structured fields makes renga internally compose `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old method (feeding a `cd`-prefixed command string into `spawn_pane`) is **prohibited** (the cwd-changing prefix prevents renga's bare-`claude` auto-upgrade from firing, and `send_message`'s channel push fails to arrive — Lead → Dispatcher / Dispatcher → Worker instructions stop working entirely). Only the Secretary is started as a bare `claude` from `ops.toml` and relies on auto-upgrade.
+> **Why we use `spawn_claude_pane`**: structured launch tool added in renga 0.18.0+. Passing `cwd` / `permission_mode` / `model` / `args[]` as structured fields makes renga internally compose `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old method (feeding a `cd`-prefixed command string into `spawn_pane`) is **prohibited** (the cwd-changing prefix prevents renga's bare-`claude` auto-upgrade from firing, and `send_message`'s channel push fails to arrive — Lead → Dispatcher / Dispatcher → Worker instructions stop working entirely). Only the Lead is started as a bare `claude` from `ops.toml` and relies on auto-upgrade.
 
 ## Worker balanced split strategy
 
@@ -50,7 +50,7 @@ The Dispatcher launching a new Worker runs the following before calling `spawn_p
 2. **Candidate set**: panes with `role ∈ {worker, dispatcher, secretary}` (curator is always excluded)
 3. **Filter candidates**:
    - **Maintain dispatcher-curator adjacency**: keep dispatcher only when it is rect-adjacent (defined below) to curator. The dispatcher-curator adjacency is an organizational premise. Splitting dispatcher could break the adjacency, so dispatchers already non-adjacent are removed from candidates
-   - **Secretary protection**: secretary is a candidate only when post-split new pane width `new_w >= 125` **and** new pane height `new_h >= 45`. Insurance clause; rarely fires in practice. Width passing alone is not enough; height must also pass
+   - **Lead pane protection**: secretary is a candidate only when post-split new pane width `new_w >= 125` **and** new pane height `new_h >= 45`. Insurance clause; rarely fires in practice. Width passing alone is not enough; height must also pass
 4. **Direction decision** (from each candidate's aspect ratio):
    - `width > height * 2` → `vertical` (left/right split)
    - Otherwise → `horizontal` (top/bottom split)

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -1,18 +1,18 @@
 # Pane Layout Specification (renga-peers MCP)
 
-renga のペイン / タブ配置ルール。`org-start` と `org-delegate` が参照する。
-ペイン制御は `mcp__renga-peers__*` MCP ツール経由で行う（renga 0.18.0+ 前提。`spawn_claude_pane` / `set_pane_identity` を含む 14 ツールすべて MCP で完結）。
+renga pane / tab placement rules. Referenced by `org-start` and `org-delegate`.
+Pane control happens via the `mcp__renga-peers__*` MCP tools (assumes renga 0.18.0+; all 14 tools, including `spawn_claude_pane` / `set_pane_identity`, are MCP-complete).
 
-## 初期レイアウト (`renga --layout ops` の結果 + フォアマン・キュレーター起動後)
+## Initial layout (after `renga --layout ops` plus Dispatcher / Curator launch)
 
-窓口 (`secretary`) / フォアマン / キュレーターが同一タブに立ち上がり、ワーカーも同一タブ内に split で積んでいく方針。
+The Lead (`secretary`) / Dispatcher / Curator come up in the same tab; Workers are also stacked into the same tab via splits.
 
 ```
-Tab 1: ops (ワーカー 0 人)
+Tab 1: ops (zero workers)
 ┌────────────────────┬────────────────────┐
 │                    │                    │
 │                    │     Secretary      │
-│                    │     (上半分)       │
+│                    │     (top half)     │
 │                    │                    │
 │                    ├──────────┬─────────┤
 │                    │ Dispatcher  │ Curator │
@@ -20,97 +20,97 @@ Tab 1: ops (ワーカー 0 人)
 └────────────────────┴──────────┴─────────┘
 ```
 
-> ※ 実際には `secretary` が左で `dispatcher/curator` が下半分を占める構成もあり、初期レイアウト詳細は org-start に委ねる。本ドキュメントで重要なのは「`dispatcher` ペインの矩形から balanced split でワーカー zone を作っていく」という点。
+> ※ In practice, `secretary` is sometimes on the left and `dispatcher/curator` occupy the bottom half — initial layout details are entrusted to org-start. The point that matters here is "build the Worker zone via balanced splits from the dispatcher pane's rect".
 
-## 配置ルール
+## Placement rules
 
-| 対象 | 操作 | 備考 |
+| Target | Operation | Notes |
 |---|---|---|
-| フォアマン | 窓口ペインを水平分割して下半分 | `mcp__renga-peers__spawn_claude_pane(target="focused", direction="horizontal", role="dispatcher", name="dispatcher", cwd=".dispatcher", permission_mode="bypassPermissions", model="sonnet")` (org-start Step 2) |
-| キュレーター | フォアマンペインを垂直分割して右半分 | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="{default_permission_mode}")` (org-start Step 3) |
-| 各ワーカー | **balanced split**: `list_panes` が返す現在の rect から target と direction を動的に選び、同一タブ内に積む | 詳細は下記「ワーカーの balanced split 戦略」セクション。`mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="{default_permission_mode}")` (org-delegate Step 3) |
+| Dispatcher | Horizontally split the Lead pane and take the bottom half | `mcp__renga-peers__spawn_claude_pane(target="focused", direction="horizontal", role="dispatcher", name="dispatcher", cwd=".dispatcher", permission_mode="bypassPermissions", model="sonnet")` (org-start Step 2) |
+| Curator | Vertically split the Dispatcher pane and take the right half | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="{default_permission_mode}")` (org-start Step 3) |
+| Each Worker | **Balanced split**: dynamically pick target and direction from the current rect returned by `list_panes`, and stack into the same tab | See "Worker balanced split strategy" below for details. `mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="{default_permission_mode}")` (org-delegate Step 3) |
 
-> **`spawn_claude_pane` を使う理由**: renga 0.18.0+ で追加された構造化 launch ツール。`cwd` / `permission_mode` / `model` / `args[]` を構造化フィールドで渡すと、renga が内部で `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...` を合成する。旧方式（`cd`-プレフィックス付き command 文字列を `spawn_pane` に流し込む）は **禁止**（cwd 変更プレフィックスがあると renga の bare-`claude` auto-upgrade が発動せず、`send_message` の channel push が届かなくなる。窓口→フォアマン / フォアマン→ワーカーの指示が一切通らなくなる）。Secretary のみ `ops.toml` から bare `claude` で起動され auto-upgrade に任せる。
+> **Why we use `spawn_claude_pane`**: structured launch tool added in renga 0.18.0+. Passing `cwd` / `permission_mode` / `model` / `args[]` as structured fields makes renga internally compose `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old method (feeding a `cd`-prefixed command string into `spawn_pane`) is **prohibited** (the cwd-changing prefix prevents renga's bare-`claude` auto-upgrade from firing, and `send_message`'s channel push fails to arrive — Lead → Dispatcher / Dispatcher → Worker instructions stop working entirely). Only the Secretary is started as a bare `claude` from `ops.toml` and relies on auto-upgrade.
 
-## ワーカーの balanced split 戦略
+## Worker balanced split strategy
 
-### なぜ balanced split が必要か
+### Why balanced split is necessary
 
-renga は各 split で対象ペインを 50/50 に分ける。`MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5` の下限を割り込むと `[split_refused]` で拒否される (調査: `<workers_dir>/renga-split-inv/findings.md`)。
+renga splits each target pane 50/50. Going below `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5` causes a `[split_refused]` rejection (investigation: `<workers_dir>/renga-split-inv/findings.md`).
 
-固定 target や序数 `k` ベースの lookup table では、dispatcher 幅の累積半減や、ワーカーが途中で閉じた後の再派遣で想定レイアウトと実レイアウトが乖離し、早期に `split_refused` を誘発していた。
+With a fixed target or an ordinal-`k`-based lookup table, the cumulative halving of dispatcher width and re-dispatch after a Worker closed in the middle made the assumed layout diverge from the actual layout, easily inducing `split_refused`.
 
-現設計は `mcp__renga-peers__list_panes` が返す各ペインの **rect 情報 (`x / y / width / height`, cell 単位)** を使い、**現状のレイアウトから動的に target と direction を選ぶ**。ワーカー退役順の揺れや途中クローズに強く、固定的な「N 並列上限」は持たず、ターミナルサイズと MIN_PANE 制約が許す限り分割し続け、限界に達したら自動 escalate する。
+The current design uses each pane's **rect (`x / y / width / height`, in cell units)** returned by `mcp__renga-peers__list_panes` and **picks target and direction dynamically from the current layout**. It is robust to shifting Worker retirement order and mid-flight closures, has no fixed "N parallel cap", continues splitting as far as terminal size and the MIN_PANE constraint allow, and auto-escalates when the limit is hit.
 
-### アルゴリズム
+### Algorithm
 
-新規ワーカーを起動するフォアマンは、`spawn_pane` を呼ぶ前に以下を実行する。判定ステップの詳細は `SKILL.md` Step 3-1 を参照（Claude が `list_panes` の結果テキストを解釈してロジックを実行する）。
+The Dispatcher launching a new Worker runs the following before calling `spawn_pane`. See SKILL.md Step 3-1 for the detailed decision steps (Claude interprets the result text of `list_panes` and runs the logic).
 
-1. `mcp__renga-peers__list_panes` で全ペインと属性 (id / name / role / focused / x / y / width / height) を取得する
-2. **候補集合**: `role ∈ {worker, dispatcher, secretary}` のペイン (curator は常に除外)
-3. **候補の絞り込み**:
-   - **dispatcher-curator 隣接維持**: dispatcher は curator と rect 隣接 (後述) しているときのみ候補に入れる。組織運営上 dispatcher と curator の隣接配置は前提。dispatcher を分割すると隣接が崩れ得るので、既に非隣接な dispatcher は候補から外す
-   - **secretary 保護**: secretary は分割後の新ペイン幅 `new_w >= 125` **かつ** 新ペイン高さ `new_h >= 45` を満たす場合のみ候補化 (保険条項、実運用では通常発動しない)。width だけ通っても height が足りなければ却下する
-4. **direction 決定** (各候補の aspect ratio から):
-   - `width > height * 2` → `vertical` (左右分割)
-   - それ以外 → `horizontal` (上下分割)
-   - ターミナルセルは縦長 (縦横比 ≈ 2:1) なので、文字単位で `width = 2 * height` のとき物理的にほぼ正方形。`width > height * 2` は「物理的に横長」判定として妥当
-5. **MIN_PANE 制約**: 分割後の新ペインサイズ `(new_w, new_h)` が `new_w >= 20` かつ `new_h >= 5` を満たさない候補は除外
-   - vertical 分割: `(new_w, new_h) = (floor(width / 2), height)`
-   - horizontal 分割: `(new_w, new_h) = (width, floor(height / 2))`
-6. **target 選出**: 残った候補から **「分割軸方向の新サイズ」** (vertical なら `new_w`、horizontal なら `new_h`) が最大のペインを target にする。tie-break はその時点の pane id 昇順 (スナップショット内で再現可能。セッション跨ぎの安定性までは保証しない)
-7. **候補が空なら escalate**: `SKILL.md` Step 3-1c の `SPLIT_CAPACITY_EXCEEDED` 経路で窓口に escalate (`spawn_pane` は発行せず、該当ワーカー 1 件だけ派遣中止、フォアマン本体は継続)
+1. Get all panes and their attributes (id / name / role / focused / x / y / width / height) via `mcp__renga-peers__list_panes`
+2. **Candidate set**: panes with `role ∈ {worker, dispatcher, secretary}` (curator is always excluded)
+3. **Filter candidates**:
+   - **Maintain dispatcher-curator adjacency**: keep dispatcher only when it is rect-adjacent (defined below) to curator. The dispatcher-curator adjacency is an organizational premise. Splitting dispatcher could break the adjacency, so dispatchers already non-adjacent are removed from candidates
+   - **Secretary protection**: secretary is a candidate only when post-split new pane width `new_w >= 125` **and** new pane height `new_h >= 45`. Insurance clause; rarely fires in practice. Width passing alone is not enough; height must also pass
+4. **Direction decision** (from each candidate's aspect ratio):
+   - `width > height * 2` → `vertical` (left/right split)
+   - Otherwise → `horizontal` (top/bottom split)
+   - Terminal cells are tall (height:width ≈ 2:1), so per-character `width = 2 * height` is roughly square physically. `width > height * 2` is a reasonable "physically wide" criterion
+5. **MIN_PANE constraint**: remove candidates whose post-split new size `(new_w, new_h)` does not satisfy `new_w >= 20` and `new_h >= 5`
+   - vertical split: `(new_w, new_h) = (floor(width / 2), height)`
+   - horizontal split: `(new_w, new_h) = (width, floor(height / 2))`
+6. **Target selection**: pick the candidate with the largest "new size in the split-axis direction" (`new_w` for vertical, `new_h` for horizontal). Tie-break by ascending pane id at that moment (reproducible within a snapshot; cross-session stability is not guaranteed)
+7. **Empty candidate set → escalate**: escalate to the Lead via the `SPLIT_CAPACITY_EXCEEDED` path in SKILL.md Step 3-1c (do not issue `spawn_pane`; cancel only the one Worker dispatch and continue the Dispatcher main loop)
 
-### rect 隣接判定の定義
+### Definition of rect adjacency
 
-rect `A, B` が隣接するとは以下のいずれかを満たすこと:
+Rects `A, B` are adjacent if they satisfy one of:
 
-- **左右隣接**: `A.x + A.width == B.x` または `B.x + B.width == A.x`、かつ y 区間が overlap (`max(A.y, B.y) < min(A.y + A.height, B.y + B.height)`)
-- **上下隣接**: `A.y + A.height == B.y` または `B.y + B.height == A.y`、かつ x 区間が overlap (`max(A.x, B.x) < min(A.x + A.width, B.x + B.width)`)
+- **Left-right adjacency**: `A.x + A.width == B.x` or `B.x + B.width == A.x`, and y intervals overlap (`max(A.y, B.y) < min(A.y + A.height, B.y + B.height)`)
+- **Top-bottom adjacency**: `A.y + A.height == B.y` or `B.y + B.height == A.y`, and x intervals overlap (`max(A.x, B.x) < min(A.x + A.width, B.x + B.width)`)
 
-renga の cell 座標は整数なので tolerance なし完全一致で判定する。
+renga's cell coordinates are integers, so judgment uses exact equality with no tolerance.
 
-### 初期状態と典型的な挙動
+### Initial state and typical behavior
 
-ワーカー 0 人の時点では、候補は `dispatcher` のみ (secretary は `new_w >= 125` / `new_h >= 45` 条件または隣接条件で除外されるのが通常。curator は常に除外)。dispatcher は典型的に横長なので vertical 分割され、最初のワーカー zone が dispatcher の右側に作られる。
+With zero workers, the only candidate is normally `dispatcher` (secretary is normally excluded by the `new_w >= 125` / `new_h >= 45` condition or the adjacency condition; curator is always excluded). The dispatcher is typically wide, so it gets a vertical split, and the first Worker zone is created on the right side of the dispatcher.
 
-以降は既存ペインの中で「分割後サイズが最大」のものが選ばれ、direction が rect に応じて自然に交替することで準 balanced な配置になる。固定的な 4 並列 / 8 並列の図は意味を持たないため割愛する (動的で決まるため)。
+After that, among the existing panes the one with the largest post-split size is selected, and direction alternates naturally based on the rect — yielding a near-balanced placement. Fixed 4-parallel / 8-parallel diagrams have no meaning (placement is dynamic), so they are omitted.
 
-### Edge cases / 運用時の注意
+### Edge cases / operational notes
 
-- **ワーカーが途中で閉じた後の再派遣**: 旧 k-table 方式で問題になった「閉じた slot を詰めるとテーブル前提と乖離」は rect ベースでは発生しない。常に実レイアウトから target を選ぶため、renga のレイアウト tree と判断が一致する
-- **`spawn_pane` エラー**: `[split_refused]` / `[pane_not_found]` が MCP 結果テキストで返る。`references/renga-error-codes.md` の手順でキュレーター → 窓口にエスカレーション (方針は旧設計と同じ)
-- **レース**: `list_panes` 実行から `spawn_pane` 実行までに他ワーカーが増減した場合、target 不整合は `[pane_not_found]` として顕在化する。既存のエラーハンドリング経路で吸収する
-- **target 選出の責務**: 計算はフォアマンが `list_panes` の rect ベースで行う。窓口は DELEGATE メッセージに task_id だけを渡せばよく、target は指定しない
+- **Re-dispatch after a Worker closed mid-flight**: the issue with the old k-table approach — "filling a closed slot diverges from the table assumption" — does not arise with the rect-based approach. The target is always picked from the actual layout, so judgment matches renga's layout tree
+- **`spawn_pane` errors**: `[split_refused]` / `[pane_not_found]` are returned in the MCP result text. Follow the procedure in `references/renga-error-codes.md` to escalate Curator → Lead (same policy as the old design)
+- **Race**: if other Workers are added or removed between `list_panes` and `spawn_pane`, target inconsistency surfaces as `[pane_not_found]`. Existing error-handling paths absorb it
+- **Responsibility for target selection**: the calculation is done by the Dispatcher based on `list_panes` rects. The Lead only passes a task_id in the DELEGATE message; it does not specify the target
 
-## 運用メモ
+## Operational notes
 
-- **全ペインを同一タブ内に配置する**: renga の `list_panes` / `focus_pane` / `send_message` / `inspect`（CLI） は現在フォーカス中のタブのペインしか扱えないため、フォアマン・キュレーター・全ワーカーを同一タブ内に split で積む。`new_tab` でワーカーを別タブに置くとフォアマン側から addressable でなくなる (2026-04-20 判明。renga 本体での解決は suisya-systems/renga#71)
-- **命名規約**:
-  - 窓口 → `secretary`
-  - フォアマン → `dispatcher`
-  - キュレーター → `curator`
-  - ワーカー → `worker-{task_id}` (task_id は kebab-case の一意識別子)
-  - **renga-peers の target 解決ルール**: 全桁数字の name は id として解釈されるため、name には英字を必ず含める (`worker-1` は OK、`1` は id 扱いになるので NG)
-- **役割ラベル (`role`)**: `secretary` / `dispatcher` / `curator` / `worker` の 4 種
-  - `list_panes` の出力で `role` フィールドが取得でき、組織状態の集計や balanced split の target 選出に使える
-- **ワーカー完了時**:
-  1. 窓口がフォアマンに `CLOSE_PANE` を依頼
-  2. フォアマンは `mcp__renga-peers__close_pane(target="worker-{task_id}")` でペインを明示破棄する
-     (renga が pane を撤去 → `Event::PaneExited` を 1 回 emit → `list_panes` からも消える。
-     `[pane_not_found]` / `[pane_vanished]` は「既に閉じた扱い」として skip する)
-- **org-suspend 時の停止順**: ワーカー → フォアマン → キュレーター (いずれも `mcp__renga-peers__close_pane` で破棄。最後の 1 ペインを閉じるときだけ `[last_pane]` が返るので、そのペインは自分自身で `exit` させる)
+- **Place every pane in the same tab**: renga's `list_panes` / `focus_pane` / `send_message` / `inspect` (CLI) can only handle panes in the currently focused tab, so stack the Dispatcher, Curator, and all Workers into the same tab via splits. Putting Workers in separate tabs via `new_tab` makes them unaddressable from the Dispatcher (discovered 2026-04-20; resolution in renga itself is suisya-systems/renga#71)
+- **Naming convention**:
+  - Lead → `secretary`
+  - Dispatcher → `dispatcher`
+  - Curator → `curator`
+  - Worker → `worker-{task_id}` (task_id is a unique identifier in kebab-case)
+  - **renga-peers target resolution rule**: all-digit names are interpreted as ids, so always include letters in the name (`worker-1` is OK; `1` is treated as an id and is therefore NG)
+- **Role labels (`role`)**: 4 kinds — `secretary` / `dispatcher` / `curator` / `worker`
+  - The `role` field is available in `list_panes` output and can be used for organizational state aggregation and target selection in balanced splits
+- **On Worker completion**:
+  1. The Lead asks the Dispatcher with `CLOSE_PANE`
+  2. The Dispatcher explicitly disposes the pane via `mcp__renga-peers__close_pane(target="worker-{task_id}")`
+     (renga removes the pane → emits `Event::PaneExited` once → it disappears from `list_panes`.
+     `[pane_not_found]` / `[pane_vanished]` are skipped as "already closed")
+- **Stop order on org-suspend**: Worker → Dispatcher → Curator (all disposed via `mcp__renga-peers__close_pane`. Only when closing the very last pane does `[last_pane]` come back; let that pane self-`exit`)
 
-## spawn_pane の direction 慣習
+## spawn_pane direction convention
 
-renga の分割方向は以下の定義（旧 `renga split --direction` と同じ）:
-- `direction="vertical"` = 左右分割 (既存ペイン=左、新ペイン=右)
-- `direction="horizontal"` = 上下分割 (既存ペイン=上、新ペイン=下)
+renga's split direction is defined as follows (same as the legacy `renga split --direction`):
+- `direction="vertical"` = left/right split (existing pane = left, new pane = right)
+- `direction="horizontal"` = top/bottom split (existing pane = top, new pane = bottom)
 
-## 将来機能 / upstream 追跡
+## Future features / upstream tracking
 
-- **ペイン lifecycle 購読**: 現在は `renga events` CLI 併用（フォアマン監視ループなど）。upstream suisya-systems/renga#117 / renga PR #120 で `mcp__renga-peers__poll_events` が追加されたら後続 Issue で MCP に切替
-- **画面スクレイプ**: `renga inspect` CLI 併用。upstream suisya-systems/renga#116 / renga PR #121 で `mcp__renga-peers__inspect_pane` が追加されたら後続 Issue で MCP に切替
-- **raw キー送信**: `renga send --text` CLI 併用（開発チャネル Enter / permission mode 切替 Shift+Tab 等）。upstream suisya-systems/renga#118 で `send_keys` MCP が設計中。追加されたら後続 Issue で MCP に切替
-- `spawn_pane --ratio 0.2` 等の比率指定 (現状は 50/50 固定)
-- `spawn_pane --target-largest` / `--direction auto` 等の renga 側自動 target 選出 (現状はフォアマン側で `list_panes` rect から算出。upstream に移譲できれば balanced split ロジックを MCP 側に畳める)
+- **Pane lifecycle subscription**: currently used together with the `renga events` CLI (Dispatcher monitoring loop, etc.). Once `mcp__renga-peers__poll_events` lands via upstream suisya-systems/renga#117 / renga PR #120, switch to MCP in a follow-up issue
+- **Screen scraping**: used together with the `renga inspect` CLI. Once `mcp__renga-peers__inspect_pane` lands via upstream suisya-systems/renga#116 / renga PR #121, switch to MCP in a follow-up issue
+- **Raw key send**: used together with the `renga send --text` CLI (development-channel Enter / permission-mode toggle Shift+Tab, etc.). The `send_keys` MCP is being designed in upstream suisya-systems/renga#118; switch to MCP in a follow-up issue once landed
+- Ratio specification like `spawn_pane --ratio 0.2` (currently fixed at 50/50)
+- renga-side automatic target selection like `spawn_pane --target-largest` / `--direction auto` (currently computed by the Dispatcher from `list_panes` rects; if delegated to upstream, the balanced-split logic could fold into the MCP side)

--- a/.claude/skills/org-delegate/references/renga-error-codes.md
+++ b/.claude/skills/org-delegate/references/renga-error-codes.md
@@ -1,60 +1,60 @@
 # renga-peers MCP error codes — Dispatcher / Secretary reference
 
-renga 0.14.0+ の `renga-peers` MCP サーバは、エラー応答に安定した machine-readable な code を載せる。フォアマン / キュレーター / 窓口は message 文字列の substring match ではなく **code で分岐する**のを推奨する。
+The renga 0.14.0+ `renga-peers` MCP server returns a stable, machine-readable code in error responses. The Dispatcher / Curator / Lead are recommended to **branch on the code**, not by substring-matching the message string.
 
 ## Wire format
 
-MCP ツール（`mcp__renga-peers__*`）が失敗すると、JSON-RPC error の human-readable message 先頭に `[<code>] <human message>` が埋まる。renga 側の `fmt_code` 関数がこの形式を保証。
+When an MCP tool (`mcp__renga-peers__*`) fails, the JSON-RPC error's human-readable message is prefixed with `[<code>] <human message>`. renga's `fmt_code` function guarantees this format.
 
 ```
 mcp__renga-peers__send_message(to_id="worker-nonexistent", message="hi")
 → renga refused send: [pane_not_found] pane not found: Name("worker-nonexistent")
 ```
 
-抽出方法: tool result text を substring match（`[pane_not_found]` 等で case 分岐）。
+Extraction: substring-match on the tool result text (branch on `[pane_not_found]`, etc.).
 
 ## Known codes
 
-| Code | 意味 | Dispatcher の推奨挙動 |
+| Code | Meaning | Recommended Dispatcher behavior |
 |---|---|---|
-| `pane_not_found` | 指定した pane 名 / id / Focused が存在しない | そのワーカーは既に閉じた扱い。`.state/workers/worker-*.md` の status を `pane_closed` に遷移、`WORKER_PANE_EXITED` を窓口に通知。リトライしない。**注意**: `list_panes` / `focus_pane` / `send_message` / `inspect_pane` は現在フォーカス中のタブのペインしか見えない。別タブ (`new_tab` 由来) のワーカーは本 code で返るので、org-delegate では全ワーカーを同一タブ内 `spawn_pane` で起動する (suisya-systems/renga#71) |
-| `pane_vanished` | resolve 成功後に消えたレース | `pane_not_found` と同等扱い |
-| `last_pane` | `close_pane` で唯一のタブの唯一のペインを閉じようとした | 通常のワーカー停止では発生しない (窓口/フォアマン/キュレーターが同タブに同居するため)。`org-suspend` 末端で残った最後のペイン (通常は窓口) に対して発生した場合、そのペインは自分自身で `exit` して自然終了させる。強制再試行はしない |
-| `split_refused` | `spawn_pane` / `spawn_claude_pane` が MAX_PANES / too small で拒否 | ワーカー起動 (`org-delegate` Step 3) で balanced split のいずれかのステップが 16 ペイン上限 / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` で拒否された場合、キュレーター → 窓口に escalate。典型シナリオは (a) 9 並列以上に到達、(b) ターミナル幅が balanced split の要件 (W ≥ 160) を満たさない、(c) ワーカー退役後の再派遣でレイアウト tree が想定と乖離。`new_tab` フォールバックは tab-scoped 制約のため不可 (suisya-systems/renga#71) |
-| `cwd_invalid` | `spawn_pane` / `spawn_claude_pane` / `new_tab` の `cwd` が存在しないか、ディレクトリでない | renga 0.16.0+ で追加。ペイン作成前に reject されるので half-mutated layout にはならない。Dispatcher 側では窓口に escalate し、ワーカーディレクトリ準備（org-delegate Step 1.5）が完了しているか、相対パスの解決基準（caller pane の cwd）を取り違えていないか確認 |
-| `invalid-params` | `spawn_claude_pane` の `args[]` に conflicting flag を含めた / `send_keys` の `keys[]` に未知のキー名を含めた等、JSON-RPC レベルの input 検証失敗 | `spawn_claude_pane` では `--dangerously-load-development-channels` / `--permission-mode` / `--model` を `args[]` に入れると rejected。構造化フィールド（`permission_mode` / `model`）で渡す。発生したらコード側のバグなので journal 記録 + 窓口 escalate |
-| `name_in_use` | `set_pane_identity` で既存の別ペインが使用中の name を割り当てようとした | `/org-start` Step 0 の secretary 識別修復では、この code を拾ってユーザーに「永続修復には `/org-suspend` → 再起動」を提示する。短期回避は numeric pane id 運用 |
-| `name_invalid` | `set_pane_identity` で全桁数字 / 禁止文字を含む name を指定した | 許可文字は `[A-Za-z0-9_-]`。全桁数字は numeric pane id と曖昧化するため拒否される。バグなので journal 記録 |
-| `io_error` | PTY write / spawn / OS レベル失敗 | 1 サイクル spin して再試行。2 連続で同じ worker に出たら窓口に `IO_ERROR_DETECTED` で escalate |
-| `shutting_down` | renga 本体がシャットダウン中 | 監視ループを **即停止** する。窓口 (`secretary`) に renga-peers で `DISPATCHER_STOPPING` を通知（best-effort — renga 自体が落ちる場合は届かない） |
-| `app_timeout` | renga 内部 App スレッドが応答しなかった | 1 サイクル spin (renga 再起動は管理者判断)。連続発生なら窓口にログ |
-| `parse` / `protocol` | 通常出ない (MCP が正しく組み立てる前提) | 発生時はバグ。journal に記録して窓口に `IPC_PROTOCOL_ERROR` で報告 |
-| `internal` | renga 内部不変条件違反 (parser lock poison 等) | `app_timeout` と同じ扱い |
+| `pane_not_found` | The specified pane name / id / Focused does not exist | Treat that Worker as already closed. Transition `.state/workers/worker-*.md` status to `pane_closed` and notify the Lead with `WORKER_PANE_EXITED`. Do not retry. **Note**: `list_panes` / `focus_pane` / `send_message` / `inspect_pane` can only see panes in the currently focused tab. Workers in other tabs (originating from `new_tab`) return this code, so org-delegate launches all Workers via `spawn_pane` in the same tab (suisya-systems/renga#71) |
+| `pane_vanished` | Race in which the pane disappeared after a successful resolve | Treat the same as `pane_not_found` |
+| `last_pane` | `close_pane` tried to close the only pane in the only tab | Does not occur during normal Worker stop (Lead/Dispatcher/Curator coexist in the same tab). If it occurs at the end of `org-suspend` against the very last pane (normally the Lead), let that pane `exit` itself and terminate naturally. Do not force-retry |
+| `split_refused` | `spawn_pane` / `spawn_claude_pane` rejected by MAX_PANES / too small | When any step of balanced split during Worker launch (`org-delegate` Step 3) is refused by the 16-pane limit / `MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT`, escalate Curator → Lead. Typical scenarios: (a) reached 9-parallel or more, (b) terminal width does not satisfy balanced split requirements (W ≥ 160), (c) re-dispatch after Worker retirement made the layout tree diverge from expected. `new_tab` fallback is impossible due to tab-scoped constraints (suisya-systems/renga#71) |
+| `cwd_invalid` | `cwd` of `spawn_pane` / `spawn_claude_pane` / `new_tab` does not exist or is not a directory | Added in renga 0.16.0+. Rejected before pane creation, so no half-mutated layout. The Dispatcher should escalate to the Lead and verify whether Worker directory preparation (org-delegate Step 1.5) is complete or whether the relative-path resolution base (caller pane's cwd) was misunderstood |
+| `invalid-params` | JSON-RPC level input validation failure (e.g. including a conflicting flag in `spawn_claude_pane`'s `args[]`, or an unknown key name in `send_keys`'s `keys[]`) | In `spawn_claude_pane`, putting `--dangerously-load-development-channels` / `--permission-mode` / `--model` into `args[]` is rejected. Pass them via the structured fields (`permission_mode` / `model`). When this occurs it's a code bug, so log to journal and escalate to the Lead |
+| `name_in_use` | `set_pane_identity` tried to assign a name already in use by another existing pane | In `/org-start` Step 0 secretary identity recovery, catch this code and present the user with "for permanent fix, `/org-suspend` → restart". Short-term workaround is operating with numeric pane ids |
+| `name_invalid` | `set_pane_identity` was given an all-digit / forbidden-character name | Allowed characters are `[A-Za-z0-9_-]`. All-digit names are rejected because they are ambiguous with numeric pane ids. Bug — log to journal |
+| `io_error` | PTY write / spawn / OS-level failure | Spin once and retry. If the same Worker hits it twice in a row, escalate to the Lead with `IO_ERROR_DETECTED` |
+| `shutting_down` | renga itself is shutting down | **Stop the monitoring loop immediately**. Notify the Lead (`secretary`) with `DISPATCHER_STOPPING` via renga-peers (best-effort — won't arrive if renga itself is going down) |
+| `app_timeout` | renga's internal App thread did not respond | Spin one cycle (renga restart is up to the admin). On consecutive occurrences, log to the Lead |
+| `parse` / `protocol` | Should not normally occur (MCP is expected to assemble messages correctly) | Bug if it occurs. Log to journal and report to the Lead with `IPC_PROTOCOL_ERROR` |
+| `internal` | renga internal invariant violation (parser lock poison, etc.) | Treat the same as `app_timeout` |
 
-## MCP ツール特有の ok-return ルール
+## MCP-tool-specific ok-return rules
 
-以下 2 つの MCP ツールは、renga 到達不可でも **JSON-RPC error にせず ok-text で返す** 例外扱い。
+The following 2 MCP tools are exceptions: even when renga is unreachable, they **return ok-text instead of a JSON-RPC error**.
 
-- `mcp__renga-peers__list_peers`: renga 本体未起動 / detached mode → `"(no peers — renga not reachable: <reason>)"`
-- `mcp__renga-peers__send_message`: 同上 → `"(message dropped — renga not reachable: <reason>)"`
+- `mcp__renga-peers__list_peers`: renga itself not running / detached mode → `"(no peers — renga not reachable: <reason>)"`
+- `mcp__renga-peers__send_message`: same as above → `"(message dropped — renga not reachable: <reason>)"`
 
-他の renga-peers ツール (`spawn_pane` / `close_pane` / `list_panes` / `focus_pane` / `new_tab` /
-`check_messages` / `set_summary` / `poll_events` / `inspect_pane` / `send_keys`) は `require_connected` で非接続時に JSON-RPC error になる。この 2 つだけは**ハンドリング分岐を `[code]` パターンだけでなく `(no peers` / `(message dropped` 接頭辞**でも見るべき。
+The other renga-peers tools (`spawn_pane` / `close_pane` / `list_panes` / `focus_pane` / `new_tab` /
+`check_messages` / `set_summary` / `poll_events` / `inspect_pane` / `send_keys`) become a JSON-RPC error when not connected, via `require_connected`. Only for these two should handler branches also look for the **`(no peers` / `(message dropped` prefixes** in addition to `[code]` patterns.
 
-## シェル側のハンドリング例
+## Shell-side handling example
 
-MCP ツール呼び出し結果テキスト (`content[0].text` or JSON-RPC error message) に対する case 分岐:
+Case branching on the MCP tool result text (`content[0].text` or JSON-RPC error message):
 
 ```
-# MCP ツール呼び出し後、返ってきたテキストを $out に入れた状態を想定
+# Assume the returned text is in $out after an MCP tool call
 case "$out" in
   *"[pane_not_found]"*|*"[pane_vanished]"*)
-    # worker 既に閉じた — lifecycle 処理に回す
+    # Worker already closed — route to lifecycle handling
     mark_worker_pane_closed worker-foo
     ;;
   *"[last_pane]"*)
-    # org-suspend 末端で最後のペインを閉じようとした
-    # 強制クローズしない。当該ペインは自分自身で exit
+    # org-suspend tried to close the very last pane
+    # Do not force close; that pane should self-exit
     echo "last pane — leave for self-exit"
     ;;
   *"[shutting_down]"*)
@@ -65,7 +65,7 @@ case "$out" in
     log_journal "transient renga error: $out"
     ;;
   *"(no peers"*|*"(message dropped"*)
-    # list_peers / send_message の renga 非接続時の ok-text
+    # ok-text returned by list_peers / send_message when renga is not connected
     log_journal "renga peer unreachable: $out"
     ;;
   *)
@@ -74,63 +74,63 @@ case "$out" in
 esac
 ```
 
-## なぜ code か、substring ではなく
+## Why codes, not substrings
 
-- メッセージ本文は human-facing。理由なしで変更される可能性がある
+- The message body is human-facing. It may change without notice for any reason
   (e.g. "pane not found: Id(3)" → "pane 3 does not exist")
-- renga 側の契約については、以下を正本として参照する (このリポジトリ内では検証不能な前提なので **外部依存** として扱うこと):
-  - `renga/src/ipc/mod.rs::err_code` の doc コメント — 公開 code の一覧と ABI 安定性 (rename は deprecation window 付き) の明文
-  - `renga/src/mcp_peer/mod.rs::fmt_code` — MCP 経由の `[<code>] <message>` 成形ロジック
-  - renga `Response::Err { message, code }` の wire schema — `code` は `Option<String>` で、`skip_serializing_if = "Option::is_none"`
-- 未知の code は必ず非致命扱いにする — 将来 renga が新 code を追加してもフォアマンが落ちないようにデフォルトブランチ必須
+- For the renga-side contract, refer to the following as the source of truth (treat them as **external dependencies**, since they cannot be verified inside this repository):
+  - The doc comment on `renga/src/ipc/mod.rs::err_code` — declares the public code list and ABI stability (renames go through a deprecation window)
+  - `renga/src/mcp_peer/mod.rs::fmt_code` — the formatting logic for `[<code>] <message>` over MCP
+  - The wire schema of renga's `Response::Err { message, code }` — `code` is `Option<String>` with `skip_serializing_if = "Option::is_none"`
+- Always treat unknown codes as non-fatal — even if renga adds new codes in the future, the Dispatcher must not fall over. A default branch is required
 
 ## Event stream — `poll_events` MCP
 
-pane lifecycle (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat` / forward-compat variants) は `mcp__renga-peers__poll_events` で cursor-based long-poll する:
+Pane lifecycle (`pane_started` / `pane_exited` / `events_dropped` / `heartbeat` / forward-compat variants) is cursor-based long-polled via `mcp__renga-peers__poll_events`:
 
 ```
 mcp__renga-peers__poll_events(
-  since=<前回の next_since、初回は省略>,
+  since=<previous next_since; omit on first call>,
   timeout_ms=5000,
   types=["pane_exited", "events_dropped"]
 )
 ```
 
-戻り値の `events[]` は `type` / `role` / `name` / `id` / `ts` を含む。フォアマンは `role == "worker"` で絞り込んで `WORKER_PANE_EXITED` 通知する。`next_since` を次回 `since` に流用して idempotent resume。
+The returned `events[]` includes `type` / `role` / `name` / `id` / `ts`. The Dispatcher filters by `role == "worker"` and notifies `WORKER_PANE_EXITED`. Reuse `next_since` as the next call's `since` for idempotent resume.
 
-### type 別の扱い
+### Per-type handling
 
-| type | 扱い |
+| type | Handling |
 |---|---|
-| `pane_started` | 現状 skip (将来必要になれば追加) |
-| `pane_exited` | `role == "worker"` に絞って `WORKER_PANE_EXITED` 通知 |
-| `events_dropped` | `.state/journal.jsonl` に drop 件数を記録 (監視が追いついていないシグナル) |
-| `heartbeat` | 通常 `poll_events` のバッファに入らない (subscribe 内部で消化される) |
+| `pane_started` | Currently skipped (added later if needed) |
+| `pane_exited` | Filter by `role == "worker"` and notify `WORKER_PANE_EXITED` |
+| `events_dropped` | Record the drop count in `.state/journal.jsonl` (signal that monitoring is falling behind) |
+| `heartbeat` | Normally not put into the `poll_events` buffer (consumed inside subscribe) |
 
-### `types` フィルタの挙動
+### `types` filter behavior
 
-`types` filter は cursor を全 type で advance させるので重複 scan なし。ただし **filter 不一致イベント到着で long-poll が early return** し、`events: []` + 進んだ cursor が返る (renga PR #120 参照)。Dispatcher 監視ループでは空応答時に spin せず、`next_since` を保持したまま次のサイクルで再呼び出しする。
+The `types` filter advances the cursor on all types, so there are no duplicate scans. However, **arrival of a filter-mismatching event causes long-poll to early-return**, returning `events: []` + an advanced cursor (see renga PR #120). The Dispatcher monitoring loop must not spin on empty responses; instead, retain `next_since` and re-call on the next cycle.
 
-### 初回呼び出しのセマンティクス
+### First-call semantics
 
-`since` 省略で「今以降のイベントだけ」を返す（過去の履歴を flood しない）。旧 `renga events --timeout` と同じ契約。
+Omitting `since` returns "events from now on" (does not flood with past history). Same contract as the legacy `renga events --timeout`.
 
-## Raw キー入力 — `send_keys` MCP
+## Raw key input — `send_keys` MCP
 
-raw PTY キー送信は `mcp__renga-peers__send_keys` を使う。論理メッセージ配送の `send_message` とは**別物**（PTY に生バイトを書き込むので、そのペインで走っているアプリケーション側に見える）:
+Use `mcp__renga-peers__send_keys` for raw PTY key sending. This is **separate** from `send_message`'s logical message delivery (it writes raw bytes to the PTY, so the application running in that pane sees them):
 
 ```
 mcp__renga-peers__send_keys(
-  target: string,           # pane name or id (list_panes と同じ解決規則)
-  text?: string,            # 送信するテキスト（optional）
-  keys?: string[],          # 特殊キー名の配列（optional、text と併用可、text の後に送られる）
-  enter?: boolean           # 末尾に Enter (CR, 0x0D) を付ける（optional、keys の後に送られる）
+  target: string,           # pane name or id (same resolution rule as list_panes)
+  text?: string,            # text to send (optional)
+  keys?: string[],          # array of special key names (optional; can be combined with text; sent after text)
+  enter?: boolean           # append Enter (CR, 0x0D) at the end (optional; sent after keys)
 )
 ```
 
-### 対応キー語彙
+### Supported key vocabulary
 
-- `Enter` / `Return` (CR, `\r` = 0x0D。`enter: true` と byte-identical)
+- `Enter` / `Return` (CR, `\r` = 0x0D; byte-identical to `enter: true`)
 - `Tab`
 - `Shift+Tab` / `BackTab`
 - `Esc` / `Escape`
@@ -140,16 +140,16 @@ mcp__renga-peers__send_keys(
 - `Home` / `End`
 - `PageUp` / `PageDown`
 - `Space`
-- `Ctrl+<A-Z>`（例: `Ctrl+C`）
+- `Ctrl+<A-Z>` (e.g. `Ctrl+C`)
 
-未知の key 名は `-32602 invalid-params` error が返る。
+Unknown key names return a `-32602 invalid-params` error.
 
-### 典型的な呼び出しパターン
+### Typical call patterns
 
-| 用途 | 呼び出し |
+| Use | Call |
 |---|---|
-| 空 Enter（プロンプトへの返答） | `send_keys(target="X", enter=true)` |
-| "yes" + Enter（確認プロンプトへの応答など） | `send_keys(target="X", text="yes", enter=true)` |
-| Shift+Tab（permission mode 切替） | `send_keys(target="X", keys=["Shift+Tab"])` |
-| Esc（モーダル escape） | `send_keys(target="X", keys=["Esc"])` |
-| Ctrl+C（走行中プロセス中断） | `send_keys(target="X", keys=["Ctrl+C"])` |
+| Bare Enter (replying to a prompt) | `send_keys(target="X", enter=true)` |
+| "yes" + Enter (replying to a confirmation prompt) | `send_keys(target="X", text="yes", enter=true)` |
+| Shift+Tab (toggle permission mode) | `send_keys(target="X", keys=["Shift+Tab"])` |
+| Esc (modal escape) | `send_keys(target="X", keys=["Esc"])` |
+| Ctrl+C (interrupt running process) | `send_keys(target="X", keys=["Ctrl+C"])` |

--- a/.claude/skills/org-delegate/references/renga-error-codes.md
+++ b/.claude/skills/org-delegate/references/renga-error-codes.md
@@ -1,4 +1,4 @@
-# renga-peers MCP error codes — Dispatcher / Secretary reference
+# renga-peers MCP error codes — Dispatcher / Lead reference
 
 The renga 0.14.0+ `renga-peers` MCP server returns a stable, machine-readable code in error responses. The Dispatcher / Curator / Lead are recommended to **branch on the code**, not by substring-matching the message string.
 

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -1,80 +1,80 @@
 # Worker CLAUDE.md Template
 
-org-delegate の Step 1.5 でワーカー専用ディレクトリ（`{workers_dir}/{task_id}/`）に配置する CLAUDE.md のテンプレート。
-変数は `{variable_name}` 形式で、生成時に実際の値に置換する。
+The CLAUDE.md template that org-delegate Step 1.5 places in the Worker's dedicated directory (`{workers_dir}/{task_id}/`).
+Variables are in `{variable_name}` form and are substituted with actual values at generation time.
 
 ---
 
-## テンプレート本体
+## Template body
 
-以下をそのまま `{workers_dir}/{task_id}/CLAUDE.md` として書き出す。
+Write the following directly to `{workers_dir}/{task_id}/CLAUDE.md`.
 
 ```markdown
 # Worker
 
-あなたは claude-orgのワーカーである。以下の指示に従って作業を遂行する。
+You are a Worker of claude-org. Carry out the task following the instructions below.
 
-## 作業ディレクトリ（最重要制約）
+## Working directory (most important constraint)
 
-あなたの作業ディレクトリ: `{worker_dir}`
+Your working directory: `{worker_dir}`
 
-起動直後に `pwd` を実行し、上記パスと一致することを確認せよ。
-一致しない場合は作業を開始せず、窓口にエラー報告せよ。
+Run `pwd` immediately on launch and confirm it matches the path above.
+If it does not match, do not start work — report the error to the Lead.
 
-### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
-1. `{worker_dir}` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
-2. claude-org リポジトリ（`{claude_org_path}`）を別途 clone してはならない（直接編集すること）
-3. `git push` は実行できない（完了報告で窓口に依頼すること）
+### Prohibited (technically blocked by permissions.deny + PreToolUse Hooks)
+1. Do not reproduce the claude-org structure (.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/, etc.) inside `{worker_dir}`
+2. Do not separately clone the claude-org repository (`{claude_org_path}`); edit it in place
+3. `git push` is not allowed (ask the Lead in the completion report)
 
-### 正しい作業手順
-- 新規プロジェクト: `{worker_dir}` 内で `git init` し、直接ファイルを作成
-- 既存リポジトリ: `{worker_dir}` 内で `git clone {URL}` を実行
-- ファイル作成時は絶対パスが `{worker_dir}/` で始まることを確認
+### Correct work procedure
+- New project: `git init` inside `{worker_dir}` and create files directly
+- Existing repository: run `git clone {URL}` inside `{worker_dir}`
+- When creating files, confirm the absolute path starts with `{worker_dir}/`
 
-### Windows 環境の注意事項
-- Python 実行時は `python` ではなく `py -3` を使用すること（Windows では `python` がストアアプリにリダイレクトされる場合がある）
-- 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
+### Notes for Windows environments
+- When running Python, use `py -3` instead of `python` (on Windows, `python` may be redirected to the Store app)
+- When dealing with files containing non-ASCII characters, explicitly specify `encoding="utf-8"`
 
-## プロジェクト情報
-- プロジェクト名: {project_name}
-- 説明: {project_description}
+## Project information
+- Project name: {project_name}
+- Description: {project_description}
 
-## 現在のタスク
-- タスクID: {task_id}
-- 目的: {task_description}
+## Current task
+- Task ID: {task_id}
+- Goal: {task_description}
 
-## ナレッジ参照（読み取り専用）
+## Knowledge reference (read-only)
 
-組織に蓄積された知見を活用できる。以下のディレクトリを **Read ツールで読み取り可能**（書き込みは振り返り記録のみ許可）。
+You can leverage knowledge accumulated by the organization. The following directories are **readable via the Read tool** (writes are allowed only for retro records).
 
-- `{claude_org_path}/knowledge/curated/` — 整理済みの知見
-- `{claude_org_path}/knowledge/raw/` — 未整理の生の学び
+- `{claude_org_path}/knowledge/curated/` — curated knowledge
+- `{claude_org_path}/knowledge/raw/` — raw, unorganized lessons
 
-### いつ参照するか
-1. **作業開始前**: タスクに関連しそうなファイルがないか確認する。ファイル名やタイトルから判断し、役立ちそうなものがあれば読む
-2. **作業中に詰まったとき**: 同様の問題に対する知見が記録されていないか確認する
+### When to consult them
+1. **Before starting work**: check whether there are files relevant to the task. Judge from the file name or title; read what looks useful
+2. **When stuck mid-work**: check whether knowledge about a similar problem has been recorded
 
-## 権限
-- git commit: 可
-- PR作成: 不可（窓口経由）
-- git push: 不可（`permissions.deny` + hook により技術的にブロック。窓口経由で依頼すること）
-- `rm -rf` / `rm -r`: 不可（`permissions.deny` により技術的にブロック）
+## Permissions
+- git commit: allowed
+- PR creation: not allowed (via the Lead)
+- git push: not allowed (technically blocked by `permissions.deny` + hook; request via the Lead)
+- `rm -rf` / `rm -r`: not allowed (technically blocked by `permissions.deny`)
 
-## Codex セルフレビュー手順
+## Codex self-review procedure
 
-派遣指示に**必ず含まれる「検証深度」行**（`full` または `minimal`）に従うこと。指示に値が無い・不明瞭な場合は勝手に決めず窓口（`secretary`）に確認すること。
+Follow the **"Verification depth" line that is always included in the dispatch instruction** (`full` or `minimal`). If the value is missing or unclear, do not decide on your own — confirm with the Lead (`secretary`).
 
-### 検証深度 `full` の場合（コード・挙動の変更を伴うタスク）
+### When verification depth is `full` (tasks that change code or behavior)
 
-**`full` の前提（codex の有無に関わらず必ず実施）:**
-- 既存テストスイート / lint / type-check 等、リポジトリで定義された通常検証を実行し、green を確認してから完了報告する
-- 通常の完了報告フォーマット（成果物説明・残作業・PR 草案 / 振り返り記録）に従う
+**`full` premise (always run, regardless of whether codex is available):**
+- Run the repository-defined normal verification (existing test suite / lint / type-check, etc.) and confirm green before sending the completion report
+- Follow the normal completion-report format (deliverable description, remaining work, PR draft / retro record)
 
-**追加ゲートとしての Codex セルフレビュー（任意。codex CLI がインストールされていれば実行）:**
+**Codex self-review as an additional gate (optional; run if the codex CLI is installed):**
 
-commit 完了後・完了報告前に **`codex` CLI が available なら** `codex exec --skip-git-repo-check` 直打ちでセルフレビューを実行する。これは `full` の上に乗る追加ゲートであり、未導入環境では上記「`full` の前提」のみで完了報告に進んで構わない。
+After commit completes and before the completion report, **if the `codex` CLI is available**, run a self-review by calling `codex exec --skip-git-repo-check` directly. This is an extra gate on top of `full`; in environments where it is not installed, you may proceed to the completion report on the "`full` premise" alone.
 
-availability check 例:
+Availability check examples:
 ```bash
 # Bash / zsh
 command -v codex >/dev/null 2>&1 && echo available || echo unavailable
@@ -82,88 +82,88 @@ command -v codex >/dev/null 2>&1 && echo available || echo unavailable
 Get-Command codex -ErrorAction SilentlyContinue
 ```
 
-- `unavailable` の場合: セルフレビューを skip し、commit 後そのまま完了報告に進む（このセクション以下のラウンド規律・修正ループは適用しない）
-- `available` の場合: 以下のコマンドで実行する
+- `unavailable`: skip the self-review and proceed straight to the completion report after commit (the round discipline / fix loop below does not apply)
+- `available`: run the following command
 
 ```bash
-codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"
+codex exec --skip-git-repo-check "Review the diff between this branch and main. Classify findings as Blocker/Major/Minor/Nit and add target file:line and the rationale to each, concise in Japanese"
 ```
 
-`codex` を実行した場合のみ以下が適用される:
-- Blocker / Major は修正コミットを積み、再レビュー
-- **同一指摘カテゴリで 3 ラウンド消せない場合は設計問題**と判断し、即完了報告して窓口に仕様縮小の判断を仰ぐ（無限ループ防止）
-- Minor / Nit は原則残置し、README / Issue / PR 本文に既知制限として明記する
-- 別ワーカーにレビュー委譲しないこと（書いた本人が修正ループを回す方が速く、責任境界も明確）
+The following applies only when `codex` was run:
+- For Blocker / Major, stack a fix commit and re-review
+- **If the same finding category cannot be eliminated in 3 rounds, judge it a design issue**, send the completion report immediately, and ask the Lead for a scope-reduction decision (to prevent infinite loops)
+- Minor / Nit are left in place by default; document them as known limitations in README / Issue / PR body
+- Do not delegate the review to another Worker (it's faster, and responsibility is clearer, when the author runs the fix loop)
 
-### 検証深度 `minimal` の場合（trivial fix）
-Codex セルフレビュー・追加テスト実行・拡張された動作確認は**一切禁止**。指示された fix を反映したら `git add` → `git commit` → 窓口に以下 1 行だけ送信する:
+### When verification depth is `minimal` (trivial fix)
+Codex self-review, additional test runs, and any extended behavioral checks are **strictly forbidden**. After applying the requested fix, do `git add` → `git commit` and send only the following single line to the Lead:
 
 ```
-done: {commit SHA 短縮形} {変更ファイル名}
+done: {short commit SHA} {changed file name}
 ```
 
-- SHA は `git rev-parse --short HEAD`
-- ファイルが複数なら空白区切り（例: `done: be8f497 tests/test-block-pretooluse-hooks.sh`）
-- 下記「作業完了時（必須）」の 完了報告フォーマット（成果物説明・残作業・PR 草案等）は minimal では **適用されない**（窓口が push / PR 起票を実施するのに commit SHA と変更ファイルがあれば足りる）
-- 振り返り記録（`knowledge/raw/`）も minimal では **不要**（trivial fix に再利用可能な学びはない前提）。非自明な発見があれば `full` と同じ手順で 1 件作ってよい
+- SHA from `git rev-parse --short HEAD`
+- If multiple files, separate with spaces (e.g. `done: be8f497 tests/test-block-pretooluse-hooks.sh`)
+- The completion-report format below ("On work completion (mandatory)" — deliverable description, remaining work, PR draft, etc.) is **not applied** under minimal (the Lead does push / PR creation, and only the commit SHA and changed file are needed)
+- Retro record (`knowledge/raw/`) is also **not needed** under minimal (trivial fixes are presumed to have no reusable lessons). If you make a non-obvious discovery, you may create one as in `full`
 
-### 禁止事項（両モード共通・codex を使う場合）
-`codex:rescue` スキルは使用しないこと（過去に 18 分超ハングした実害あり。`codex exec` 直打ちに切り替えると正常動作した）。codex 未導入環境ではこの注記は無関係。
+### Prohibited (common to both modes; when using codex)
+Do not use the `codex:rescue` skill (there have been actual >18-minute hangs; switching to direct `codex exec` worked correctly). Irrelevant in environments where codex is not installed.
 
-## 作業完了時（必須・検証深度 `full` のみ）
+## On work completion (mandatory; verification depth `full` only)
 
-検証深度 `minimal` の場合は上記「Codex セルフレビュー手順」節の minimal 用 1 行報告フォーマット（`done: {SHA} {files}`）で終了する。振り返り記録も不要。このセクションは **検証深度 `full` のタスクに限定して適用**される。
+Under verification depth `minimal`, finish with the 1-line minimal report format (`done: {SHA} {files}`) in the "Codex self-review procedure" section above. No retro record is needed either. This section **applies only to verification depth `full`**.
 
-作業が完了したら、以下を**必ず**実行すること:
+When work is complete, **always** do the following:
 
-1. **完了報告**: renga-peers で **窓口（`secretary`）** に報告する
-   - 送信方法: `mcp__renga-peers__send_message(to_id="secretary", message="...")`（`secretary` は renga layout で固定された pane name）
-   - **注意: フォアマン（指示を送ってきた相手）ではなく、窓口に送ること**
-   - **フォールバック**: `to_id="secretary"` が `[pane_not_found]` で返る場合は、`renga --layout ops` 以外の経路で窓口ペインが起動された可能性がある。その場合は DELEGATE メッセージ本文で指定された numeric pane id（例: `to_id="1"`）を使って送信する。窓口側で `/org-start` Step 0 の `set_pane_identity` 自動修復が走れば、以降は `to_id="secretary"` が使える
-   - 何を完了したか
-   - 作成したファイル、コミット、PR等の成果物
-   - 残作業や注意点があれば
+1. **Completion report**: report to the **Lead (`secretary`)** via renga-peers
+   - How to send: `mcp__renga-peers__send_message(to_id="secretary", message="...")` (`secretary` is the pane name fixed by the renga layout)
+   - **Note: send to the Lead, not to the Dispatcher (the one who sent you the instructions)**
+   - **Fallback**: if `to_id="secretary"` returns `[pane_not_found]`, the Lead pane may have been started via a path other than `renga --layout ops`. In that case, send using the numeric pane id specified in the DELEGATE message body (e.g. `to_id="1"`). Once the Lead's `/org-start` Step 0 `set_pane_identity` auto-recovery runs, `to_id="secretary"` becomes usable again
+   - What was completed
+   - Created files, commits, PRs, and other deliverables
+   - Remaining work or caveats, if any
 
-2. **振り返り記録**: 再利用可能な学びがあれば記録する
-   - パス: {claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md
-   - topic は英語 kebab-case（例: jwt-rs256-key-rotation）
-   - フォーマット:
+2. **Retro record**: record any reusable lessons
+   - Path: {claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md
+   - topic in English kebab-case (e.g. jwt-rs256-key-rotation)
+   - Format:
      ```
-     # {タイトル}
+     # {Title}
 
-     ## 事実
-     {何が起きたか}
+     ## Facts
+     {What happened}
 
-     ## 判断
-     {どういう判断を下したか}
+     ## Decision
+     {What was decided}
 
-     ## 根拠
-     {なぜその判断か}
+     ## Rationale
+     {Why that decision}
 
-     ## 適用場面
-     {この知見が役立つ状況}
+     ## When to apply
+     {When this knowledge is useful}
      ```
-   - 記録基準: 再現性がある / 非自明 / コードを読むだけではわからない
-   - 一般的なプログラミング知識や公式ドキュメントに書いてあることは記録不要
+   - Recording criteria: reproducible / non-obvious / not learnable just by reading code
+   - General programming knowledge or anything documented in official docs need not be recorded
 
-## SUSPEND対応
-"SUSPEND:" で始まるメッセージを受け取ったら、作業を中断し即座に以下を報告:
-1. これまでに完了したこと
-2. 変更したファイル（コミット済み / 未コミット）
-3. 次にやろうとしていたこと
-4. ブロッカーや未解決の問題
+## SUSPEND handling
+On receiving a message starting with "SUSPEND:", suspend work and immediately report:
+1. What has been completed so far
+2. Files modified (committed / not yet committed)
+3. What you were about to do next
+4. Blockers or open issues
 ```
 
 ---
 
-## 変数一覧
+## Variable reference
 
-| 変数 | 説明 | 例 |
+| Variable | Description | Example |
 |---|---|---|
-| `{project_name}` | registry/projects.md の通称 | ブログ |
-| `{project_description}` | registry/projects.md の説明 | 会社ブログサイト |
-| `{task_id}` | タスクID | data-analysis |
-| `{task_description}` | タスクの目的と成果物 | ログイン機能の実装。JWT認証を使用。 |
-| `{claude_org_path}` | claude-org リポジトリの絶対パス | /home/user/work/claude-org |
-| `{worker_dir}` | ワーカー作業ディレクトリの絶対パス | /home/user/work/workers/data-analysis |
-| `{YYYY-MM-DD}` | 実行日 | 2026-04-05 |
+| `{project_name}` | nickname from registry/projects.md | Blog |
+| `{project_description}` | description from registry/projects.md | Company blog site |
+| `{task_id}` | task ID | data-analysis |
+| `{task_description}` | task goal and deliverable | Implement login. Use JWT auth. |
+| `{claude_org_path}` | absolute path of the claude-org repository | /home/user/work/claude-org |
+| `{worker_dir}` | absolute path of the Worker working directory | /home/user/work/workers/data-analysis |
+| `{YYYY-MM-DD}` | execution date | 2026-04-05 |

--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -1,103 +1,103 @@
 ---
 name: org-setup
 description: |
-  組織の全ロール（窓口・フォアマン・キュレーター・ワーカー）に必要な
-  Claude Code の許可設定・環境変数を一括で配置・更新するスキル。
-  「設定して」「許可設定を更新して」「セットアップして」
-  「permissions設定」「org-setup」等で発動する。
+  Skill that installs / updates the Claude Code permission settings and
+  environment variables required by every role in the organization
+  (Lead / Dispatcher / Curator / Worker) in one shot.
+  Triggered by phrases like "configure", "update permissions", "set up",
+  "permissions config", "org-setup".
 ---
 
-# org-setup: 組織の許可設定を一括配置
+# org-setup: install organization permissions in one shot
 
-組織の各ロールが必要とする permissions allow と環境変数を、
-正しいスコープの settings ファイルに配置する。
+Place the permissions allow entries and environment variables required by each
+role in the organization into the settings files at the correct scope.
 
-## 設定ファイルの配置先とスコープ
+## Where settings live and at what scope
 
-Claude Code は**起動ディレクトリの `.claude/` 配下**から設定を読み込む。
-サブディレクトリで起動した場合、親ディレクトリの設定は**読み込まれない**。
-そのため、ロールごとに独立した設定ファイルが必要になる。
+Claude Code reads settings from **`.claude/` under the launch directory**.
+When launched from a subdirectory, settings in the parent directory are **not** loaded.
+For that reason each role needs its own independent settings file.
 
-| スコープ | ファイルパス | 対象 |
+| Scope | File path | Target |
 |---|---|---|
-| ユーザー共通 | `~/.claude/settings.json` | 全プロジェクト・全ロール |
-| 窓口 | `<repo>/.claude/settings.local.json` | リポジトリルートで起動した窓口 |
-| フォアマン | `<repo>/.dispatcher/.claude/settings.local.json` | `.dispatcher/` で起動したフォアマン |
-| キュレーター | `<repo>/.curator/.claude/settings.local.json` | `.curator/` で起動したキュレーター |
-| ワーカー | ワーカーディレクトリの `.claude/settings.local.json` | org-delegate が動的に作成 |
+| User-wide | `~/.claude/settings.json` | All projects, all roles |
+| Lead | `<repo>/.claude/settings.local.json` | Lead launched at the repository root |
+| Dispatcher | `<repo>/.dispatcher/.claude/settings.local.json` | Dispatcher launched in `.dispatcher/` |
+| Curator | `<repo>/.curator/.claude/settings.local.json` | Curator launched in `.curator/` |
+| Worker | Worker directory's `.claude/settings.local.json` | Created dynamically by org-delegate |
 
-## 各ロールの必要設定
+## Required settings per role
 
-**references/permissions.md** に全ロールのJSON定義がある。以下の手順でこれを参照する。
+The JSON definitions for every role live in **references/permissions.md**. The procedure below references it.
 
-## 実行手順
+## Procedure
 
-### Step 1: 現在の設定を読み取る
+### Step 1: Read the current settings
 
-以下の4ファイルを読み取る（存在しない場合は空オブジェクト扱い）:
+Read the following 4 files (treat as empty object if absent):
 
 1. `~/.claude/settings.json`
 2. `<repo>/.claude/settings.local.json`
 3. `<repo>/.dispatcher/.claude/settings.local.json`
 4. `<repo>/.curator/.claude/settings.local.json`
 
-### Step 2: 差分を特定する
+### Step 2: Identify the diff
 
-各ファイルについて、上記「各ロールの必要設定」と比較し、不足しているエントリを特定する。
+For each file, compare against "Required settings per role" above and identify the missing entries.
 
-### Step 3: マージして書き込む
+### Step 3: Merge and write
 
-不足分を追加する。既存の設定は**絶対に削除しない**。
-`permissions.allow` は配列なので、既存エントリを保持しつつ新規エントリを追加する。
-`env` はオブジェクトなので、既存キーを保持しつつ新規キーを追加する。
+Add the missing entries. **Never delete** existing settings.
+`permissions.allow` is an array, so preserve existing entries while appending new ones.
+`env` is an object, so preserve existing keys while adding new ones.
 
-### Step 4: 結果を報告する
+### Step 4: Report the result
 
-変更があった場合:
+When changes were made:
 ```
-設定を更新しました:
-- ~/.claude/settings.json: renga, renga-peers の許可を追加
-- .dispatcher/.claude/settings.local.json: claude 起動コマンドの許可を追加
-- (変更なし: .curator/.claude/settings.local.json)
-```
-
-変更がなかった場合:
-```
-全ての設定は最新です。変更はありません。
+Settings updated:
+- ~/.claude/settings.json: added renga, renga-peers permissions
+- .dispatcher/.claude/settings.local.json: added permission for the claude launch command
+- (no change: .curator/.claude/settings.local.json)
 ```
 
-### Step 5: drift を解消する（`--prune` モード）
+When nothing changed:
+```
+All settings are up to date. No changes.
+```
 
-通常の Step 1〜3 は **additive-only**（不足分を追加するだけで既存は削除しない）。
-過去に蓄積した広すぎる allow や旧エントリは残り続けるため、
-`permissions.md` を SOT として `settings.local.json` を**完全に書き換える** prune モードを用意している。
+### Step 5: Resolve drift (`--prune` mode)
 
-実行は `tools/org_setup_prune.py` を使う:
+The normal Steps 1–3 are **additive-only** (only add what is missing; never delete what exists).
+Overly broad allows or stale entries that have accumulated in the past therefore stick around forever, so a prune mode is provided that **completely rewrites** `settings.local.json` using `permissions.md` as the source of truth.
+
+Run it via `tools/org_setup_prune.py`:
 
 ```bash
-# 差分プレビュー（書き換え無し）
+# Diff preview (no writes)
 python tools/org_setup_prune.py --role secretary --dry-run
 python tools/org_setup_prune.py --all --dry-run
 
-# 実行（タイムスタンプ付き .bak を自動生成 → 書き換え）
+# Execute (auto-generates a timestamped .bak, then rewrites)
 python tools/org_setup_prune.py --role secretary
 python tools/org_setup_prune.py --all
 ```
 
-対象ロール: `secretary` / `dispatcher` / `curator`。
-（`user_common` は `~/.claude/settings.json` で他プラグインと同居するため対象外。
-ワーカーは org-delegate が動的生成するため対象外。）
+Target roles: `secretary` / `dispatcher` / `curator`.
+(`user_common` is excluded because `~/.claude/settings.json` coexists with other plugins.
+Workers are excluded because org-delegate generates them dynamically.)
 
-#### user 拡張の保護: `settings.local.override.json`
+#### Protecting user extensions: `settings.local.override.json`
 
-prune は `permissions.md` の role テンプレートで丸ごと書き換えるため、
-個人で追加した allow / env / hook をそのままにすると消えてしまう。
-これを避けるため、各 settings ファイルと**同じディレクトリ**に
-`settings.local.override.json` を置くと、prune 時に deep-merge される。
+Because prune wholesale-rewrites using the role template in `permissions.md`,
+any allow / env / hook you added personally would be wiped out.
+To avoid that, place a `settings.local.override.json` in the **same directory**
+as each settings file; prune deep-merges it in.
 
-例: 窓口で `Bash(my-private-tool:*)` を恒久的に許可したい場合は
-`.claude/settings.local.override.json` に以下を書く（このファイルは
-prune ツールが読むだけで、書き換えはしない）:
+Example: to permanently allow `Bash(my-private-tool:*)` for the Lead, write the
+following to `.claude/settings.local.override.json` (the prune tool only reads
+this file; it never rewrites it):
 
 ```json
 {
@@ -107,48 +107,50 @@ prune ツールが読むだけで、書き換えはしない）:
 }
 ```
 
-マージ規則:
-- `permissions.allow` / `permissions.deny`: base 順を保ったまま和集合
-- `env`: キー単位 merge（override 側が勝つ）
-- `hooks.PreToolUse[]` 等: 等値判定で重複排除した上で append
-- それ以外のスカラー: override が勝つ
+Merge rules:
+- `permissions.allow` / `permissions.deny`: union, preserving base order
+- `env`: per-key merge (override wins)
+- `hooks.PreToolUse[]` etc.: dedupe by equality, then append
+- Other scalars: override wins
 
-`.gitignore` 対象（個人設定のため。`.gitignore:23-25` で `.claude/settings.local.override.json` と
-`.claude/settings.local.json.bak.*` を ignore 済み。`.curator/.claude/` と `.dispatcher/.claude/`
-配下はディレクトリごと ignore のため自動的に対象）。チームで共有したい設定は
-`permissions.md` 側に追加し、schema (`tools/role_configs_schema.json`) も同時に更新する。
+It is `.gitignore`d (because it is personal). `.gitignore:23-25` already ignores
+`.claude/settings.local.override.json` and `.claude/settings.local.json.bak.*`.
+`.curator/.claude/` and `.dispatcher/.claude/` are entirely ignored, so they are
+covered automatically. For settings to share with the team, add them to
+`permissions.md` and update the schema (`tools/role_configs_schema.json`) at the
+same time.
 
-`tools/check_role_configs.py` は同じ override ファイルを読み、その allow を
-closed-world 検証から除外する（`_load_override_allow`）。よって override に追加した
-個人 allow は CI / `--include-local` で `unknown allow entry` にならない。
-ただし `forbidden_allow_exact`（`Bash(git *)` 等の wide allow）と
-`disallow_allow_regex`（旧 `mcp__claude-peers__*` 等）は override 側にあっても
-従来通り ERROR となる。安全契約は override で迂回できない。
+`tools/check_role_configs.py` reads the same override file and excludes its
+allows from closed-world validation (`_load_override_allow`). So personal
+allows added via override do not show up as `unknown allow entry` under CI /
+`--include-local`. However `forbidden_allow_exact` (wide allows like `Bash(git *)`)
+and `disallow_allow_regex` (e.g. legacy `mcp__claude-peers__*`) still ERROR
+even when they appear in override. The safety contract cannot be bypassed via override.
 
-#### dispatcher の `{claude_org_path}` 解決
+#### Resolving `{claude_org_path}` for the dispatcher
 
-dispatcher テンプレートには `{claude_org_path}` プレースホルダがある。
-prune ツールは以下の優先順で解決する:
+The dispatcher template contains a `{claude_org_path}` placeholder.
+The prune tool resolves it in the following order of precedence:
 
-1. `--claude-org-path <abs>` 引数
-2. 既存 `settings.local.json` の `env.CLAUDE_ORG_PATH`
-3. 既存 hook command 内の `bash "<abs>/.hooks/..."` の `<abs>`
+1. The `--claude-org-path <abs>` argument
+2. `env.CLAUDE_ORG_PATH` in the existing `settings.local.json`
+3. `<abs>` from `bash "<abs>/.hooks/..."` inside an existing hook command
 
-いずれも取れない場合（fresh install など）は `--claude-org-path` を明示する:
+If none can be obtained (fresh install, etc.), pass `--claude-org-path` explicitly:
 
 ```bash
 python tools/org_setup_prune.py --role dispatcher --claude-org-path "C:/Users/me/work/claude-org"
 ```
 
-#### バックアップ
+#### Backups
 
-書き換え前に `settings.local.json.bak.YYYYMMDD-HHMMSS` を同ディレクトリに作成する。
-失敗時はこの `.bak` を `mv` で戻せば原状復帰できる。
-不要であれば `--no-backup` で抑止できる。
+Before rewriting, a `settings.local.json.bak.YYYYMMDD-HHMMSS` is created in the same directory.
+On failure, `mv` this `.bak` back to restore the previous state.
+Suppress with `--no-backup` if not needed.
 
-## 注意事項
+## Notes
 
-- `settings.local.json` は `.gitignore` に入っている前提（個人設定のため）
-- ユーザーレベルの `~/.claude/settings.json` は既存の設定（plugins 等）を壊さないよう注意する
-- ワーカーの設定はこのスキルでは配置しない（org-delegate が担当）
-- prune の挙動は `tools/org_setup_prune.py` の docstring と `tools/test_org_setup_prune.py` のテストが正典
+- `settings.local.json` is assumed to be in `.gitignore` (because it is personal config)
+- Take care not to clobber existing settings (plugins etc.) in user-level `~/.claude/settings.json`
+- Worker settings are not placed by this skill (org-delegate handles them)
+- The canonical reference for prune behavior is the docstring in `tools/org_setup_prune.py` and the tests in `tools/test_org_setup_prune.py`

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -1,16 +1,17 @@
-# 各ロールの必要設定
+# Required settings per role
 
-> **Source of truth**: このドキュメントは人間向け説明であり、機械可読な正典は
-> [`tools/role_configs_schema.json`](../../../../tools/role_configs_schema.json)。
-> 本ファイルの JSON ブロックと schema の間に drift があれば CI
-> (`tools/check_role_configs.py`) が fail する。ルール追加や
-> 文面変更は schema → docs の順で反映すること。
+> **Source of truth**: this document is a human-facing explanation; the
+> machine-readable canonical version is
+> [`tools/role_configs_schema.json`](../../../../tools/role_configs_schema.json).
+> If the JSON blocks in this file drift from the schema, CI
+> (`tools/check_role_configs.py`) fails. When adding rules or changing
+> wording, update the schema first, then the docs.
 
-org-setup が参照する、ロールごとの permissions allow と環境変数の定義。
+The per-role definitions of permissions allow entries and environment variables that org-setup references.
 
-## ユーザー共通 (`~/.claude/settings.json`)
+## User-wide (`~/.claude/settings.json`)
 
-全ロールが必要とする設定。ユーザーレベルに置くことで全サブディレクトリに適用される。
+Settings every role needs. Putting them at the user level applies them to every subdirectory.
 
 ```json
 {
@@ -45,21 +46,21 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 }
 ```
 
-**Bash permission 方針**: 旧 `Bash(renga:*)` glob は撤去済み（renga 0.14.0+ でペイン操作・ピア通信・event 購読・スクレイプ・raw キー送信がすべて MCP 化されたため）。残している `Bash(renga …)` は **運用コマンド限定**:
+**Bash permission policy**: the legacy `Bash(renga:*)` glob has been removed (since renga 0.14.0+ pane operations, peer messaging, event subscription, scraping, and raw key sending are all available via MCP). The remaining `Bash(renga …)` entries are **operational commands only**:
 
-- `renga --version` / `renga --help`: 環境確認
-- `renga --layout ops` 相当 (`--layout:*`): 初回レイアウト起動（`renga-layouts/ops.toml` 参照）
-- `renga mcp install` / `uninstall` / `status` / `--help`: MCP サーバー登録管理（`mcp__renga-peers__*` を使えるようにするための bootstrap）
+- `renga --version` / `renga --help`: environment check
+- Equivalent of `renga --layout ops` (`--layout:*`): initial layout launch (see `renga-layouts/ops.toml`)
+- `renga mcp install` / `uninstall` / `status` / `--help`: MCP server registration management (bootstrap to make `mcp__renga-peers__*` usable)
 
-ペイン操作（`renga split` / `close` / `list` / `send` / `events` / `inspect` / `new-tab` 等）は MCP ツール (`mcp__renga-peers__*`) 経由で実施する。該当 Bash permission は含めない。
+Pane operations (`renga split` / `close` / `list` / `send` / `events` / `inspect` / `new-tab` etc.) go through MCP tools (`mcp__renga-peers__*`). Do not include the corresponding Bash permissions.
 
-**注意**: `renga-peers` MCP ツール 14 種は `renga mcp install` を一度実行して user-scope に MCP サーバーを登録した後に利用可能になる。登録手順は README「インストール」セクションを参照。
+**Note**: the 14 `renga-peers` MCP tools become usable only after running `renga mcp install` once to register the MCP server at user scope. See the README "Installation" section for the registration procedure.
 
-## 窓口 (`<repo>/.claude/settings.local.json`)
+## Lead (`<repo>/.claude/settings.local.json`)
 
-窓口固有の設定。ユーザー共通分はユーザーレベルにあるため、ここには窓口だけが必要なものを書く。
+Lead-specific settings. Common entries live at the user level, so write only what only the Lead needs here.
 
-**narrow 方針**: `gh:*` のような機能全体を許す wide allow は避け、`gh issue:*` `gh pr:*` のように**サブコマンドごとに narrow** にする。git も `Bash(git *)`（スペース形式 wildcard）ではなく `Bash(git add:*)` 等の `:*` コロン形式で narrow にする。
+**Narrow policy**: avoid wide allows that grant entire feature sets like `gh:*`; instead, **narrow per subcommand** like `gh issue:*` / `gh pr:*`. For git, also narrow with the colon form `Bash(git add:*)` etc., not `Bash(git *)` (the space-form wildcard).
 
 ```json
 {
@@ -140,38 +141,38 @@ org-setup が参照する、ロールごとの permissions allow と環境変数
 }
 ```
 
-**mcp__renga-peers__\* の重複**: ユーザー共通 settings.json と重複するが、窓口は run 直後に renga-peers MCP を必ず使うため、窓口スコープでも明示的に列挙して source-of-truth として固定する（user settings の drift でも窓口が動くことを保証）。
+**Duplication of mcp__renga-peers__\***: these duplicate the user-wide settings.json, but the Lead always uses the renga-peers MCP immediately on launch, so we explicitly list them at Lead scope as well to pin the source of truth (so the Lead still works even if user settings drift).
 
-**renga bootstrap の重複**: 同じ理由でユーザー共通と重複するが、窓口が初回レイアウト起動やペイン制御で即時使うため明示列挙。
+**Duplicate renga bootstrap**: duplicates user-wide settings for the same reason — the Lead uses these immediately for initial layout launch and pane control, so we list them explicitly.
 
-**並び順**: (1) MCP ツール、(2) git、(3) gh、(4) python/dashboard、(5) renga bootstrap、(6) その他（sleep / codex / curl / PowerShell）。新規エントリ追加時はこの並び順を維持する。
+**Ordering**: (1) MCP tools, (2) git, (3) gh, (4) python/dashboard, (5) renga bootstrap, (6) other (sleep / codex / curl / PowerShell). Preserve this order when adding new entries.
 
-**hooks の説明**: `block-workers-delete.sh` は workers ディレクトリへの再帰的削除（`rm -r`/`rm -rf`/`rm --recursive`）をブロックする。個別ファイルの `rm` は許可する。`renga` コマンドは除外する（ワーカー起動時の偽陽性防止）。
+**About hooks**: `block-workers-delete.sh` blocks recursive deletion of the workers directory (`rm -r` / `rm -rf` / `rm --recursive`). It allows `rm` of individual files. The `renga` command is excluded (to prevent false positives during Worker launch).
 
-**書いてはいけないもの**:
-- wide allow (`Bash(git *)`, `Bash(git push *)`, `Bash(git fetch *)`, `Bash(git branch *)`, `Bash(git pull *)`, `Bash(gh:*)`, `Bash(gh *)`)
-- 旧 `mcp__claude-peers__*`（2025 年に renga-peers へ移行済み）
-- 旧 `renga list/split/send/events/close/inspect *` の Bash allow（renga 0.14.0+ で MCP 化）
-- 過去の一発コマンド（特定 PR 番号・branch 名・PID を含むコマンド、`gh pr create --repo ... --head feat/xxx ...` 等）
-- user-specific absolute path（`Read(//c/Users/<you>/Documents/work/**)` のような）
+**What must not be written**:
+- Wide allows (`Bash(git *)`, `Bash(git push *)`, `Bash(git fetch *)`, `Bash(git branch *)`, `Bash(git pull *)`, `Bash(gh:*)`, `Bash(gh *)`)
+- Legacy `mcp__claude-peers__*` (migrated to renga-peers in 2025)
+- Legacy Bash allows for `renga list/split/send/events/close/inspect *` (replaced by MCP in renga 0.14.0+)
+- Past one-shot commands (commands containing a specific PR number / branch name / PID, like `gh pr create --repo ... --head feat/xxx ...`)
+- User-specific absolute paths (such as `Read(//c/Users/<you>/Documents/work/**)`)
 
-これらが蓄積すると drift となる。定期的に `permissions.md` と突き合わせて剪定する。
+If these accumulate, you have drift. Periodically prune by reconciling against `permissions.md`.
 
-**剪定（drift 解消）は `--prune` モードで自動化済み**: 上記「書いてはいけないもの」のエントリが `settings.local.json` に蓄積した場合、`tools/org_setup_prune.py` で本ドキュメントの role 別サンプルを SOT として丸ごと書き換えられる。
+**Pruning (drift resolution) is automated via the `--prune` mode**: when entries from "What must not be written" above accumulate in `settings.local.json`, you can wholesale-rewrite using the per-role samples in this document as the SOT via `tools/org_setup_prune.py`.
 
 ```bash
-python tools/org_setup_prune.py --role secretary --dry-run   # diff プレビュー
-python tools/org_setup_prune.py --role secretary             # 実行（.bak を自動生成）
-python tools/org_setup_prune.py --all                        # secretary / dispatcher / curator まとめて
+python tools/org_setup_prune.py --role secretary --dry-run   # diff preview
+python tools/org_setup_prune.py --role secretary             # execute (auto-generates .bak)
+python tools/org_setup_prune.py --all                        # secretary / dispatcher / curator together
 ```
 
-**user 拡張の保護**: 個人で追加した allow / env / hook を残すには、各 settings ファイルと**同じディレクトリ**に `settings.local.override.json` を置く。prune 時に deep-merge され、ツールはこの override ファイルを書き換えない。詳細は `.claude/skills/org-setup/SKILL.md` の Step 5 参照。
+**Protecting user extensions**: to keep personally added allow / env / hook entries, place a `settings.local.override.json` in the **same directory** as each settings file. Prune deep-merges it in, and the tool never rewrites the override file. See Step 5 of `.claude/skills/org-setup/SKILL.md` for details.
 
-## フォアマン (`<repo>/.dispatcher/.claude/settings.local.json`)
+## Dispatcher (`<repo>/.dispatcher/.claude/settings.local.json`)
 
-フォアマンはワーカーペインで claude を起動し、ペイン内容を取得する。
+The Dispatcher launches claude in Worker panes and inspects pane contents.
 
-**重要**: フォアマンは Sonnet 制約により `permission_mode=bypassPermissions` で起動するため、`permissions.allow` と `permissions.deny` は **両方とも bypass される**（Claude Code 公式仕様）。実効的な書き込み境界・git 制限は **PreToolUse フックでしか強制できない**。下記 `hooks.PreToolUse` がフォアマンの唯一の障壁であり、削除・無効化してはいけない。
+**Important**: due to a Sonnet constraint, the Dispatcher launches with `permission_mode=bypassPermissions`, so **both `permissions.allow` and `permissions.deny` are bypassed** (Claude Code official behavior). The effective write boundary and git restrictions can **only be enforced by PreToolUse hooks**. The `hooks.PreToolUse` block below is the Dispatcher's only barrier; do not delete or disable it.
 
 ```json
 {
@@ -221,18 +222,18 @@ python tools/org_setup_prune.py --all                        # secretary / dispa
 }
 ```
 
-**注意**: `{claude_org_path}` は settings.local.json 生成時に解決済みの絶対パスに置換すること。Hook command 内のパスはスペース対策のためクォートされている。
+**Note**: replace `{claude_org_path}` with a resolved absolute path when generating `settings.local.json`. Paths inside hook commands are quoted to handle spaces.
 
-**hooks の役割分担**:
-- `block-dispatcher-out-of-scope.sh`: フォアマンの Edit/Write 対象パスを `.dispatcher/`, `.state/`, `knowledge/raw/YYYY-MM-DD-{topic}.md` に限定。アプリケーションコード（`tools/`, `dashboard/`, `tests/`, `.claude/skills/`, `docs/`, `registry/` 等）の編集はワーカーへの委譲を強制する
-- `block-git-push.sh`: フォアマンからの直接 push を禁止（push は窓口経由）
-- `block-dangerous-git.sh`: `git push --force` / `git reset --hard` / `git branch -D` をブロック
-- `block-workers-delete.sh`: workers ディレクトリの再帰削除をブロック（ワーカー成果物の保護）
-- `block-no-verify.sh`: `--no-verify` 系の検証バイパスをブロック
+**Hook responsibilities**:
+- `block-dispatcher-out-of-scope.sh`: limits the Dispatcher's Edit/Write target paths to `.dispatcher/`, `.state/`, and `knowledge/raw/YYYY-MM-DD-{topic}.md`. Forces delegation to a Worker for application code (`tools/`, `dashboard/`, `tests/`, `.claude/skills/`, `docs/`, `registry/`, etc.)
+- `block-git-push.sh`: forbids the Dispatcher from pushing directly (push goes through the Lead)
+- `block-dangerous-git.sh`: blocks `git push --force` / `git reset --hard` / `git branch -D`
+- `block-workers-delete.sh`: blocks recursive deletion of the workers directory (protects Worker deliverables)
+- `block-no-verify.sh`: blocks `--no-verify`-style validation bypass
 
-## キュレーター (`<repo>/.curator/.claude/settings.local.json`)
+## Curator (`<repo>/.curator/.claude/settings.local.json`)
 
-キュレーターは知見整理のみ。追加の Bash 許可は不要。
+The Curator does only knowledge curation. No additional Bash permissions are needed.
 
 ```json
 {
@@ -242,9 +243,9 @@ python tools/org_setup_prune.py --all                        # secretary / dispa
 }
 ```
 
-## ワーカー（動的生成）
+## Worker (dynamically generated)
 
-ワーカーの設定は org-delegate の Step 3 で動的に作成される。
+Worker settings are created dynamically in Step 3 of org-delegate.
 
 ```json
 {
@@ -306,6 +307,6 @@ python tools/org_setup_prune.py --all                        # secretary / dispa
 }
 ```
 
-**注意**: `{claude_org_path}` と `{worker_dir}` は settings.local.json 生成時に解決済みの絶対パスに置換すること。Hook command 内のパスはスペース対策のためクォートされている。
+**Note**: replace `{claude_org_path}` and `{worker_dir}` with resolved absolute paths when generating `settings.local.json`. Paths inside hook commands are quoted to handle spaces.
 
-**deny と hooks の役割分担**: `permissions.deny` は静的パターンマッチによるブロックで、`bypassPermissions` モードでも常に有効。外部コマンド（jq, bash）に依存しないため信頼性が高い。一方 hooks はワーカーディレクトリ境界チェック等の動的検証を担う。両者を併用することで多層防御を実現する。`deny` は `echo foo && git push` のような埋め込みコマンドはカバーできないため、`block-git-push.sh` hook は副次防御として維持する。
+**Roles of `deny` and hooks**: `permissions.deny` blocks via static pattern match and is always effective even in `bypassPermissions` mode. It does not depend on external commands (jq, bash), making it highly reliable. Hooks meanwhile handle dynamic checks like Worker directory boundary checks. Combining the two yields defense in depth. Because `deny` cannot cover embedded commands like `echo foo && git push`, the `block-git-push.sh` hook is kept as a secondary defense.

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -20,7 +20,7 @@ The first skill to run after ClaudeCode launches. It restores prior state, bring
 
 ## Step 0: Initialization
 
-1. Set your own summary via `mcp__renga-peers__set_summary`: "Secretary: Lead"
+1. Set your own summary via `mcp__renga-peers__set_summary`: "Lead"
    - Required so that Workers / Dispatcher / Curator can find the Lead via `mcp__renga-peers__list_peers`
 2. Verify `renga-peers` MCP connectivity by calling `mcp__renga-peers__list_panes`.
    - If a response comes back without error, MCP is enabled. From here on, assume the renga-peers MCP tools are usable.
@@ -122,7 +122,7 @@ Pane layout follows org-delegate/references/pane-layout.md (renga edition).
    - `name="dispatcher"`: stable name used for later `mcp__renga-peers__send_message(to_id="dispatcher", ...)` and `close_pane(target="dispatcher")`. **renga-peers interprets all-digit names as ids, so always use a name that contains letters.**
    - `cwd=".dispatcher"`: resolved to `.dispatcher/` relative to the caller pane (= Lead) cwd. The old method of embedding `cd X && claude ...` in `command` is prohibited (auto-upgrade does not fire and channel push is lost).
    - `permission_mode="bypassPermissions"` / `model="sonnet"`: renga composes and runs `claude --permission-mode bypassPermissions --model sonnet --dangerously-load-development-channels server:renga-peers`
-   - `.dispatcher/CLAUDE.md` contains the role instructions for the Dispatcher (separate from the Secretary's CLAUDE.md)
+   - `.dispatcher/CLAUDE.md` contains the role instructions for the Dispatcher (separate from the Lead's CLAUDE.md)
    - Return value: text of the form `"Spawned pane id=N."`. Subsequent pane operations should reference it as `name="dispatcher"`.
    - Errors are returned as text in `[<code>] <msg>` form (e.g. `[split_refused]` / `[pane_not_found]` / `[cwd_invalid]`). See `.claude/skills/org-delegate/references/renga-error-codes.md` for the code list and branches.
 2. On the first launch of Claude Code, a "Load development channel? (Y/n)" prompt appears. Approve it by sending Enter via `mcp__renga-peers__send_keys`:

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -1,110 +1,110 @@
 ---
 name: org-start
 description: >
-  組織を起動する。前回の状態を読み込んでブリーフィングし、
-  フォアマンとキュレーターペインを起動する。ClaudeCode起動直後に1回実行する。
-  「起動して」「スタート」「始めて」等でも発動。
+  Start the organization. Load prior state, brief, and bring up the Dispatcher
+  and Curator panes. Run this once immediately after launching ClaudeCode.
+  Also triggered by "start it", "boot", "begin", etc.
 ---
 
-# org-start: 組織の起動
+# org-start: Starting the organization
 
-ClaudeCode起動後に最初に実行するスキル。前回の状態復元、フォアマン起動、キュレーター起動を行う。
+The first skill to run after ClaudeCode launches. It restores prior state, brings up the Dispatcher, and brings up the Curator.
 
-> **前提**: この Claude は `renga --layout ops` で起動された窓口ペイン内で動作している。
-> `RENGA_SOCKET` / `RENGA_PANE_ID` 環境変数が継承されているので、`mcp__renga-peers__*` MCP
-> ツール 14 種（`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` /
+> **Prerequisite**: This Claude runs inside a Lead pane that was started via `renga --layout ops`.
+> The `RENGA_SOCKET` / `RENGA_PANE_ID` environment variables are inherited, so the 14 `mcp__renga-peers__*` MCP
+> tools (`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` /
 > `list_panes` / `new_tab` / `send_message` / `list_peers` / `set_summary` /
 > `check_messages` / `inspect_pane` / `poll_events` / `send_keys` /
-> `set_pane_identity`）で同タブ内のペイン操作・ピア通信・画面スクレイプ・lifecycle
-> event 購読・raw キー入力まですべてカバーできる（**renga 0.18.0+ 前提**）。
+> `set_pane_identity`) cover everything: pane operations within the same tab, peer messaging, screen scraping, lifecycle
+> event subscription, even raw key input (**requires renga 0.18.0+**).
 
-## Step 0: 初期化
+## Step 0: Initialization
 
-1. `mcp__renga-peers__set_summary` で自分のサマリーを設定する: 「Secretary: 窓口」
-   - ワーカー / フォアマン / キュレーターが `mcp__renga-peers__list_peers` で窓口を発見するために必須
-2. `renga-peers` MCP の疎通確認: `mcp__renga-peers__list_panes` を呼び出す。
-   - エラーなく応答が返れば MCP 有効。以降 renga-peers MCP ツールが使える前提で進む
-   - エラーが返る / ツール未登録の場合はユーザーに `renga mcp install` の実行を促し、
-     Skill の実行を一時停止する（MCP 導入後にやり直してもらう）。詳細は README の
-     「インストール」セクション参照
-3. **secretary ペイン identity の検証と自動リカバリ**:
-   - `mcp__renga-peers__list_panes` の結果から `focused=true` のペイン（= 自分）を特定する
-   - 期待値: `name == "secretary"` かつ `role == "secretary"`
-   - **不一致の場合** — `renga --layout ops` 以外の経路で起動された / 旧ops.tomlで起動された既存セッションに attach 等:
-     1. `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")` を呼んで自動修復
-     2. 成功すれば警告ログ（`journal.jsonl` に `{"event":"secretary_identity_restored"}`）を残して続行
-     3. 失敗ケースの分岐:
-        - `name_in_use` エラー: 既存の別ペインが `secretary` を占有している。ユーザーに状況を報告し、「現セッション継続なら全ワーカーに `to_id="{numeric_pane_id}"` で送信させる」「永続修復なら `/org-suspend` → 終了 → `renga --layout ops` で再起動」の選択肢を提示
-        - `name_invalid` / その他: ユーザーに原因を報告
-   - **一致している場合**: そのまま続行
-4. `registry/org-config.md` の `workers_dir` を読み、ワーカーディレクトリの存在を確認する。
-   存在するディレクトリがあれば一覧をユーザーに報告する（削除は絶対にしない）。
-   **禁止事項**: ワーカーディレクトリは過去の作業成果や再利用可能なプロジェクトを含むため、
-   org-start 時に削除してはならない。org-delegate のディレクトリ保持ポリシーに従うこと。
+1. Set your own summary via `mcp__renga-peers__set_summary`: "Secretary: Lead"
+   - Required so that Workers / Dispatcher / Curator can find the Lead via `mcp__renga-peers__list_peers`
+2. Verify `renga-peers` MCP connectivity by calling `mcp__renga-peers__list_panes`.
+   - If a response comes back without error, MCP is enabled. From here on, assume the renga-peers MCP tools are usable.
+   - If an error is returned / the tool is unregistered, prompt the user to run `renga mcp install`
+     and pause this Skill (have them retry once MCP is set up). See the README's
+     "Installation" section for details.
+3. **Validate the secretary pane identity and auto-recover if needed**:
+   - From the result of `mcp__renga-peers__list_panes`, identify the pane with `focused=true` (= yourself)
+   - Expected: `name == "secretary"` and `role == "secretary"`
+   - **If they do not match** — started via a path other than `renga --layout ops`, or attached to an existing session created with an old ops.toml, etc.:
+     1. Call `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")` to auto-repair
+     2. On success, leave a warning log (`{"event":"secretary_identity_restored"}` in `journal.jsonl`) and continue
+     3. Failure branches:
+        - `name_in_use` error: another existing pane occupies `secretary`. Report the situation to the user and offer the choice between "if continuing the current session, have all Workers send with `to_id="{numeric_pane_id}"`" or "for a permanent fix, `/org-suspend` → exit → restart with `renga --layout ops`".
+        - `name_invalid` / other: report the cause to the user
+   - **If they match**: continue as-is
+4. Read `workers_dir` from `registry/org-config.md` and confirm that the worker directories exist.
+   If any directories exist, report the list to the user (never delete them).
+   **Prohibited**: worker directories may contain past deliverables or reusable projects, so
+   they must not be deleted at org-start time. Follow the directory retention policy in org-delegate.
 
-## Step 1: 前回の状態確認
+## Step 1: Check prior state
 
-1. `.state/org-state.md` が存在するか確認する
-2. 存在する場合:
-   - ファイルを読み、Status を確認する
-   - Status が `SUSPENDED` なら /org-resume の Phase 1〜3（ブリーフィング・照合・再開計画）を実行する。
-     その後 Step 2 以降に進み、フォアマン・キュレーターを起動してから、org-resume の Phase 4（ワーカー再派遣）を人間の承認に基づいて実行する
-   - Status が `ACTIVE` なら、前回のセッションが突然終了した可能性がある。
-     各ワーカーディレクトリの git 状態を確認し、現状を報告する
-3. 存在しない場合:
-   - 初回起動と判断する
+1. Check whether `.state/org-state.md` exists
+2. If it exists:
+   - Read the file and check Status
+   - If Status is `SUSPENDED`, run Phases 1–3 (briefing / reconciliation / resume plan) of /org-resume.
+     Then proceed to Step 2 onward, bring up the Dispatcher and Curator, and finally execute Phase 4 (re-dispatch Workers) of /org-resume based on human approval
+   - If Status is `ACTIVE`, the prior session may have terminated abruptly.
+     Check the git status of each worker directory and report the current state
+3. If it does not exist:
+   - Treat this as the first launch
 
-## ClaudeCode 起動コマンド（役割別）
+## ClaudeCode launch commands (per role)
 
-renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造化フィールド（`cwd` / `permission_mode` / `model` / `args[]`）を受け取り、`--dangerously-load-development-channels server:renga-peers` を自動付与する。旧方式の `cd X && claude ...` を `spawn_pane` に流し込むパターンは **禁止**（renga の bare-`claude` auto-upgrade が発動せず channel push が届かなくなる落とし穴を再導入するため）。
+In renga 0.18.0+, `mcp__renga-peers__spawn_claude_pane` accepts role-specific structured fields (`cwd` / `permission_mode` / `model` / `args[]`) and automatically appends `--dangerously-load-development-channels server:renga-peers`. The old pattern of feeding `cd X && claude ...` into `spawn_pane` is **prohibited** (it reintroduces the trap where renga's bare-`claude` auto-upgrade does not fire and channel push fails to arrive).
 
-共通引数:
-- `permission_mode`: registry/org-config.md の default_permission_mode の値を使用（フォアマン除く）
-- `cwd`: 各ロール専用ディレクトリへの相対パス（caller pane の cwd 基準で解決される）
+Common arguments:
+- `permission_mode`: use the value of `default_permission_mode` from registry/org-config.md (except for the Dispatcher)
+- `cwd`: relative path to each role's dedicated directory (resolved against the caller pane's cwd)
 
-### フォアマン
+### Dispatcher
 
 - `cwd=".dispatcher"`
-- `permission_mode="bypassPermissions"`（固定。`default_permission_mode` の影響を受けない）
+- `permission_mode="bypassPermissions"` (fixed; not affected by `default_permission_mode`)
 - `model="sonnet"`
 
-理由: フォアマンはワーカー起動時に `mcp__renga-peers__spawn_claude_pane` を発行する。auto モードの安全分類器はこの「子エージェント起動」を "Create Unsafe Agents" と判定してブロックするため、auto ではワーカー派遣が成立しない。
+Reason: when launching Workers, the Dispatcher issues `mcp__renga-peers__spawn_claude_pane`. The auto-mode safety classifier flags this "child agent launch" as "Create Unsafe Agents" and blocks it, so Worker dispatch does not work in auto mode.
 
-### キュレーター
+### Curator
 
 - `cwd=".curator"`
 - `permission_mode={default_permission_mode}`
 - `model="opus"`
 
-### ワーカー（org-delegate の Step 3 で使用）
+### Worker (used in org-delegate Step 3)
 
-**`model="opus"` は必須（sonnet 禁止）。**
-理由: ワーカーの既定 permission_mode は `auto`（分類器ベース）。この safety classifier は Opus でのみ安定動作する。sonnet だと分類器が誤判定を多発し、承認フローが崩れて作業が詰まる。フォアマンだけは `bypassPermissions` 固定なので分類器を経由せず、sonnet 運用で問題ない（フォアマンを sonnet にしているのはコスト最適化のため、ワーカーには適用しない）。
+**`model="opus"` is required (sonnet prohibited).**
+Reason: the Worker's default permission_mode is `auto` (classifier-based). This safety classifier only operates reliably on Opus. With sonnet the classifier misclassifies frequently, the approval flow breaks down, and work stalls. Only the Dispatcher is fixed at `bypassPermissions`, so it bypasses the classifier and runs fine on sonnet (the Dispatcher uses sonnet as a cost optimization; do not extend that to Workers).
 
-通常:
-- `cwd="{workers_dir}/{task_id}"`（絶対パス推奨）
+Normal:
+- `cwd="{workers_dir}/{task_id}"` (absolute path recommended)
 - `permission_mode={default_permission_mode}`
 - `model="opus"`
 
-## Step 1.5: ダッシュボードサーバー起動
+## Step 1.5: Start the dashboard server
 
-1. ダッシュボードサーバーが起動しているか確認する:
+1. Check whether the dashboard server is running:
    ```bash
    cat .state/dashboard.pid 2>/dev/null && kill -0 $(cat .state/dashboard.pid) 2>/dev/null && echo "running" || echo "stopped"
    ```
-2. 停止中であれば起動する:
+2. If stopped, start it:
    ```bash
    python3 dashboard/server.py &   # Mac/Linux
    py -3 dashboard/server.py &     # Windows
    ```
-3. ユーザーに案内する:
-   「ダッシュボードを起動しました → http://localhost:8099」
+3. Tell the user:
+   "Dashboard started → http://localhost:8099"
 
-## Step 2: フォアマンペイン起動
+## Step 2: Spawn the Dispatcher pane
 
-ペイン配置は org-delegate/references/pane-layout.md に従う (renga 版)。
+Pane layout follows org-delegate/references/pane-layout.md (renga edition).
 
-1. `mcp__renga-peers__spawn_claude_pane` で窓口ペインを上下分割し、下半分にフォアマン用の Claude を起動する:
+1. Use `mcp__renga-peers__spawn_claude_pane` to split the Lead pane horizontally and launch the Dispatcher Claude in the bottom half:
    ```
    mcp__renga-peers__spawn_claude_pane(
      target="focused",
@@ -116,31 +116,31 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
      model="sonnet"
    )
    ```
-   - `target="focused"`: 現在フォーカスされている窓口ペインを分割（省略可。省略時は focused）
-   - `direction="horizontal"` = 上下分割（窓口=上 / フォアマン=下）
-   - `role="dispatcher"`: `mcp__renga-peers__list_panes` で役割識別できるようにラベル付与
-   - `name="dispatcher"`: 後続の `mcp__renga-peers__send_message(to_id="dispatcher", ...)` や `close_pane(target="dispatcher")` で宛先指定するための安定名。**renga-peers は全桁数字の name を id として解釈するので、英字を含む名前を必ず付ける**
-   - `cwd=".dispatcher"`: caller ペイン（= 窓口）の cwd を基点に `.dispatcher/` へ解決される。`cd X && claude ...` を `command` に埋める旧方式は禁止（auto-upgrade が発動せず channel push が失われる落とし穴）
-   - `permission_mode="bypassPermissions"` / `model="sonnet"`: renga が `claude --permission-mode bypassPermissions --model sonnet --dangerously-load-development-channels server:renga-peers` を合成して実行する
-   - `.dispatcher/CLAUDE.md` にフォアマン用の役割指示がある（Secretary の CLAUDE.md とは別）
-   - 戻り値: `"Spawned pane id=N."` のテキスト。以降のペイン操作では `name="dispatcher"` で参照する
-   - エラーは `[<code>] <msg>` 形式のテキストで返却される（例: `[split_refused]` / `[pane_not_found]` / `[cwd_invalid]`）。code 一覧と分岐は `.claude/skills/org-delegate/references/renga-error-codes.md` を参照
-2. Claude Code 初回起動時に「Load development channel? (Y/n)」確認プロンプトが表示される。`mcp__renga-peers__send_keys` で Enter を送信して承認する:
+   - `target="focused"`: split the currently focused Lead pane (optional; defaults to focused)
+   - `direction="horizontal"` = top/bottom split (Lead = top / Dispatcher = bottom)
+   - `role="dispatcher"`: label so that `mcp__renga-peers__list_panes` can identify the role
+   - `name="dispatcher"`: stable name used for later `mcp__renga-peers__send_message(to_id="dispatcher", ...)` and `close_pane(target="dispatcher")`. **renga-peers interprets all-digit names as ids, so always use a name that contains letters.**
+   - `cwd=".dispatcher"`: resolved to `.dispatcher/` relative to the caller pane (= Lead) cwd. The old method of embedding `cd X && claude ...` in `command` is prohibited (auto-upgrade does not fire and channel push is lost).
+   - `permission_mode="bypassPermissions"` / `model="sonnet"`: renga composes and runs `claude --permission-mode bypassPermissions --model sonnet --dangerously-load-development-channels server:renga-peers`
+   - `.dispatcher/CLAUDE.md` contains the role instructions for the Dispatcher (separate from the Secretary's CLAUDE.md)
+   - Return value: text of the form `"Spawned pane id=N."`. Subsequent pane operations should reference it as `name="dispatcher"`.
+   - Errors are returned as text in `[<code>] <msg>` form (e.g. `[split_refused]` / `[pane_not_found]` / `[cwd_invalid]`). See `.claude/skills/org-delegate/references/renga-error-codes.md` for the code list and branches.
+2. On the first launch of Claude Code, a "Load development channel? (Y/n)" prompt appears. Approve it by sending Enter via `mcp__renga-peers__send_keys`:
    ```
    mcp__renga-peers__send_keys(target="dispatcher", enter=true)
    ```
-   - Enter は CR (0x0D) として PTY に書き込まれる
-   - 承認しないと `server:renga-peers` チャネルが有効化されず、`send_message` の channel push が届かない。Step 3 の `list_peers` 待ちもタイムアウトする
-3. `mcp__renga-peers__list_peers` で新しいピアが現れるのを待つ
-4. `mcp__renga-peers__send_message` でフォアマンに以下を送信する:
-   「あなたはフォアマンです。窓口からの DELEGATE メッセージを受け取り、ワーカーのペイン起動・指示送信・状態記録を代行してください。CLOSE_PANE メッセージを受けたらペインを閉じてください。」
-5. フォアマンのピアIDと renga ペイン名（`dispatcher`）を記録する（org-state.md の Dispatcher セクション）
-6. JSON スナップショットを再生成する:
+   - Enter is written to the PTY as CR (0x0D)
+   - Without this approval the `server:renga-peers` channel is not enabled, and channel push from `send_message` does not arrive. The `list_peers` wait in Step 3 will also time out.
+3. Wait for the new peer to appear via `mcp__renga-peers__list_peers`
+4. Send the following to the Dispatcher via `mcp__renga-peers__send_message`:
+   "You are the Dispatcher. Receive DELEGATE messages from the Lead and, on its behalf, launch Worker panes, send instructions, and record state. When you receive a CLOSE_PANE message, close the pane."
+5. Record the Dispatcher's peer ID and renga pane name (`dispatcher`) (in the Dispatcher section of org-state.md)
+6. Regenerate the JSON snapshot:
    `py -3 dashboard/org_state_converter.py`
 
-## Step 3: キュレーターペイン起動
+## Step 3: Spawn the Curator pane
 
-1. `mcp__renga-peers__spawn_claude_pane` でフォアマンペインの右半分をキュレーター用に立ち上げる:
+1. Use `mcp__renga-peers__spawn_claude_pane` to launch the Curator on the right half of the Dispatcher pane:
    ```
    mcp__renga-peers__spawn_claude_pane(
      target="dispatcher",
@@ -152,38 +152,38 @@ renga 0.18.0+ では `mcp__renga-peers__spawn_claude_pane` が役割別の構造
      model="opus"
    )
    ```
-   - `target="dispatcher"`: Step 2 で命名したフォアマンペインを分割対象に指定
-   - `direction="vertical"` = 左右分割（フォアマン=左 / キュレーター=右）
-   - `name="curator"`: 安定名（英字を含む、全桁数字禁止）
-   - `cwd=".curator"`: caller ペイン（= 窓口）の cwd 基点で `.curator/` 解決
-   - `.curator/CLAUDE.md` にキュレーター用の役割指示がある
-   - エラーは Step 2 と同様の `[<code>] <msg>` 形式
-2. Step 2 と同様に「Load development channel?」確認プロンプトを Enter で承認する:
+   - `target="dispatcher"`: target the Dispatcher pane named in Step 2 for splitting
+   - `direction="vertical"` = left/right split (Dispatcher = left / Curator = right)
+   - `name="curator"`: stable name (must contain letters; all-digit names are forbidden)
+   - `cwd=".curator"`: resolved to `.curator/` from the caller pane (= Lead) cwd
+   - `.curator/CLAUDE.md` contains the role instructions for the Curator
+   - Errors use the same `[<code>] <msg>` form as Step 2
+2. As in Step 2, approve the "Load development channel?" prompt with Enter:
    ```
    mcp__renga-peers__send_keys(target="curator", enter=true)
    ```
-3. `mcp__renga-peers__list_peers` で新しいピアが現れるのを待つ
-4. `mcp__renga-peers__send_message` でキュレーターに以下を送信する:
-   「あなたはキュレーターです。 /loop 30m /org-curate を実行してください。知見整理を30分ごとに行います。」
-5. キュレーターのピアIDと renga ペイン名（`curator`）を記録する（org-state.md の Curator セクション）
-6. JSON スナップショットを再生成する:
+3. Wait for the new peer to appear via `mcp__renga-peers__list_peers`
+4. Send the following to the Curator via `mcp__renga-peers__send_message`:
+   "You are the Curator. Run /loop 30m /org-curate. Knowledge curation runs every 30 minutes."
+5. Record the Curator's peer ID and renga pane name (`curator`) (in the Curator section of org-state.md)
+6. Regenerate the JSON snapshot:
    `py -3 dashboard/org_state_converter.py`
 
-## Step 4: 準備完了の報告
+## Step 4: Report readiness
 
-人間に簡潔に報告する:
+Report concisely to the human:
 
-**前回の状態がある場合**:
+**When prior state exists**:
 ```
-組織を起動しました。
-前回の状態: {サマリー}
-フォアマンとキュレーターを起動しました。
-何をしますか？
+Organization started.
+Prior state: {summary}
+Dispatcher and Curator are up.
+What would you like to do?
 ```
 
-**初回起動の場合**:
+**On first launch**:
 ```
-組織を起動しました。
-フォアマンとキュレーターを起動しました。
-プロジェクトはまだ登録されていません。何をしましょうか？
+Organization started.
+Dispatcher and Curator are up.
+No projects are registered yet. What shall we do?
 ```

--- a/tools/role_configs_schema.json
+++ b/tools/role_configs_schema.json
@@ -50,7 +50,7 @@
     },
     "user_common": {
       "description": "User-level (~/.claude/settings.json) — shared across all roles.",
-      "docs_section": "ユーザー共通",
+      "docs_section": "User-wide",
       "settings_paths": [],
       "closed_world": true,
       "required_allow": [
@@ -83,7 +83,7 @@
     },
     "secretary": {
       "description": "Lead (role id: secretary) — repo .claude/settings.local.json.",
-      "docs_section": "窓口",
+      "docs_section": "Lead",
       "settings_paths": [".claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -156,7 +156,7 @@
     },
     "dispatcher": {
       "description": "Dispatcher — .dispatcher/.claude/settings.local.json. Runs in bypassPermissions mode (Sonnet constraint), so permissions.allow / deny are no-ops; PreToolUse hooks are the only enforcement layer.",
-      "docs_section": "フォアマン",
+      "docs_section": "Dispatcher",
       "settings_paths": [".dispatcher/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -200,7 +200,7 @@
     },
     "curator": {
       "description": "Curator — .curator/.claude/settings.local.json (narrow / empty by design).",
-      "docs_section": "キュレーター",
+      "docs_section": "Curator",
       "settings_paths": [".curator/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [],
@@ -216,7 +216,7 @@
     },
     "worker": {
       "description": "Worker (dynamic template) — <worker_dir>/.claude/settings.local.json.",
-      "docs_section": "ワーカー",
+      "docs_section": "Worker",
       "settings_paths": [],
       "closed_world": true,
       "required_allow": [


### PR DESCRIPTION
## Summary

Wave B-runtime PR-8 of the 5-Wave plan for claude-org-ja#110.

Translates 9 files (B2 structure-preserving):
- `.claude/skills/org-start/SKILL.md`
- `.claude/skills/org-setup/SKILL.md` + `references/permissions.md`
- `.claude/skills/org-delegate/SKILL.md` + `references/{claude-org-self-edit,instruction-template,pane-layout,renga-error-codes,worker-claude-template}.md`

Glossary terms locked. Code blocks, frontmatter, paths preserved.

## Codex review

- Round 1: Major:6 (Secretary alias drift) → fixed in commit 5d64802 (rendered as `Lead` per glossary).
- Round 2: clean. One Minor retained (source-level wording).
- The `secretary` lowercase literal is preserved as a pane-name code identifier, matching org-start / org-curate behaviour.

## Manifest entries

- `.claude/skills/org-start/SKILL.md` | translated
- `.claude/skills/org-setup/SKILL.md` | translated
- `.claude/skills/org-setup/references/permissions.md` | translated
- `.claude/skills/org-delegate/SKILL.md` | translated
- `.claude/skills/org-delegate/references/claude-org-self-edit.md` | translated
- `.claude/skills/org-delegate/references/instruction-template.md` | translated
- `.claude/skills/org-delegate/references/pane-layout.md` | translated
- `.claude/skills/org-delegate/references/renga-error-codes.md` | translated
- `.claude/skills/org-delegate/references/worker-claude-template.md` | translated

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#161 (Wave B-runtime)

## Test plan

- [x] No remaining ja-glossary terms (フォアマン/キュレーター/ワーカー/窓口) or `Secretary`/`Foreman` aliases
- [x] Frontmatter / code blocks / paths preserved
- [x] Codex review converged (2 rounds)
- [ ] CI green