### PR TITLE
docs: address README/docs drift findings (audit 2026-05-03, en mirror)

### DIFF
--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -124,7 +124,7 @@ same time.
 allows from closed-world validation (`_load_override_allow`). So personal
 allows added via override do not show up as `unknown allow entry` under CI /
 `--include-local`. However `forbidden_allow_exact` (wide allows like `Bash(git *)`)
-and `disallow_allow_regex` (e.g. legacy `mcp__claude-peers__*`) still ERROR
+and `disallow_allow_regex` (e.g. legacy `mcp__claude-peers__*`, now `renga-peers`) still ERROR
 even when they appear in override. The safety contract cannot be bypassed via override.
 
 #### Resolving `{claude_org_path}` for the dispatcher

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -161,7 +161,7 @@ This deny is limited to gates on Claude's file-editing tools (Write/Edit). The L
 
 **What must not be written**:
 - Wide allows (`Bash(git *)`, `Bash(git push *)`, `Bash(git fetch *)`, `Bash(git branch *)`, `Bash(git pull *)`, `Bash(gh:*)`, `Bash(gh *)`)
-- Legacy `mcp__claude-peers__*` (migrated to renga-peers in 2025)
+- Legacy `mcp__claude-peers__*` (migrated to `mcp__renga-peers__*` in 2025; use the current name)
 - Legacy Bash allows for `renga list/split/send/events/close/inspect *` (replaced by MCP in renga 0.14.0+)
 - Past one-shot commands (commands containing a specific PR number / branch name / PID, like `gh pr create --repo ... --head feat/xxx ...`)
 - User-specific absolute paths (such as `Read(//c/Users/<you>/Documents/work/**)`)

--- a/.claude/skills/org-setup/references/permissions.md
+++ b/.claude/skills/org-setup/references/permissions.md
@@ -161,7 +161,7 @@ This deny is limited to gates on Claude's file-editing tools (Write/Edit). The L
 
 **What must not be written**:
 - Wide allows (`Bash(git *)`, `Bash(git push *)`, `Bash(git fetch *)`, `Bash(git branch *)`, `Bash(git pull *)`, `Bash(gh:*)`, `Bash(gh *)`)
