### PR TITLE
ci: implement auto-mirror P2 (Closes claude-org-ja#335)

### DIFF
--- a/.github/workflows/auto-mirror-runtime.yml
+++ b/.github/workflows/auto-mirror-runtime.yml
@@ -1,20 +1,26 @@
 name: Auto-mirror runtime (ja -> en)
 
-# Phase P1 (warn-only). Listens to repository_dispatch ja_pr_merged from
-# suisya-systems/claude-org-ja, classifies the changed files via
-# tools/sync_classifier.py, and opens a single tracking issue **on this
-# repo** with the classification summary. Does NOT open a mirror PR yet —
-# that is gated by the OPEN_PR env var below (set to "true" to advance to P2).
+# Phase P2 (mirror PR, manual merge). Listens to repository_dispatch
+# ja_pr_merged from suisya-systems/claude-org-ja, classifies the changed
+# files via tools/sync_classifier.py, and:
 #
-# This workflow subsumes the previous notify-ja-changes.yml: when any
-# translation-class file is touched, the same TRANSLATION-PENDING issue
-# (label=`translation-pending`) is created here, so legacy consumers of
-# that label keep working.
+#   - For runtime-class files: opens (or refreshes) a mirror PR on this
+#     repo with the runtime files copied from ja at the merge SHA.
+#   - For translation- or unknown-class files: opens (or refreshes) a
+#     tracking issue carrying the existing TRANSLATION-PENDING contract.
+#   - For divergence-allowed-only batches: no-op.
 #
-# Cross-repo writes are deliberately avoided so that the default
-# GITHUB_TOKEN (scoped to this repo only) is sufficient — no new PAT
-# required on the en side. See Issue suisya-systems/claude-org-ja#189
-# for the design and docs/runbook/auto-mirror-runtime.md for ops.
+# Auth (Issue #189 / #335 Lead decision):
+#   - Same-repo writes use AUTO_MIRROR_PAT if configured; otherwise fall
+#     back to the default GITHUB_TOKEN. PRs opened by GITHUB_TOKEN do NOT
+#     trigger pull_request workflows (e.g. tests.yml), so configuring
+#     AUTO_MIRROR_PAT is recommended once Lead is ready to require CI on
+#     mirror PRs. Issue #189 keeps the ja side on its existing
+#     NOTIFY_EN_PAT only.
+#
+# Kill-switch: set OPEN_PR=false to revert to P1 warn-only (issue-only).
+#
+# See docs/runbook/auto-mirror-runtime.md for ops detail.
 
 on:
   repository_dispatch:
@@ -38,20 +44,26 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pull-requests: write
 
 env:
-  # P1 = warn-only. Flip to "true" to advance to P2 (open mirror PR).
-  OPEN_PR: 'false'
+  # P2 = open mirror PR for runtime-class files. Flip to "false" to
+  # revert to P1 warn-only (tracking issue only, even for runtime files).
+  OPEN_PR: 'true'
   JA_REPO: suisya-systems/claude-org-ja
 
 jobs:
-  classify-and-warn:
+  classify-and-mirror:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout en repo
         uses: actions/checkout@v4
+        with:
+          # We re-configure auth ourselves later so we can prefer
+          # AUTO_MIRROR_PAT over GITHUB_TOKEN for the mirror push.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -71,9 +83,6 @@ jobs:
             echo "ja_pr_number missing from dispatch payload" >&2
             exit 1
           fi
-          # Read-only cross-repo access works with default GITHUB_TOKEN for
-          # public repos. If the GH API call fails (private fork, outage),
-          # fall back to dispatch payload / workflow_dispatch inputs.
           payload_title='${{ github.event.client_payload.ja_pr_title }}'
           payload_url='${{ github.event.client_payload.ja_pr_url }}'
           payload_sha='${{ github.event.client_payload.ja_merge_sha }}'
@@ -103,30 +112,47 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Keep both a filename-only list (for the existing classifier
+          # CLI) and a structured NDJSON file (for status-aware mirror
+          # operations: added / modified / removed / renamed).
           gh api --paginate \
             "repos/${JA_REPO}/pulls/${{ steps.meta.outputs.pr_number }}/files" \
             -q '.[].filename' > changed_files.txt
+          gh api --paginate \
+            "repos/${JA_REPO}/pulls/${{ steps.meta.outputs.pr_number }}/files" \
+            -q '.[] | {filename, status, previous_filename}' \
+            > pr_files.ndjson
           echo "Changed files:"
           cat changed_files.txt
 
       - name: Classify changed files
+        id: classify
         run: |
           set -euo pipefail
-          # Sanity-check the classifier with the existing unittest suite
-          # (matches the runner used by tests.yml — no extra dependency).
           python -m unittest discover -s tools -p test_sync_classifier.py -v
           python tools/sync_classifier.py < changed_files.txt > classification.json
           cat classification.json
-          python - <<'PY' > issue_body.md
-          import json
+          runtime_count="$(jq '.by_class.runtime | length' classification.json)"
+          translation_count="$(jq '.by_class.translation | length' classification.json)"
+          unknown_count="$(jq '.by_class.unknown | length' classification.json)"
+          divergence_count="$(jq '.by_class["divergence-allowed"] | length' classification.json)"
+          echo "runtime_count=${runtime_count}" >> "$GITHUB_OUTPUT"
+          echo "translation_count=${translation_count}" >> "$GITHUB_OUTPUT"
+          echo "unknown_count=${unknown_count}" >> "$GITHUB_OUTPUT"
+          echo "divergence_count=${divergence_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Build classification summary body
+        run: |
+          set -euo pipefail
+          python - <<'PY' > classification_body.md
+          import json, os
           data = json.load(open('classification.json'))
           by_class = data['by_class']
-          pr = "${{ steps.meta.outputs.pr_number }}"
-          url = "${{ steps.meta.outputs.pr_url }}"
-          sha = "${{ steps.meta.outputs.merge_sha }}"
+          pr = os.environ['JA_PR_NUM']
+          url = os.environ['JA_PR_URL']
+          sha = os.environ['JA_MERGE_SHA']
+          phase_open = os.environ['OPEN_PR']
           lines = [
-              "auto-mirror-runtime classification (P1 warn-only).",
-              "",
               f"Source: ja PR [#{pr}]({url})",
           ]
           if sha:
@@ -151,21 +177,164 @@ jobs:
               lines.append("</details>")
           lines += [
               "",
-              "Phase: **P1 warn-only**. No mirror PR opened.",
+              f"Phase: **{'P2 (mirror PR, manual merge)' if phase_open == 'true' else 'P1 warn-only'}**.",
               "See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.",
           ]
           print("\n".join(lines))
           PY
-
-      - name: Open tracking issue on en repo
-        if: ${{ env.OPEN_PR == 'false' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JA_PR_NUM: ${{ steps.meta.outputs.pr_number }}
+          JA_PR_URL: ${{ steps.meta.outputs.pr_url }}
+          JA_MERGE_SHA: ${{ steps.meta.outputs.merge_sha }}
+
+      - name: Open mirror PR (P2, runtime files)
+        if: ${{ env.OPEN_PR == 'true' && steps.classify.outputs.runtime_count != '0' }}
+        env:
+          # Prefer AUTO_MIRROR_PAT (so resulting PR triggers pull_request
+          # CI like tests.yml). Fall back to GITHUB_TOKEN — push and PR
+          # creation still work, but PRs opened by GITHUB_TOKEN do not
+          # trigger downstream workflows.
+          GH_TOKEN: ${{ secrets.AUTO_MIRROR_PAT || secrets.GITHUB_TOKEN }}
+          PUSH_TOKEN: ${{ secrets.AUTO_MIRROR_PAT || secrets.GITHUB_TOKEN }}
+          JA_PR_NUM: ${{ steps.meta.outputs.pr_number }}
+          JA_PR_TITLE: ${{ steps.meta.outputs.pr_title }}
+          JA_PR_URL: ${{ steps.meta.outputs.pr_url }}
+          JA_MERGE_SHA: ${{ steps.meta.outputs.merge_sha }}
         run: |
           set -euo pipefail
-          translation_count="$(jq '.by_class.translation | length' classification.json)"
-          unknown_count="$(jq '.by_class.unknown | length' classification.json)"
-          runtime_count="$(jq '.by_class.runtime | length' classification.json)"
+
+          if [ -z "${JA_MERGE_SHA}" ]; then
+            echo "ja merge SHA could not be resolved; cannot mirror runtime files." >&2
+            exit 1
+          fi
+
+          # 1. Shallow fetch of ja at the merge SHA into a sibling dir.
+          rm -rf ja-src
+          git init -q ja-src
+          git -C ja-src remote add origin "https://github.com/${JA_REPO}.git"
+          git -C ja-src fetch --depth=1 origin "${JA_MERGE_SHA}"
+          git -C ja-src checkout --quiet --detach FETCH_HEAD
+
+          # 2. Apply runtime ops (added/modified/renamed/removed) into the
+          # en working tree. Classification is re-run inside Python so we
+          # use the same source-of-truth module as the standalone CLI.
+          python - <<'PY'
+          import json, os, shutil, subprocess, sys
+          sys.path.insert(0, '.')
+          from tools.sync_classifier import classify_path, CLASS_RUNTIME
+
+          ja_root = "ja-src"
+          ops = []
+          with open("pr_files.ndjson") as f:
+              for line in f:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  rec = json.loads(line)
+                  if classify_path(rec["filename"]) != CLASS_RUNTIME:
+                      continue
+                  ops.append(rec)
+
+          def git(*args):
+              subprocess.check_call(["git", *args])
+
+          applied = removed = renamed = skipped_missing = 0
+          for rec in ops:
+              path = rec["filename"]
+              status = rec["status"]
+              prev = rec.get("previous_filename")
+              src = os.path.join(ja_root, path)
+              if status == "removed":
+                  if os.path.exists(path):
+                      git("rm", "-q", "--", path)
+                      removed += 1
+                  continue
+              if status == "renamed" and prev:
+                  # Drop the old en path if it lived there. classify_path on
+                  # `prev` may be non-runtime (e.g. tools/x.py renamed from
+                  # docs/x.md); only en files actually present matter.
+                  if os.path.exists(prev):
+                      git("rm", "-q", "--", prev)
+                      renamed += 1
+              if not os.path.exists(src):
+                  # ja side reports add/modify but the file isn't in the
+                  # tree at merge SHA — should not happen for a merged PR,
+                  # but skip rather than crash if it does.
+                  skipped_missing += 1
+                  continue
+              parent = os.path.dirname(path)
+              if parent:
+                  os.makedirs(parent, exist_ok=True)
+              shutil.copy2(src, path)
+              git("add", "--", path)
+              applied += 1
+
+          print(f"runtime ops: applied={applied} removed={removed} renamed={renamed} "
+                f"skipped_missing_in_ja={skipped_missing} total_runtime_in_pr={len(ops)}")
+          PY
+
+          # 3. Commit. If nothing actually staged (e.g. en already at the
+          # same content), skip PR creation gracefully.
+          git config user.name "auto-mirror-bot"
+          git config user.email "auto-mirror-bot@users.noreply.github.com"
+
+          if git diff --cached --quiet; then
+            echo "No net runtime changes after applying ops — en already in sync. Skipping PR."
+            exit 0
+          fi
+
+          BRANCH="auto-mirror/ja-pr-${JA_PR_NUM}"
+          git checkout -B "${BRANCH}"
+
+          COMMIT_MSG="auto-mirror: ja#${JA_PR_NUM} ${JA_PR_TITLE}"
+          # Trim to 240 chars to stay under GH title cap and keep room for ellipsis.
+          COMMIT_MSG="${COMMIT_MSG:0:240}"
+          git commit -q -m "${COMMIT_MSG}" -m "Source: ${JA_PR_URL}" -m "Merge SHA: ${JA_MERGE_SHA}"
+
+          # 4. Push using the chosen token. Force-push is safe because the
+          # auto-mirror branch namespace is exclusively owned by this
+          # workflow (rerun/replay overwrites prior attempts).
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force origin "${BRANCH}"
+
+          # 5. Build PR body and create or update the PR.
+          {
+            echo "auto-mirror: runtime files from ja PR [#${JA_PR_NUM}](${JA_PR_URL})"
+            echo
+            echo "Merge SHA: \`${JA_MERGE_SHA}\`"
+            echo
+            cat classification_body.md
+            echo
+            echo "---"
+            echo
+            echo "Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge."
+            echo "If conflicts surface, rebase locally or close in favor of a hand-applied port."
+          } > pr_body.md
+
+          existing="$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" --body-file pr_body.md --title "${COMMIT_MSG}"
+            echo "Existing PR #${existing} refreshed."
+          else
+            gh pr create \
+              --title "${COMMIT_MSG}" \
+              --body-file pr_body.md \
+              --base main \
+              --head "${BRANCH}" \
+              --label auto-mirror-runtime
+          fi
+
+      - name: Open or refresh tracking issue (translation / unknown)
+        if: ${{ steps.classify.outputs.translation_count != '0' || steps.classify.outputs.unknown_count != '0' || (env.OPEN_PR != 'true' && steps.classify.outputs.runtime_count != '0') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JA_PR_NUM: ${{ steps.meta.outputs.pr_number }}
+          JA_PR_TITLE: ${{ steps.meta.outputs.pr_title }}
+        run: |
+          set -euo pipefail
+          translation_count="${{ steps.classify.outputs.translation_count }}"
+          unknown_count="${{ steps.classify.outputs.unknown_count }}"
+          runtime_count="${{ steps.classify.outputs.runtime_count }}"
           labels=(auto-mirror-runtime)
           if [ "${translation_count}" -gt 0 ]; then
             labels+=(translation-pending)
@@ -174,13 +343,29 @@ jobs:
             labels+=(needs-triage)
           fi
           label_csv="$(IFS=,; echo "${labels[*]}")"
-          title="auto-mirror P1: ja#${{ steps.meta.outputs.pr_number }} ${{ steps.meta.outputs.pr_title }}"
-          # Trim title to GH 256-char cap.
+
+          if [ "${OPEN_PR}" = 'true' ]; then
+            phase_tag="auto-mirror P2"
+          else
+            phase_tag="auto-mirror P1"
+          fi
+          title="${phase_tag}: ja#${JA_PR_NUM} ${JA_PR_TITLE}"
           title="${title:0:240}"
-          # Idempotency: if a tracking issue for this ja PR already exists
-          # (rerun, duplicate dispatch, manual replay), comment on it
-          # instead of opening a duplicate.
-          marker="auto-mirror P1: ja#${{ steps.meta.outputs.pr_number }} "
+
+          {
+            echo "${phase_tag} classification."
+            echo
+            cat classification_body.md
+            if [ "${OPEN_PR}" = 'true' ] && [ "${runtime_count}" -gt 0 ]; then
+              echo
+              echo "Runtime files have been opened as a separate mirror PR (branch \`auto-mirror/ja-pr-${JA_PR_NUM}\`)."
+            fi
+          } > issue_body.md
+
+          # Idempotency: match by phase-prefixed marker. P1->P2 reruns
+          # land on a different marker on purpose so the rollout phase is
+          # auditable; cleanup of pre-P2 issues stays manual.
+          marker="${phase_tag}: ja#${JA_PR_NUM} "
           existing="$(gh issue list \
             --label auto-mirror-runtime \
             --state all \
@@ -199,10 +384,3 @@ jobs:
               >/dev/null
             echo "Issue opened (runtime=${runtime_count}, translation=${translation_count}, unknown=${unknown_count})."
           fi
-
-      - name: P2+ stub — would open mirror PR here
-        if: ${{ env.OPEN_PR == 'true' }}
-        run: |
-          echo "OPEN_PR=true — P2 mirror-PR step not yet implemented." >&2
-          echo "This branch will land in a follow-up commit when P1 observation completes." >&2
-          exit 1

--- a/.github/workflows/auto-mirror-runtime.yml
+++ b/.github/workflows/auto-mirror-runtime.yml
@@ -120,10 +120,11 @@ jobs:
           PR_NUM: ${{ steps.meta.outputs.pr_number }}
         run: |
           set -euo pipefail
-          # gh api --paginate concatenates JSON-array pages into one big
-          # array, so a single jq pass projects the fields we need.
+          # gh api --paginate emits one JSON array per page (not a merged
+          # array), so slurp + add concatenates them into a single array
+          # before projecting the fields we need. Holds for any page count.
           gh api --paginate "repos/${JA_REPO}/pulls/${PR_NUM}/files" \
-            | jq 'map({filename, status, previous_filename})' \
+            | jq -s 'add | map({filename, status, previous_filename})' \
             > pr_files.json
           jq -r '.[].filename' pr_files.json > changed_files.txt
           echo "Changed files:"
@@ -136,11 +137,34 @@ jobs:
           python -m unittest discover -s tools -p test_sync_classifier.py -v
           python tools/sync_classifier.py < changed_files.txt > classification.json
           cat classification.json
-          runtime_count="$(jq '.by_class.runtime | length' classification.json)"
           translation_count="$(jq '.by_class.translation | length' classification.json)"
           unknown_count="$(jq '.by_class.unknown | length' classification.json)"
           divergence_count="$(jq '.by_class["divergence-allowed"] | length' classification.json)"
+          # The mirror-PR gate (runtime_touched_count) considers both the
+          # new path and the rename source. A runtime->non-runtime rename
+          # has runtime_count=0 from the new-path-only classifier, but en
+          # still needs a mirror PR to drop the orphaned old path.
+          runtime_touched_count="$(python - <<'PY'
+          import json, sys
+          sys.path.insert(0, 'tools')
+          from sync_classifier import classify_path, CLASS_RUNTIME
+          entries = json.load(open('pr_files.json'))
+          n = 0
+          for e in entries:
+              new_runtime = classify_path(e['filename']) == CLASS_RUNTIME
+              prev = e.get('previous_filename')
+              prev_runtime = bool(prev) and classify_path(prev) == CLASS_RUNTIME
+              if new_runtime or prev_runtime:
+                  n += 1
+          print(n)
+          PY
+          )"
+          # runtime_count keeps the legacy semantic (filename-only) for the
+          # tracking-issue summary table; runtime_touched_count drives the
+          # mirror-PR step.
+          runtime_count="$(jq '.by_class.runtime | length' classification.json)"
           echo "runtime_count=${runtime_count}" >> "$GITHUB_OUTPUT"
+          echo "runtime_touched_count=${runtime_touched_count}" >> "$GITHUB_OUTPUT"
           echo "translation_count=${translation_count}" >> "$GITHUB_OUTPUT"
           echo "unknown_count=${unknown_count}" >> "$GITHUB_OUTPUT"
           echo "divergence_count=${divergence_count}" >> "$GITHUB_OUTPUT"
@@ -192,7 +216,8 @@ jobs:
           JA_MERGE_SHA: ${{ steps.meta.outputs.merge_sha }}
 
       - name: Open mirror PR (P2, runtime files)
-        if: ${{ env.OPEN_PR == 'true' && steps.classify.outputs.runtime_count != '0' }}
+        id: mirror
+        if: ${{ env.OPEN_PR == 'true' && steps.classify.outputs.runtime_touched_count != '0' }}
         env:
           # Prefer AUTO_MIRROR_PAT (so resulting PR triggers pull_request
           # CI like tests.yml). Fall back to GITHUB_TOKEN — push and PR
@@ -313,6 +338,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No net runtime changes after applying ops — en already in sync. Skipping PR."
+            echo "pr_opened=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -356,13 +382,15 @@ jobs:
               --head "${BRANCH}" \
               --label auto-mirror-runtime
           fi
+          echo "pr_opened=true" >> "$GITHUB_OUTPUT"
 
       - name: Open or refresh tracking issue (translation / unknown)
-        if: ${{ steps.classify.outputs.translation_count != '0' || steps.classify.outputs.unknown_count != '0' || (env.OPEN_PR != 'true' && steps.classify.outputs.runtime_count != '0') }}
+        if: ${{ always() && (steps.classify.outputs.translation_count != '0' || steps.classify.outputs.unknown_count != '0' || (env.OPEN_PR != 'true' && steps.classify.outputs.runtime_count != '0')) }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JA_PR_NUM: ${{ steps.meta.outputs.pr_number }}
           JA_PR_TITLE: ${{ steps.meta.outputs.pr_title }}
+          PR_OPENED: ${{ steps.mirror.outputs.pr_opened }}
         run: |
           set -euo pipefail
           translation_count="${{ steps.classify.outputs.translation_count }}"
@@ -389,7 +417,11 @@ jobs:
             echo "${phase_tag} classification."
             echo
             cat classification_body.md
-            if [ "${OPEN_PR}" = 'true' ] && [ "${runtime_count}" -gt 0 ]; then
+            # Only mention the mirror PR if one was actually opened/
+            # refreshed. The mirror step also runs (and skips with
+            # pr_opened=false) when en is already in sync; in that case
+            # this issue should not falsely advertise a separate PR.
+            if [ "${PR_OPENED:-false}" = 'true' ]; then
               echo
               echo "Runtime files have been opened as a separate mirror PR (branch \`auto-mirror/ja-pr-${JA_PR_NUM}\`)."
             fi

--- a/.github/workflows/auto-mirror-runtime.yml
+++ b/.github/workflows/auto-mirror-runtime.yml
@@ -73,25 +73,28 @@ jobs:
       - name: Resolve ja PR metadata
         id: meta
         env:
+          # Dispatch payload / workflow_dispatch inputs are passed via env
+          # (not inlined into the shell) so titles containing `'`, `"`, or
+          # newlines cannot break the script.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD_NUM: ${{ github.event.client_payload.ja_pr_number }}
+          PAYLOAD_TITLE: ${{ github.event.client_payload.ja_pr_title }}
+          PAYLOAD_URL: ${{ github.event.client_payload.ja_pr_url }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.ja_merge_sha }}
+          INPUT_NUM: ${{ github.event.inputs.ja_pr_number }}
+          INPUT_TITLE: ${{ github.event.inputs.ja_pr_title }}
+          INPUT_URL: ${{ github.event.inputs.ja_pr_url }}
+          INPUT_SHA: ${{ github.event.inputs.ja_merge_sha }}
         run: |
           set -euo pipefail
-          payload_num='${{ github.event.client_payload.ja_pr_number }}'
-          input_num='${{ github.event.inputs.ja_pr_number }}'
-          PR_NUM="${payload_num:-$input_num}"
+          PR_NUM="${PAYLOAD_NUM:-$INPUT_NUM}"
           if [ -z "${PR_NUM}" ]; then
             echo "ja_pr_number missing from dispatch payload" >&2
             exit 1
           fi
-          payload_title='${{ github.event.client_payload.ja_pr_title }}'
-          payload_url='${{ github.event.client_payload.ja_pr_url }}'
-          payload_sha='${{ github.event.client_payload.ja_merge_sha }}'
-          input_title='${{ github.event.inputs.ja_pr_title }}'
-          input_url='${{ github.event.inputs.ja_pr_url }}'
-          input_sha='${{ github.event.inputs.ja_merge_sha }}'
-          title="${payload_title:-$input_title}"
-          url="${payload_url:-$input_url}"
-          merge_sha="${payload_sha:-$input_sha}"
+          title="${PAYLOAD_TITLE:-$INPUT_TITLE}"
+          url="${PAYLOAD_URL:-$INPUT_URL}"
+          merge_sha="${PAYLOAD_SHA:-$INPUT_SHA}"
           if pr_json="$(gh api "repos/${JA_REPO}/pulls/${PR_NUM}" 2>/dev/null)"; then
             api_title="$(printf '%s' "$pr_json" | jq -r '.title // empty')"
             api_url="$(printf '%s' "$pr_json" | jq -r '.html_url // empty')"
@@ -102,26 +105,27 @@ jobs:
           fi
           : "${title:=ja PR #${PR_NUM}}"
           : "${url:=https://github.com/${JA_REPO}/pull/${PR_NUM}}"
-          echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
-          echo "pr_title=${title}" >> "$GITHUB_OUTPUT"
-          echo "pr_url=${url}" >> "$GITHUB_OUTPUT"
-          echo "merge_sha=${merge_sha}" >> "$GITHUB_OUTPUT"
+          # Use the heredoc form for outputs so newlines in title cannot
+          # corrupt $GITHUB_OUTPUT framing.
+          {
+            echo "pr_number=${PR_NUM}"
+            echo "merge_sha=${merge_sha}"
+            printf 'pr_title<<__META_EOF__\n%s\n__META_EOF__\n' "${title}"
+            printf 'pr_url<<__META_EOF__\n%s\n__META_EOF__\n' "${url}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch changed files from ja PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.meta.outputs.pr_number }}
         run: |
           set -euo pipefail
-          # Keep both a filename-only list (for the existing classifier
-          # CLI) and a structured NDJSON file (for status-aware mirror
-          # operations: added / modified / removed / renamed).
-          gh api --paginate \
-            "repos/${JA_REPO}/pulls/${{ steps.meta.outputs.pr_number }}/files" \
-            -q '.[].filename' > changed_files.txt
-          gh api --paginate \
-            "repos/${JA_REPO}/pulls/${{ steps.meta.outputs.pr_number }}/files" \
-            -q '.[] | {filename, status, previous_filename}' \
-            > pr_files.ndjson
+          # gh api --paginate concatenates JSON-array pages into one big
+          # array, so a single jq pass projects the fields we need.
+          gh api --paginate "repos/${JA_REPO}/pulls/${PR_NUM}/files" \
+            | jq 'map({filename, status, previous_filename})' \
+            > pr_files.json
+          jq -r '.[].filename' pr_files.json > changed_files.txt
           echo "Changed files:"
           cat changed_files.txt
 
@@ -215,62 +219,91 @@ jobs:
           git -C ja-src fetch --depth=1 origin "${JA_MERGE_SHA}"
           git -C ja-src checkout --quiet --detach FETCH_HEAD
 
-          # 2. Apply runtime ops (added/modified/renamed/removed) into the
-          # en working tree. Classification is re-run inside Python so we
-          # use the same source-of-truth module as the standalone CLI.
+          # 2. Apply runtime ops (added / modified / renamed / removed)
+          # into the en working tree. Two-phase to be safe against rename
+          # chains (A->B then B->C) and swaps (A<->B): collect all paths
+          # to remove first, then collect all paths to copy, finally
+          # apply remove-then-copy. Both `filename` and `previous_filename`
+          # are classified independently so a rename across class
+          # boundaries (runtime->translation or vice versa) is handled
+          # correctly: only paths that classify as runtime are touched.
           python - <<'PY'
           import json, os, shutil, subprocess, sys
           sys.path.insert(0, '.')
           from tools.sync_classifier import classify_path, CLASS_RUNTIME
 
           ja_root = "ja-src"
-          ops = []
-          with open("pr_files.ndjson") as f:
-              for line in f:
-                  line = line.strip()
-                  if not line:
-                      continue
-                  rec = json.loads(line)
-                  if classify_path(rec["filename"]) != CLASS_RUNTIME:
-                      continue
-                  ops.append(rec)
+          with open("pr_files.json") as f:
+              entries = json.load(f)
+
+          to_remove = set()  # en paths to drop
+          to_copy = {}       # en path -> ja-src relative path
+
+          for rec in entries:
+              path = rec["filename"]
+              status = rec["status"]
+              prev = rec.get("previous_filename")
+              new_is_runtime = classify_path(path) == CLASS_RUNTIME
+              prev_is_runtime = (
+                  prev is not None and classify_path(prev) == CLASS_RUNTIME
+              )
+
+              if status == "removed":
+                  if new_is_runtime:
+                      to_remove.add(path)
+                  continue
+
+              if status == "renamed":
+                  # Drop old runtime path on en (regardless of new class)
+                  # so a runtime->non-runtime rename also leaves en clean.
+                  if prev_is_runtime:
+                      to_remove.add(prev)
+                  if new_is_runtime:
+                      to_copy[path] = path
+                  continue
+
+              # added / modified / copied / changed
+              if new_is_runtime:
+                  to_copy[path] = path
+
+          # Drop any path from `to_remove` that is also being copied — a
+          # rename A->A (status renamed but identical path, rare but
+          # possible) or A->B alongside another A->A would otherwise
+          # delete the file we just staged.
+          to_remove -= set(to_copy.keys())
 
           def git(*args):
               subprocess.check_call(["git", *args])
 
-          applied = removed = renamed = skipped_missing = 0
-          for rec in ops:
-              path = rec["filename"]
-              status = rec["status"]
-              prev = rec.get("previous_filename")
-              src = os.path.join(ja_root, path)
-              if status == "removed":
-                  if os.path.exists(path):
-                      git("rm", "-q", "--", path)
-                      removed += 1
-                  continue
-              if status == "renamed" and prev:
-                  # Drop the old en path if it lived there. classify_path on
-                  # `prev` may be non-runtime (e.g. tools/x.py renamed from
-                  # docs/x.md); only en files actually present matter.
-                  if os.path.exists(prev):
-                      git("rm", "-q", "--", prev)
-                      renamed += 1
+          removed = applied = skipped_missing = 0
+
+          # Phase 1: removes. Skip silently if the file isn't tracked on
+          # en — the rename source may have been excluded via .gitignore
+          # historically, or en may have already removed it manually.
+          for path in sorted(to_remove):
+              if os.path.exists(path):
+                  git("rm", "-q", "--", path)
+                  removed += 1
+
+          # Phase 2: copies. Source content comes from ja-src (already
+          # checked out at the merge SHA), so swaps and chains resolve
+          # to ja's final-state content automatically.
+          for dst, ja_rel in sorted(to_copy.items()):
+              src = os.path.join(ja_root, ja_rel)
               if not os.path.exists(src):
-                  # ja side reports add/modify but the file isn't in the
-                  # tree at merge SHA — should not happen for a merged PR,
-                  # but skip rather than crash if it does.
+                  # Should not happen for a merged PR, but be defensive.
                   skipped_missing += 1
                   continue
-              parent = os.path.dirname(path)
+              parent = os.path.dirname(dst)
               if parent:
                   os.makedirs(parent, exist_ok=True)
-              shutil.copy2(src, path)
-              git("add", "--", path)
+              shutil.copy2(src, dst)
+              git("add", "--", dst)
               applied += 1
 
-          print(f"runtime ops: applied={applied} removed={removed} renamed={renamed} "
-                f"skipped_missing_in_ja={skipped_missing} total_runtime_in_pr={len(ops)}")
+          print(f"runtime ops: applied={applied} removed={removed} "
+                f"skipped_missing_in_ja={skipped_missing} "
+                f"total_pr_entries={len(entries)}")
           PY
 
           # 3. Commit. If nothing actually staged (e.g. en already at the

--- a/docs/runbook/auto-mirror-runtime.md
+++ b/docs/runbook/auto-mirror-runtime.md
@@ -105,8 +105,13 @@ gh workflow run auto-mirror-runtime.yml \
 from the GH API), but setting them keeps the PR / issue body legible if
 the ja PR was since edited.
 
-A rerun for the same ja PR number is safe: branch `auto-mirror/ja-pr-<N>`
-is force-updated and the PR body / title is rewritten in place.
+A rerun for the same ja PR number is safe **while the matching mirror
+PR is open**: branch `auto-mirror/ja-pr-<N>` is force-updated and the
+PR body / title are rewritten in place. If the mirror PR was previously
+closed (manually rejected, or merged), a rerun will push the branch but
+**will not** reopen or replace the closed PR — the workflow only
+detects `--state open`. To re-mirror after a close, delete the branch
+first or change the ja PR number you are replaying.
 
 ## Conflict handling
 

--- a/docs/runbook/auto-mirror-runtime.md
+++ b/docs/runbook/auto-mirror-runtime.md
@@ -5,50 +5,83 @@
 covers operational tasks and the phased rollout plan.
 
 Design source: `suisya-systems/claude-org-ja#189` (and Lead decision #171).
+P2 implementation tracked under `suisya-systems/claude-org-ja#335`.
 
-## What it does today (Phase P1)
+## What it does today (Phase P2)
 
 - Triggered by `repository_dispatch` event `ja_pr_merged` from ja repo
-  (existing pipeline; no new PAT required on this side).
-- Pulls the changed-file list of the ja PR via `gh api`.
+  (existing pipeline; no new PAT strictly required, but see Auth below).
+- Pulls the changed-file list of the ja PR via `gh api`, with per-file
+  status (added / modified / removed / renamed).
 - Classifies each file using `tools/sync_classifier.py`:
-  - `runtime`: would be auto-mirrored in P2+
-  - `translation`: handled by existing TRANSLATION-PENDING flow
-  - `divergence-allowed`: intentionally divergent; ignored
-  - `unknown`: surfaced for manual triage
-- Opens a single tracking issue **on this repo** with the classification
-  summary, labeled `auto-mirror-runtime` (plus `translation-pending` if any
-  translation-class file was touched, and `needs-triage` if any path
-  classified as `unknown`).
-- **Does NOT open a mirror PR.** The `OPEN_PR` env var defaults to `false`.
+  - `runtime`: opened as a mirror PR on this repo (P2 behavior).
+  - `translation`: handled by existing TRANSLATION-PENDING flow.
+  - `divergence-allowed`: intentionally divergent; ignored.
+  - `unknown`: surfaced for manual triage on the tracking issue.
+- For runtime-class files: shallow-fetches ja at the merge SHA, copies
+  the runtime files into a branch `auto-mirror/ja-pr-<N>`, and opens (or
+  refreshes) a PR titled `auto-mirror: ja#<N> <title>` against `main`,
+  labeled `auto-mirror-runtime`. Force-push is used so reruns are
+  idempotent — the auto-mirror branch namespace is exclusively owned by
+  this workflow.
+- For translation- or unknown-class files (or when `OPEN_PR=false`): opens
+  (or comments on) a single tracking issue carrying the same
+  `auto-mirror-runtime` / `translation-pending` / `needs-triage` labels
+  as before. The `translation-pending` label remains the contract for
+  downstream translation-pipeline consumers.
+- For divergence-allowed-only batches: no PR, no issue.
 
-This workflow subsumes the previous `notify-ja-changes.yml`; that file has
-been removed so a single dispatch produces a single issue (no duplicates).
-The `translation-pending` label remains the contract for downstream
-translation-pipeline consumers.
+This workflow subsumes the previous `notify-ja-changes.yml`; that file
+was removed so a single dispatch produces at most one PR + at most one
+tracking issue (no duplicates).
 
-Cross-repo writes are deliberately avoided: posting back to the ja PR
-would require a PAT on the en side, which Lead chose not to introduce in
-P1 (Issue #189 design constraint). The signal lives here instead.
+## Auth
+
+Two secrets are consulted, in order, for any same-repo write (push +
+`gh pr create` / `gh pr edit`):
+
+1. `secrets.AUTO_MIRROR_PAT` — preferred. A classic PAT with `repo`
+   scope (or fine-grained PAT with Contents:write + Pull requests:write
+   on this repo) issued by a maintainer. Required if you want PRs opened
+   by the workflow to trigger `pull_request` workflows such as
+   `tests.yml`. GitHub deliberately blocks workflows from triggering
+   other workflows when the source PR was opened by `GITHUB_TOKEN`, so
+   without `AUTO_MIRROR_PAT` mirror PRs will land with **no CI**.
+2. `secrets.GITHUB_TOKEN` — automatic fallback. Push and PR creation
+   still succeed, but as above, downstream CI won't fire on the mirror PR.
+
+The ja side continues to use only its existing `secrets.NOTIFY_EN_PAT`,
+which never holds write scope on this repo. Issue #189 explicitly kept
+the ja side free of new secrets; the optional PAT lives on the en side.
+
+If `AUTO_MIRROR_PAT` is rotated or revoked, the workflow keeps running
+under `GITHUB_TOKEN` automatically; reviewers should treat any mirror PR
+without CI badges as warranting a manual rerun once the PAT is back.
 
 ## Disable temporarily
 
 Two equivalent options:
 
-1. Set `OPEN_PR` aside and short-circuit the workflow by editing the file
-   header:
+1. Flip the kill-switch in the workflow file:
+
+   ```yaml
+   env:
+     OPEN_PR: 'false'    # P1 warn-only — tracking issue, no mirror PR
+   ```
+
+   Commit, push, done. The tracking-issue path keeps working.
+
+2. Short-circuit the entire job:
 
    ```yaml
    jobs:
-     classify-and-warn:
-       if: false              # <-- disables the job entirely
+     classify-and-mirror:
+       if: false
        runs-on: ubuntu-latest
    ```
 
-   Commit, push, done. Re-enable by removing `if: false`.
-
-2. Delete the workflow file. Slower to restore; only do this for permanent
-   removal.
+   Use this if you also want to suppress the tracking issue (e.g.,
+   during a multi-day backfill).
 
 GitHub also lets you disable a workflow from the Actions UI
 (`Actions` → `Auto-mirror runtime (ja -> en)` → `…` → `Disable workflow`),
@@ -67,24 +100,43 @@ gh workflow run auto-mirror-runtime.yml \
   -f ja_pr_url="https://github.com/suisya-systems/claude-org-ja/pull/<NUMBER>"
 ```
 
-`ja_merge_sha` is optional; the workflow will resolve it from the PR if
-omitted. Title and URL are also optional in P1 (the workflow re-fetches
-them from the GH API), but setting them keeps the comment body legible if
-the ja PR has been since edited.
+`ja_merge_sha` is optional — the workflow resolves it from the PR via
+`gh api`. Title and URL are also optional (the workflow re-fetches them
+from the GH API), but setting them keeps the PR / issue body legible if
+the ja PR was since edited.
+
+A rerun for the same ja PR number is safe: branch `auto-mirror/ja-pr-<N>`
+is force-updated and the PR body / title is rewritten in place.
+
+## Conflict handling
+
+P2 does not auto-merge. If `git push` succeeds but the resulting PR
+conflicts with `main` (e.g., because en has diverged on a runtime path),
+the reviewer has three options:
+
+1. Resolve locally and push to the same `auto-mirror/ja-pr-<N>` branch
+   (the workflow won't overwrite until the next ja PR rerun touches the
+   same number).
+2. Close the mirror PR and apply the ja change by hand. Note this in
+   the matching `auto-mirror P2: ja#<N>` tracking issue (if any) for
+   audit.
+3. Re-run the workflow (`gh workflow run …`) once en is in a state where
+   a clean apply is possible. Force-push semantics make rerun safe.
+
+The reverse drift detector (Phase P4) will eventually catch the second
+case — en runtime edits without a ja parent — but is out of scope here.
 
 ## Phased rollout
 
 | Phase | Status | Behavior | Exit criterion |
 |---|---|---|---|
-| P1 | **active** | classify + comment, no mirror PR | ≥1 week clean run, ≥5 ja merges classified correctly by spot check |
-| P2 | not yet | open mirror PR per ja merge, manual merge | ≥10 mirror PRs merged, conflict + docstring impact understood |
+| P1 | superseded | classify + tracking issue, no mirror PR | (rolled into P2) |
+| P2 | **active** | open mirror PR per ja merge, manual merge | ≥10 mirror PRs merged, conflict + docstring impact understood |
 | P3 | not yet | auto-merge runtime-only mirror PRs (gate TBD by Lead) | ≥4 weeks of P2 stability |
 | P4 | not yet | reverse-drift detector (en runtime edits without ja parent) | n/a (additive) |
 
-Switching P1 → P2 is a single-line change: `OPEN_PR: 'true'` in
-`.github/workflows/auto-mirror-runtime.yml`. The corresponding mirror-PR
-opening step is currently a stub that exits non-zero — implement it before
-flipping the toggle.
+Reverting P2 → P1 is a single-line change: `OPEN_PR: 'false'`. The
+tracking-issue path stays functional under either toggle.
 
 ## Pending Lead decisions
 
@@ -92,12 +144,12 @@ These are surfaced for visibility; defaults are applied today and can be
 flipped with doc-only edits if Lead changes course:
 
 - **Docstring overwrite policy** (Issue #189 §Open #1): default = ja
-  docstrings ride along onto en. No overlay translation in P1.
+  docstrings ride along onto en. No overlay translation in P2.
 - **ja-only doc commits** (#163, #168 reference, Issue #189 §Open #4):
   default = status quo (classified as `translation` or `divergence-allowed`,
-  not auto-mirrored). No new warn signal in P1.
-
-P3 gating decisions (#2, #3 in Issue #189) are out of scope for P1.
+  not auto-mirrored). No new warn signal in P2.
+- **P3 auto-merge gate** (Issue #189 §Open #2, #3): out of scope until
+  P2 has accumulated ≥10 merged mirror PRs of empirical data.
 
 ## Related files
 


### PR DESCRIPTION
## Summary

Implements the P2 step of `auto-mirror-runtime.yml` so that runtime / divergence-allowed file classes from ja PRs are auto-mirrored as PRs on this repo, while translation-class files keep the existing tracking-issue flow. Closes the long-standing `OPEN_PR=false` + `exit 1` stub state.

Refs: claude-org-ja#335 / claude-org-ja#189

## Implementation

- **PR aggregation**: `gh api --paginate | jq -s 'add | map(...)'` normalises multi-page PR file listings into a single array.
- **2-phase apply** (remove → copy) on `previous_filename` / `filename`, safe under rename chains and swaps.
- **Cross-class rename gate**: classification reads both `filename` and `previous_filename` so a runtime↔translation rename does not silently leak into either lane.
- **Idempotent**: branch `auto-mirror/ja-pr-<N>` is force-pushed; existing PR refreshed via `gh pr edit`. `pr_opened` output drives accurate "already-synced" skip in the issue body.
- **Auth (per ja#189 design)**: `secrets.AUTO_MIRROR_PAT` preferred, falls back to `GITHUB_TOKEN`. `OPEN_PR='true'` is default; `'false'` is the kill-switch back to P1 (issue-only).

## Files

- `.github/workflows/auto-mirror-runtime.yml` — P2 stub → full implementation
- `docs/runbook/auto-mirror-runtime.md` — P1 → P2 update, auth section, conflict section, idempotency notes

## Verification

- YAML syntax: `yaml.safe_load` ✓
- Codex self-review: 3 rounds (Blocker x4 / Major x2 / Minor x2 all addressed). Final round LGTM (no Blocker / Major).
- Live GHA run not yet performed — `workflow_dispatch` smoke test recommended after merge (e.g. replay an existing ja PR like ja#325).

## Operator notes

- Optional: set `secrets.AUTO_MIRROR_PAT` on this repo to make `pull_request`-triggered workflows (e.g. `tests.yml`) run on auto-mirror PRs. Without it, mirror PRs land but PR-triggered CI is skipped (GHA's known GITHUB_TOKEN constraint).
- Existing P1 tracking issues (#56–#110) carry a different phase tag and do not collide with P2 PRs; manual close at convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)