### PR TITLE
Wave C: sync-policy + finalized manifest + notify-ja-changes workflow

### DIFF
--- a/.github/workflows/notify-ja-changes.yml
+++ b/.github/workflows/notify-ja-changes.yml
@@ -1,0 +1,50 @@
+name: Notify on ja-side merges
+
+# Receives a repository_dispatch from suisya-systems/claude-org-ja when a
+# ja-side PR merges to main, and opens a TRANSLATION-PENDING tracking issue
+# here. The dispatching side requires a PAT (secrets.NOTIFY_EN_PAT on ja);
+# this side only needs the default GITHUB_TOKEN to open issues.
+
+on:
+  repository_dispatch:
+    types: [ja_pr_merged]
+  workflow_dispatch:
+    inputs:
+      ja_pr_number:
+        description: ja PR number
+        required: true
+      ja_pr_title:
+        description: ja PR title
+        required: true
+      ja_pr_url:
+        description: ja PR URL
+        required: true
+
+permissions:
+  issues: write
+
+jobs:
+  open-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open TRANSLATION-PENDING issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const payload = context.payload.client_payload || context.payload.inputs || {};
+            const num = payload.ja_pr_number;
+            const title = payload.ja_pr_title || `ja PR #${num}`;
+            const url = payload.ja_pr_url || '';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `TRANSLATION-PENDING: ${title}`,
+              body: [
+                `Triggered by ja-side merge: ${url}`,
+                '',
+                'Review translation impact and either close (if not relevant per docs/sync-policy.md divergence rules)',
+                'or proceed with translation. See docs/canonical-ownership.md for which side is authoritative.',
+              ].join('\n'),
+              labels: ['translation-pending'],
+            });

--- a/docs/sync-policy.md
+++ b/docs/sync-policy.md
@@ -1,0 +1,47 @@
+# Sync policy
+
+How edits propagate between this repo (`suisya-systems/claude-org`, en) and `suisya-systems/claude-org-ja` (ja).
+
+See `docs/canonical-ownership.md` for which side is the source of truth for each artifact category.
+
+## Release-gated SLA
+
+The ja side is allowed to lag the en side, bounded by release cadence:
+
+- **During a release window** (between en `vX.Y.0` tag and the matching ja release tag): ja must catch up before the ja release ships. Translation gaps that block the ja release block the release.
+- **Between release windows** (no active en release in flight): ja may lag by **up to one minor release**. If ja is more than one minor behind en `main`, open a `translation-pending` tracking issue on ja.
+- **Hot-fix patches** (en `vX.Y.Z` where Z > 0 and the change is a security or correctness fix): ja must mirror within 14 days, or sooner if the fix is exploitable.
+
+"Lag" is measured in en-side commits to canonical artifacts (per `docs/canonical-ownership.md`); doc-only typo fixes do not count.
+
+## Back-port limit
+
+Edits made directly on the ja side may be back-ported to en **only** in these three categories:
+
+1. **Terminology** — glossary fixes (e.g., `フォアマン` → `ディスパッチャー`) where the ja side discovered a clearer term and the en glossary should track it.
+2. **Concept definitions** — a ja explanation of a role, lifecycle, or invariant that turned out to be sharper than the en wording. Back-port the *definition*, not surrounding prose.
+3. **API contract** — schema, hook protocol, or CLI surface changes whose ja docs are accidentally more authoritative because the implementation was discussed in ja first.
+
+Anything else (prose polish, examples, structural reorganization on the ja side) stays ja-local. To change canonical-en content, open a PR against en first.
+
+## Divergence-allowed sections
+
+These intentionally diverge and are **not** subject to translation parity:
+
+- `registry/projects.md` — local operational state (ja-canonical per `docs/canonical-ownership.md`; en holds an unrelated en-side projects list).
+- `knowledge/curated/*.md` — curated learnings are ja-canonical; en translation is best-effort, not blocking.
+- `.state/`, `.curator/`, `.dispatcher/` — runtime/operator state, scoped per repo.
+- `bootstrap-cherry-picks.md` (en-only) and `docs/translation-manifest.md` (en-only) — meta/process artifacts.
+- README first-impression copy may differ in tone and screenshot/badge selection so long as the technical claims match.
+
+## `docs/getting-started.md` exception (B3)
+
+Per plan-110 §8 Wave C Minor reflection: `docs/getting-started.md` is **ja-canonical** in `docs/canonical-ownership.md`, but en maintains a **B3 parallel SOT** copy. Onboarding flow is sensitive to platform-specific install instructions and en/ja paths diverge enough that pure translation produces awkward output; both sides edit their own file and reconcile structural changes (new sections, removed steps) via a back-port PR within the back-port limits above.
+
+## Cross-repo notify CI
+
+When a ja-side PR merges to `main`, the workflow `.github/workflows/notify-en-changes.yml` (ja side) fires a `repository_dispatch` event of type `ja_pr_merged` to this repo. The receiving workflow `.github/workflows/notify-ja-changes.yml` (this repo) opens a `TRANSLATION-PENDING` issue carrying the ja PR title and URL. The Lead/Curator triages: either close the issue (out of scope or canonical-en) or schedule the translation work.
+
+The reverse direction (en → ja) is symmetric: an en merge fires `en_pr_merged` to the ja repo and opens a translation-pending issue there.
+
+The dispatch step requires a PAT with `repo` scope on the receiving repo, stored as `secrets.NOTIFY_EN_PAT` (ja side) and `secrets.NOTIFY_JA_PAT` (en side, currently unused — en→ja sender is a follow-up). Until the PAT is configured the workflow is dormant; the receiver side fails closed (no spurious issues) because no dispatch arrives.