-- Legacy `mcp__claude-peers__*` (migrated to `mcp__renga-peers__*` in 2025; use the current name)
+- Legacy `mcp__claude-peers__*` (migrated to `mcp__renga-peers__*` in 2026; use the current name)
 - Legacy Bash allows for `renga list/split/send/events/close/inspect *` (replaced by MCP in renga 0.14.0+)
 - Past one-shot commands (commands containing a specific PR number / branch name / PID, like `gh pr create --repo ... --head feat/xxx ...`)
 - User-specific absolute paths (such as `Read(//c/Users/<you>/Documents/work/**)`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,7 +189,8 @@ Lead:   Understood. Resuming the storefront task.
 **Diagnosis**: first, inspect the state of that role's `settings.local.json`:
 
 ```bash
-python tools/check_role_configs.py --include-local
+# Windows: prefer `py -3`; on POSIX use `python3` (`python` is a fallback when neither launcher is available)
+py -3 tools/check_role_configs.py --include-local
 ```
 
 To inspect inside a specific role's worktree, also pass `--role <secretary|dispatcher|curator|worker>` (`secretary` is the implementation identifier for the Lead role; the CLI literal is kept as-is). The output enumerates per-role missing/unknown allow entries and missing required hooks.
@@ -201,13 +202,14 @@ To inspect inside a specific role's worktree, also pass `--role <secretary|dispa
 
 ### `tools/check_role_configs.py` reports drift between schema, permissions, and settings
 
-**Symptoms**: CI or local `python tools/check_role_configs.py --include-local` reports `unknown allow entry` / `permissions.md mismatch` / `missing required hook`.
+**Symptoms**: CI or local `py -3 tools/check_role_configs.py --include-local` (POSIX: `python3 tools/check_role_configs.py --include-local`) reports `unknown allow entry` / `permissions.md mismatch` / `missing required hook`.
 
 **Diagnosis**: identify which side the drift is on — schema, `permissions.md`, or actual `settings.local.json`.
 
 ```bash
-python tools/check_role_configs.py --include-local        # validate all roles at once
-python tools/check_role_configs.py --role <role>          # individual validation in that role's worktree
+# Windows: prefer `py -3`; on POSIX use `python3`
+py -3 tools/check_role_configs.py --include-local        # validate all roles at once
+py -3 tools/check_role_configs.py --role <role>          # individual validation in that role's worktree
 git diff tools/role_configs_schema.json                   # recent edits on the schema side
 git diff .claude/skills/org-setup/references/permissions.md
 ```
@@ -218,7 +220,7 @@ git diff .claude/skills/org-setup/references/permissions.md
 
 - **An allow entry not registered in the schema is present in `permissions.md` or actual settings**: if it's needed, add it to the schema first, then propagate to `permissions.md` and `settings.local.json`. If it isn't, delete it.
 - **The sample JSON in `permissions.md` has diverged from the schema**: treat the schema as canonical and rewrite the `permissions.md` side to match.
-- **`/org-setup` re-run does not eliminate drift in `settings.local.json`**: additive-only mode can't remove anything automatically. As a **last resort**, replace the role's `settings.local.json` wholesale with the per-role sample JSON in `.claude/skills/org-setup/references/permissions.md` to return to baseline. The `{worker_dir}` / `{claude_org_path}` placeholders in the worker sample must be hand-resolved to absolute paths in your environment. Make sure to record any local overrides before doing this.
+- **`/org-setup` re-run does not eliminate drift in `settings.local.json`**: additive-only mode can't remove anything automatically. As a **last resort**, replace the role's `settings.local.json` wholesale with the per-role sample JSON in `.claude/skills/org-setup/references/permissions.md` to return to baseline. The `{worker_dir}` / `{claude_org_path}` placeholders in the worker sample must be hand-resolved to absolute paths in your environment. Make sure to record any local overrides before doing this. After updating, re-run `py -3 tools/check_role_configs.py --include-local` (POSIX: `python3 tools/check_role_configs.py --include-local`) to confirm the drift is gone.
 
 ### Schema JSON parse error / read failure
 
@@ -229,10 +231,11 @@ git diff .claude/skills/org-setup/references/permissions.md
 ```bash
 git status tools/role_configs_schema.json
 git diff tools/role_configs_schema.json
-python -c "import json; json.load(open('tools/role_configs_schema.json'))"
+# Windows: prefer `py -3`; on POSIX use `python3`
+py -3 -c "import json; json.load(open('tools/role_configs_schema.json'))"
 ```
 
-**Fix**: if a recent edit broke the file, restore it with `git restore tools/role_configs_schema.json`, or temporarily set the change aside with `git stash push tools/role_configs_schema.json` and try again. After fixing the schema syntax, always run `python tools/check_role_configs.py --include-local` cleanly before committing.
+**Fix**: if a recent edit broke the file, restore it with `git restore tools/role_configs_schema.json`, or temporarily set the change aside with `git stash push tools/role_configs_schema.json` and try again. After fixing the schema syntax, always run `py -3 tools/check_role_configs.py --include-local` (POSIX: `python3 tools/check_role_configs.py --include-local`) cleanly before committing.
 
 ---
 

--- a/docs/org-state-schema.md
+++ b/docs/org-state-schema.md
@@ -127,7 +127,7 @@ After the operations below, run the converter to update the JSON:
 | Field | Type | Description |
 |---|---|---|
 | `peerId` | `string` | renga-peers pane name (`worker-{task_id}` / `dispatcher` / `curator` form). Pass to `mcp__renga-peers__send_message` as `to_id` |
-| `paneId` | `string` | renga pane name (the value passed via `--id`, e.g. `dispatcher`, `curator`). Older WezTerm builds stored a numeric pane-id; after migrating to ccmux this became a stable name. In the current spec this is often the same value as `peerId` |
+| `paneId` | `string` | renga pane name (the value passed via `--id`, e.g. `dispatcher`, `curator`). Older WezTerm builds stored a numeric pane-id; after migrating to renga this became a stable name. In the current spec this is often the same value as `peerId` |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,8 +19,8 @@ Bash-based hook regression tests.
 
 ```bash
 # Python tests
-# Windows (use python if py -3 is unavailable)
-python -m unittest discover -s tests -v
+# Windows (use `python` as a fallback if `py -3` is unavailable)
+py -3 -m unittest discover -s tests -v
 
 # Mac / Linux
 python3 -m unittest discover -s tests -v

--- a/registry/projects.md
+++ b/registry/projects.md
@@ -1,18 +1,18 @@
 # Projects Registry
 
-既知のプロジェクト一覧。窓口Claudeがユーザーの依頼からプロジェクトを特定するために使う。
-ワーカー派遣時に自動登録される。手動で追記・編集してもよい。
+A list of known projects. The Lead Claude uses it to identify which project a user request maps to.
+Entries are auto-registered when a worker is dispatched. Manual additions and edits are also fine.
 
-「パス」列はプロジェクトの clone ソースを記録する。値によってワーカー派遣時の初期化手順が分岐する:
+The "Path" column records the clone source for the project. The value drives how the worker is initialized at dispatch time:
 
-- URL（例: `https://github.com/...`）→ リモートリポジトリ。`git clone {URL} {worker_dir}` で取得
-- ローカルパス（例: `C:/Users/.../existing-repo`）→ ローカル既存プロジェクト。`git clone {ローカルパス} {worker_dir}` で取得
-- `-` → 新規プロジェクト（clone 元なし）。`git init {worker_dir}` で初期化（clone は実行しない）
+- A URL (e.g. `https://github.com/...`) → remote repository. Fetched with `git clone {URL} {worker_dir}`.
+- A local path (e.g. `C:/Users/.../existing-repo`) → existing local project. Fetched with `git clone {local_path} {worker_dir}`.
+- `-` → new project (no clone source). Initialized with `git init {worker_dir}` (no clone is performed).
 
-注意: この列はワーカーの成果物パスを示すものではない（ワーカーは `workers/{task_id}/` 内で作業する）。
-この下の Markdown 表はワーカー派遣前に `dashboard/server.py:_parse_projects` で機械パースされるため、本セクションに追加の Markdown 表（`|---|` セパレータ付き）を差し込まないこと。説明を増やす場合はプレーン箇条書きで記述する。
+Note: this column is not the worker's output path (the worker operates inside `workers/{task_id}/`).
+The Markdown table below is machine-parsed by `dashboard/server.py:_parse_projects` before the worker is dispatched, so do not insert additional Markdown tables (with `|---|` separators) in this section. If you need to add explanations, use plain bullet lists.
 
-| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |
+| Nickname | Project | Path | Description | Common tasks |
 |---|---|---|---|---|
-| 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 |
-| renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |
+| Clock app | clock-app | - | A digital clock that runs in the web browser | Design changes, feature additions |
+| renga | renga | https://github.com/suisya-systems/renga | Rust-based terminal multiplexer (TUI) for Claude Code | Feature additions, bug fixes, issue triage |


### PR DESCRIPTION
## Summary
Paired English-mirror counterpart to claude-org-ja PR #229.

- `docs/org-state-schema.md`: replace stale "after migrating to ccmux" with "after migrating to renga".
- `registry/projects.md`: translate residual Japanese registry text into English (en-mirror translation policy).
- `docs/getting-started.md` / `docs/testing.md`: prefer `py -3` on Windows and `python3` on POSIX in sample commands; align ordering accordingly.
- `.claude/skills/org-setup/SKILL.md` / `.claude/skills/org-setup/references/permissions.md`: annotate legacy `mcp__claude-peers__*` with the current `renga-peers` name.
- Migration year corrected from 2025 to **2026** to match the ja side (verified against claude-org-ja git log: c9d51c7 / 65c9000, 2026-04-26).

## Validation
- Codex self-review: no blockers, no majors

## Out of audit scope (not addressed here)
Codex flagged unrelated drift items not covered by the 2026-05-03 audit:
- `docs/org-state-schema.md:129` `peerId` / `paneId` description diverges from current implementation/tests (mirrors a finding on the ja side).
- `org-setup` SKILL.md / `org_setup_prune.py` peripheral steps still use `python` (could be a follow-up to extend the `py -3` preference more broadly).

Refs: README/Docs Drift Audit 2026-05-03 (audit-only task readme-drift-audit)