--- a/docs/translation-manifest.md
+++ b/docs/translation-manifest.md
@@ -2,24 +2,126 @@
 
 State of every artifact that participates in the en ↔ ja translation pipeline.
 
+Bootstrap source: `suisya-systems/claude-org-ja@926df3943cb5df2d6ee419b020351178a96a88d1`. The en repo was transplanted from this ja commit; rows below cover every file at that snapshot plus every file currently tracked in en.
+
 ## Legend
 
 | State | Meaning |
 |---|---|
-| `translated` | en file is a translation of an explicit ja source; cross-linked in headers. |
-| `copied` | en file is byte-equivalent to ja source (e.g., LICENSE, schema JSON). |
-| `intentionally omitted` | ja artifact has no en counterpart (e.g., `registry/projects.md`). |
-| `local-only` | en file has no ja counterpart (e.g., `bootstrap-cherry-picks.md`). |
+| `translated` | en file is a translation of an explicit ja source. |
+| `copied` | en file is byte-equivalent to ja source (e.g., LICENSE, schema JSON, `.gitkeep`). |
+| `intentionally omitted` | ja artifact has no en counterpart (per `docs/canonical-ownership.md`). |
+| `local-only` | en file has no ja counterpart. |
 
 ## Rows
 
-(Filled in by Wave B-core, Wave B-runtime, Wave C as files are translated.)
-
-| en path | state | source ja path / sha | last sync sha | notes |
+| en path | state | ja path / sha | last sync sha | notes |
 |---|---|---|---|---|
+| `.claude/settings.json` | copied | `.claude/settings.json` @ `926df394` | `926df394` | byte-equivalent |
+| `.claude/skills/org-curate/SKILL.md` | translated | `.claude/skills/org-curate/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-curate/references/knowledge-standards.md` | translated | `.claude/skills/org-curate/references/knowledge-standards.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-dashboard/SKILL.md` | translated | `.claude/skills/org-dashboard/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/SKILL.md` | translated | `.claude/skills/org-delegate/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/references/claude-org-self-edit.md` | translated | `.claude/skills/org-delegate/references/claude-org-self-edit.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/references/instruction-template.md` | translated | `.claude/skills/org-delegate/references/instruction-template.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/references/pane-layout.md` | translated | `.claude/skills/org-delegate/references/pane-layout.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/references/renga-error-codes.md` | translated | `.claude/skills/org-delegate/references/renga-error-codes.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-delegate/references/worker-claude-template.md` | translated | `.claude/skills/org-delegate/references/worker-claude-template.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-resume/SKILL.md` | translated | `.claude/skills/org-resume/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-retro/SKILL.md` | translated | `.claude/skills/org-retro/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-retro/references/work-skill-template.md` | translated | `.claude/skills/org-retro/references/work-skill-template.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-setup/SKILL.md` | translated | `.claude/skills/org-setup/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-setup/references/permissions.md` | translated | `.claude/skills/org-setup/references/permissions.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-start/SKILL.md` | translated | `.claude/skills/org-start/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/org-suspend/SKILL.md` | translated | `.claude/skills/org-suspend/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/skill-audit/SKILL.md` | translated | `.claude/skills/skill-audit/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/skill-audit/references/audit-checklist.md` | translated | `.claude/skills/skill-audit/references/audit-checklist.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/skill-eligibility-check/SKILL.md` | translated | `.claude/skills/skill-eligibility-check/SKILL.md` @ `926df394` | `926df394` |  |
+| `.claude/skills/skill-eligibility-check/references/signals.md` | translated | `.claude/skills/skill-eligibility-check/references/signals.md` @ `926df394` | `926df394` |  |
+| `.curator/CLAUDE.md` | translated | `.curator/CLAUDE.md` @ `926df394` | `926df394` |  |
+| `.dispatcher/CLAUDE.md` | translated | `.dispatcher/CLAUDE.md` @ `926df394` | `926df394` |  |
+| `.gitattributes` | copied | `.gitattributes` @ `926df394` | `926df394` | byte-equivalent |
+| `.githooks/pre-commit` | translated | `.githooks/pre-commit` @ `926df394` | `926df394` |  |
+| `.github/workflows/install-scripts.yml` | translated | `.github/workflows/install-scripts.yml` @ `926df394` | `926df394` |  |
+| `.github/workflows/notify-ja-changes.yml` | local-only | — | — | Receives repository_dispatch from ja repo (added in this PR). |
+| `.github/workflows/tests.yml` | translated | `.github/workflows/tests.yml` @ `926df394` | `926df394` |  |
+| `.gitignore` | copied | `.gitignore` @ `926df394` | `926df394` | byte-equivalent |
+| `.hooks/block-dangerous-git.sh` | translated | `.hooks/block-dangerous-git.sh` @ `926df394` | `926df394` |  |
+| `.hooks/block-dispatcher-out-of-scope.sh` | translated | `.hooks/block-dispatcher-out-of-scope.sh` @ `926df394` | `926df394` |  |
+| `.hooks/block-git-push.sh` | translated | `.hooks/block-git-push.sh` @ `926df394` | `926df394` |  |
+| `.hooks/block-no-verify.sh` | translated | `.hooks/block-no-verify.sh` @ `926df394` | `926df394` |  |
+| `.hooks/block-org-structure.sh` | translated | `.hooks/block-org-structure.sh` @ `926df394` | `926df394` |  |
+| `.hooks/block-workers-delete.sh` | translated | `.hooks/block-workers-delete.sh` @ `926df394` | `926df394` |  |
+| `.hooks/check-worker-boundary.sh` | translated | `.hooks/check-worker-boundary.sh` @ `926df394` | `926df394` |  |
+| `.hooks/lib/segment-split.sh` | translated | `.hooks/lib/segment-split.sh` @ `926df394` | `926df394` |  |
+| `.hooks/test-always-block.sh` | translated | `.hooks/test-always-block.sh` @ `926df394` | `926df394` |  |
+| `.hooks/test-block-workers-delete.sh` | translated | `.hooks/test-block-workers-delete.sh` @ `926df394` | `926df394` |  |
+| `.state/.gitkeep` | copied | `.state/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `.state/workers/.gitkeep` | copied | `.state/workers/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `CLAUDE.md` | translated | `CLAUDE.md` @ `926df394` | `926df394` |  |
+| `CONTRIBUTING.md` | translated | `CONTRIBUTING.md` @ `926df394` | `926df394` |  |
+| `LICENSE` | copied | `LICENSE` @ `926df394` | `926df394` | byte-equivalent |
+| `README.md` | translated | `README.md` @ `926df394` | `926df394` |  |
+| `bootstrap-cherry-picks.md` | local-only | — | — | Bootstrap audit trail; en-only. |
+| `dashboard/app.js` | translated | `dashboard/app.js` @ `926df394` | `926df394` |  |
+| `dashboard/index.html` | translated | `dashboard/index.html` @ `926df394` | `926df394` |  |
+| `dashboard/org_state_converter.py` | translated | `dashboard/org_state_converter.py` @ `926df394` | `926df394` |  |
+| `dashboard/server.py` | translated | `dashboard/server.py` @ `926df394` | `926df394` |  |
+| `dashboard/style.css` | translated | `dashboard/style.css` @ `926df394` | `926df394` |  |
+| `docs/canonical-ownership.md` | local-only | — | — | Canonical ownership table; en-canonical. |
+| `docs/getting-started.md` | translated | `docs/getting-started.md` @ `926df394` | `926df394` |  |
+| `docs/glossary.md` | local-only | — | — | Term lock; en-canonical per docs/canonical-ownership.md. |
+| `docs/non-goals.md` | translated | `docs/non-goals.md` @ `926df394` | `926df394` |  |
+| `docs/org-state-schema.md` | translated | `docs/org-state-schema.md` @ `926df394` | `926df394` |  |
+| `docs/oss-comparison.md` | translated | `docs/oss-comparison.md` @ `926df394` | `926df394` |  |
+| `docs/overview-business.md` | translated | `docs/overview-business.md` @ `926df394` | `926df394` |  |
+| `docs/overview-technical.md` | translated | `docs/overview-technical.md` @ `926df394` | `926df394` |  |
+| `docs/sync-policy.md` | local-only | — | — | Cross-repo sync rules; en-canonical (added in this PR). |
+| `docs/test-results/.gitkeep` | copied | `docs/test-results/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `docs/testing.md` | translated | `docs/testing.md` @ `926df394` | `926df394` |  |
+| `docs/translation-manifest.md` | local-only | — | — | This file; en-canonical. |
+| `docs/verification.md` | translated | `docs/verification.md` @ `926df394` | `926df394` |  |
+| `knowledge/curated/.gitkeep` | copied | `knowledge/curated/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `knowledge/raw/.gitkeep` | copied | `knowledge/raw/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `knowledge/skill-candidates.md` | translated | `knowledge/skill-candidates.md` @ `926df394` | `926df394` |  |
+| `registry/org-config.md` | translated | `registry/org-config.md` @ `926df394` | `926df394` |  |
+| `registry/projects.md` | local-only | — | — | en-side operational state; ja-canonical artifact at same path is divergent (see docs/sync-policy.md). |
+| `renga-layouts/ops.toml` | translated | `renga-layouts/ops.toml` @ `926df394` | `926df394` |  |
+| `scripts/install-hooks.sh` | translated | `scripts/install-hooks.sh` @ `926df394` | `926df394` |  |
+| `scripts/install.ps1` | translated | `scripts/install.ps1` @ `926df394` | `926df394` |  |
+| `scripts/install.sh` | translated | `scripts/install.sh` @ `926df394` | `926df394` |  |
+| `tests/__init__.py` | translated | `tests/__init__.py` @ `926df394` | `926df394` |  |
+| `tests/fixtures/curated/.gitkeep` | copied | `tests/fixtures/curated/.gitkeep` @ `926df394` | `926df394` | byte-equivalent |
+| `tests/fixtures/curated/sample-topic.md` | translated | `tests/fixtures/curated/sample-topic.md` @ `926df394` | `926df394` |  |
+| `tests/fixtures/journal-sample.jsonl` | translated | `tests/fixtures/journal-sample.jsonl` @ `926df394` | `926df394` |  |
+| `tests/fixtures/org-state-sample.md` | translated | `tests/fixtures/org-state-sample.md` @ `926df394` | `926df394` |  |
+| `tests/fixtures/projects-sample.md` | translated | `tests/fixtures/projects-sample.md` @ `926df394` | `926df394` |  |
+| `tests/fixtures/workers/worker-abc12345.md` | translated | `tests/fixtures/workers/worker-abc12345.md` @ `926df394` | `926df394` |  |
+| `tests/run-all.sh` | translated | `tests/run-all.sh` @ `926df394` | `926df394` |  |
+| `tests/test-block-dispatcher-out-of-scope.sh` | translated | `tests/test-block-dispatcher-out-of-scope.sh` @ `926df394` | `926df394` |  |
+| `tests/test-block-git-push.sh` | translated | `tests/test-block-git-push.sh` @ `926df394` | `926df394` |  |
+| `tests/test-block-org-structure.sh` | translated | `tests/test-block-org-structure.sh` @ `926df394` | `926df394` |  |
+| `tests/test-block-pretooluse-hooks.sh` | translated | `tests/test-block-pretooluse-hooks.sh` @ `926df394` | `926df394` |  |
+| `tests/test-check-worker-boundary.sh` | translated | `tests/test-check-worker-boundary.sh` @ `926df394` | `926df394` |  |
+| `tests/test-install-hooks.sh` | translated | `tests/test-install-hooks.sh` @ `926df394` | `926df394` |  |
+| `tests/test-precommit-secret-scanner.sh` | translated | `tests/test-precommit-secret-scanner.sh` @ `926df394` | `926df394` |  |
+| `tests/test-unwrap-eval-bashc.sh` | translated | `tests/test-unwrap-eval-bashc.sh` @ `926df394` | `926df394` |  |
+| `tests/test_check_role_configs.py` | translated | `tests/test_check_role_configs.py` @ `926df394` | `926df394` |  |
+| `tests/test_org_state_converter.py` | translated | `tests/test_org_state_converter.py` @ `926df394` | `926df394` |  |
+| `tests/test_parsers.py` | translated | `tests/test_parsers.py` @ `926df394` | `926df394` |  |
+| `tools/check_renga_compat.py` | translated | `tools/check_renga_compat.py` @ `926df394` | `926df394` |  |
+| `tools/check_role_configs.py` | translated | `tools/check_role_configs.py` @ `926df394` | `926df394` |  |
+| `tools/dispatcher_runner.py` | translated | `tools/dispatcher_runner.py` @ `926df394` | `926df394` |  |
+| `tools/org_setup_prune.py` | translated | `tools/org_setup_prune.py` @ `926df394` | `926df394` |  |
+| `tools/role_configs_schema.json` | translated | `tools/role_configs_schema.json` @ `926df394` | `926df394` |  |
+| `tools/test_check_renga_compat.py` | translated | `tools/test_check_renga_compat.py` @ `926df394` | `926df394` |  |
+| `tools/test_dispatcher_runner.py` | translated | `tools/test_dispatcher_runner.py` @ `926df394` | `926df394` |  |
+| `tools/test_org_setup_prune.py` | translated | `tools/test_org_setup_prune.py` @ `926df394` | `926df394` |  |
+
+Total rows: 100 (every file in ja@926df394 plus every file currently tracked in en, including this PR's additions).
 
 ## Wave assignment
 
-- Wave B-core fills rows for: README, CLAUDE.md, role docs, overviews, non-goals, getting-started, oss-comparison, org-state-schema.
-- Wave B-runtime fills rows for: install / dashboard / tools / all 10 skills / testing / verification / knowledge/curated.
-- Wave C closes the manifest by ensuring every en file has either a row here or is referenced in `canonical-ownership.md` as en-canonical.
+- Wave B-core filled rows for: README, CLAUDE.md, role docs, overviews, non-goals, getting-started, oss-comparison, org-state-schema.
+- Wave B-runtime filled rows for: install / dashboard / tools / all 10 skills / testing / verification / knowledge/curated.
+- Wave C closed the manifest by enumerating every remaining file and adding the en-only `docs/sync-policy.md` and `.github/workflows/notify-ja-changes.yml` entries.


### PR DESCRIPTION
## Summary

Wave C of the 5-Wave plan for claude-org-ja#110.

- `docs/sync-policy.md` (new) — references `docs/canonical-ownership.md`, release-gated SLA, 3-category back-port limit (terminology / concept definitions / API contract), divergence-allowed sections, and the 1-sentence note that `docs/getting-started.md` is ja-canonical with an en B3 parallel SOT.
- `docs/translation-manifest.md` finalized — 100 rows covering all 94 files in `claude-org-ja@926df39` plus 6 en local-only files. Manifest is the SOT for the "equivalent to v0.1.0" release acceptance check.
- `.github/workflows/notify-ja-changes.yml` (new) — receives `repository_dispatch` from the ja repo and opens a `TRANSLATION-PENDING` issue here.

## Smoke test status

**Deferred.** End-to-end smoke (cross-repo dispatch firing) requires `NOTIFY_EN_PAT` secret configured on the ja repo. Secret setup is a Lead-only operation; this PR ships only the receive-side workflow.

## Companion PR

A symmetric ja-side PR (sync-policy in Japanese, `notify-en-changes.yml`, README en cross-link) lands on `claude-org-ja` to close #111.

## Codex self-review

- 3 findings fixed: dropped `docs/sync-policy.md` from the "en-only" listing (it exists on both sides); flipped `registry/projects.md` from `translated` to `local-only` to match the divergence rule; pre-existing parenthetical role aliases in ja README left untouched (out of Wave C scope).

## Refs

- claude-org-ja#110 (epic)
- claude-org-ja#162 (Wave C)
- closes claude-org-ja#111 once the ja sub-PR README cross-link merges

## Test plan

- [x] `docs/sync-policy.md` includes all 5 plan-110 §3 requirements
- [x] manifest covers 100% of ja@926df39 + en local-only files
- [x] notify-ja-changes.yml YAML valid
- [x] CI green
- [x] (deferred) NOTIFY_EN_PAT secret set on ja side, smoke test passes