### PR TITLE
auto-mirror: ja#325 feat(claude): back-fill runs.pr_url at PR open for MergeWatch (Closes #323)

### DIFF
--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""PR-open back-fill helper (Issue #323).
+
+Closes the auto-completion gap that surfaced on PR #321: when Secretary
+runs ``gh pr create`` immediately after a worker reports done, the
+freshly-created PR's ``url`` is not yet recorded on ``runs``. The
+``-MergeWatch`` path of ``pr-watch.ps1`` later calls
+``run_complete_on_merge --pr <N>``, which resolves ``task_id`` by
+matching ``runs.pr_url`` (or ``runs.branch``); without a back-fill the
+helper returns ``no_run`` and Secretary has to recover by hand.
+
+This helper is the canonical action Secretary runs right after
+``gh pr create`` succeeds. It:
+
+1. shells ``gh pr view <PR> --json url,headRefName`` to get the PR URL
+   and head branch (authoritative — what GitHub actually recorded);
+2. opens a ``StateWriter.transaction()`` and calls
+   :meth:`StateWriter.set_run_pr` to update ``runs.pr_url`` (and
+   ``runs.branch`` re-asserted from gh's ``headRefName``).
+
+Idempotent: a second invocation rewrites the same values and adds no
+journal entry — back-fill is metadata, not a new lifecycle event.
+
+Usage::
+
+    python tools/set_run_pr_open.py --task-id <id> --pr <N> \\
+        [--repo OWNER/REPO] [--db-path <path>]
+
+Exit codes: 0 on success, 2 on gh / DB failure, 3 when the run row for
+``task_id`` is missing (so Secretary sees the misalignment instead of a
+silent no-op), 127 when the ``gh`` CLI is not installed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: GitHub CLI (gh) not found "
+            "in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: failed to auto-detect repo "
+            f"via `gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        return json.loads(result.stdout)["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: unexpected `gh repo view` "
+            f"output: {exc}\n"
+        )
+        sys.exit(2)
+
+
+def fetch_pr_view(pr: int, repo: str) -> dict:
+    """Return the parsed ``gh pr view`` payload (url + headRefName)."""
+    proc = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr),
+            "--repo", repo,
+            "--json", "url,headRefName",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view {pr} (repo={repo}) failed: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh pr view {pr} returned unparseable JSON: {exc}"
+        ) from None
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"gh pr view {pr} returned non-object JSON: {type(data).__name__}"
+        )
+    return data
+
+
+# Stable result strings — callers (tests, future automation) can branch
+# without parsing log lines.
+RESULT_OK = "ok"
+RESULT_NO_RUN = "no_run"
+
+
+def set_run_pr_open(
+    *,
+    task_id: str,
+    pr: int,
+    repo: str,
+    db_path: Optional[Path] = None,
+    pr_view: Optional[dict] = None,
+) -> str:
+    """Back-fill ``runs.pr_url`` / ``runs.branch`` for ``task_id``.
+
+    Returns :data:`RESULT_OK` on success or :data:`RESULT_NO_RUN` if the
+    run row is missing (caller decides whether to abort).
+
+    ``pr_view`` may be supplied by callers that already fetched the
+    payload; otherwise it is fetched via :func:`fetch_pr_view`.
+    """
+    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    if pr_view is None:
+        pr_view = fetch_pr_view(pr, repo)
+
+    pr_url = (pr_view.get("url") or "").strip()
+    head_ref = pr_view.get("headRefName") or None
+    if not pr_url:
+        raise RuntimeError(
+            f"gh pr view {pr} returned no url field; refusing to write "
+            "an empty pr_url."
+        )
+
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+
+        row = conn.execute(
+            "SELECT 1 FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            sys.stderr.write(
+                "tools/set_run_pr_open.py: warning: no run row for "
+                f"task_id={task_id!r}; skipping back-fill.\n"
+            )
+            return RESULT_NO_RUN
+
+        with StateWriter(conn).transaction() as w:
+            w.set_run_pr(task_id, pr_url=pr_url, branch=head_ref)
+        return RESULT_OK
+    finally:
+        conn.close()
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/set_run_pr_open.py",
+        description=(
+            "Back-fill runs.pr_url (and runs.branch) right after Secretary "
+            "creates the PR, so run_complete_on_merge can auto-resolve "
+            "task_id on merge."
+        ),
+    )
+    parser.add_argument("--task-id", required=True,
+                        help="task_id of the run to back-fill")
+    parser.add_argument("--pr", type=int, required=True,
+                        help="pull request number")
+    parser.add_argument("--repo", default=None,
+                        help="OWNER/REPO; auto-detected via gh repo view")
+    parser.add_argument("--db-path", default=None,
+                        help=f"path to state.db (default: {DEFAULT_DB_PATH})")
+    args = parser.parse_args(argv)
+
+    if args.pr <= 0:
+        parser.error("--pr must be a positive integer")
+    if not args.task_id.strip():
+        parser.error("--task-id must be non-empty")
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    try:
+        result = set_run_pr_open(
+            task_id=args.task_id,
+            pr=args.pr,
+            repo=repo,
+            db_path=Path(args.db_path) if args.db_path else None,
+        )
+    except RuntimeError as exc:
+        sys.stderr.write(f"tools/set_run_pr_open.py: error: {exc}\n")
+        return 2
+
+    sys.stdout.write(
+        f"set_run_pr_open: task_id={args.task_id} PR #{args.pr} {result}\n"
+    )
+    if result == RESULT_NO_RUN:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/state_db/writer.py
+++ b/tools/state_db/writer.py
@@ -1,0 +1,701 @@
+"""Thin DB direct-write API for the M2 write switch (Issue #267).
+
+In M2 the SQLite DB at `.state/state.db` becomes the SoT for state writes.
+Secretary / dispatcher / worker code is expected to call into a
+``StateWriter`` instead of editing `.state/org-state.md` or appending to
+`.state/journal.jsonl` by hand. The markdown / jsonl files are regenerated
+post-commit by :mod:`tools.state_db.snapshotter` (one-way dump).
+
+Design boundary (per CLAUDE.local.md / migration-strategy.md §M2):
+- writer mutates DB rows only.
+- writer never imports snapshotter; markdown regeneration is the caller's
+  responsibility (typically via ``post_commit_regenerate``). This keeps the
+  failure surface of writer narrow and avoids a circular dependency.
+- writer wraps every public mutation in an explicit transaction. Callers
+  may compose multiple mutations inside ``begin()`` / ``commit()`` instead.
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Optional
+
+
+class _ClearSentinel:
+    """Singleton marker that means "explicitly NULL this column".
+
+    Used by :meth:`StateWriter.update_session` to distinguish "caller
+    omitted this kwarg / passed None as a meaningless default" from
+    "caller really wants to clear this column".
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover — debug aid only
+        return "StateWriter.CLEAR"
+
+
+class StateWriter:
+    """Connection-bound writer with explicit transaction control.
+
+    Construct with an open ``sqlite3.Connection`` (preferably one returned
+    by :func:`tools.state_db.connect` so that ``foreign_keys`` and
+    ``busy_timeout`` PRAGMAs are already set). The writer re-asserts those
+    PRAGMAs defensively because callers sometimes hand in a bare connection.
+    """
+
+    CLEAR = _ClearSentinel()
+
+    def __init__(self, conn: sqlite3.Connection,
+                 *, claude_org_root: Optional[Path] = None):
+        self.conn = conn
+        # Defensive: ensure project-wide PRAGMAs and row_factory even
+        # when caller passed a bare sqlite3.connect() handle. The
+        # ``sqlite3.Row`` row_factory is required by ``_detect_claude_org_root``
+        # below (which addresses ``row["file"]``); a default tuple
+        # row_factory would raise ``TypeError: tuple indices must be
+        # integers``. Setting it here is idempotent for connections
+        # opened via ``tools.state_db.connect``.
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("PRAGMA busy_timeout = 5000")
+        # Forward-migrate pre-M2 DBs in place: org_sessions may be missing
+        # if this writer attaches to an M0 / M1 DB that was created before
+        # the schema bump. ensure_m2_schema is idempotent and seeds the
+        # singleton row when it's absent.
+        from tools.state_db import ensure_m2_schema
+        ensure_m2_schema(conn)
+        # claude_org_root is the repo root that contains `.state/`. When
+        # set, ``transaction()`` regenerates `.state/org-state.md` and
+        # `.state/journal.jsonl` from the DB after each successful commit
+        # (M2.1 post-commit hook). When None we attempt to auto-detect
+        # from the connection's file path; failure is non-fatal — the
+        # transaction still commits and the caller can still call
+        # snapshotter.post_commit_regenerate manually.
+        if claude_org_root is None:
+            claude_org_root = _detect_claude_org_root(conn)
+        self._claude_org_root: Optional[Path] = (
+            Path(claude_org_root) if claude_org_root is not None else None
+        )
+        # Issue #284: task_ids whose run was just transitioned to
+        # 'completed'. Drained on commit so we never move the worker
+        # state file before the DB row is durable on disk.
+        self._pending_worker_archives: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Transaction control
+    # ------------------------------------------------------------------
+
+    def begin(self) -> None:
+        """Open an explicit transaction.
+
+        sqlite3's default isolation level is "deferred" (= a transaction
+        opens implicitly on the first DML); calling ``BEGIN`` directly
+        would raise ``OperationalError: cannot start a transaction within
+        a transaction`` if one is already open. We swallow that case so
+        callers can defensively bracket their writes.
+        """
+        try:
+            self.conn.execute("BEGIN")
+        except sqlite3.OperationalError:
+            pass
+
+    def commit(self) -> None:
+        self.conn.commit()
+        # Post-commit hooks. Hosted on ``commit()`` so they fire for
+        # both callers — explicit ``begin() / commit()`` and the
+        # ``transaction()`` context manager (which delegates here).
+        # Order matters: markdown is the SoT for humans, JSON is the
+        # dashboard derivative read from the DB after the markdown
+        # dump finishes (Issue #284 / CLAUDE.local.md constraint —
+        # markdown 再生成 → JSON 再生成). Archive moves run last so a
+        # mid-hook failure leaves the worker file in place.
+        # Each step soft-fails individually: a converter, FS, or import
+        # error must never bubble up after the DB commit succeeded.
+        self._regenerate_markdown_snapshot()
+        self._regenerate_json_snapshot()
+        self._drain_pending_worker_archives()
+
+    def rollback(self) -> None:
+        self.conn.rollback()
+        # Issue #284: a rollback voids any 'completed' transitions made
+        # during the aborted transaction, so drop their archive intents
+        # too — otherwise the next commit on this writer would archive
+        # files for runs that are not actually completed.
+        self._pending_worker_archives.clear()
+
+    # ------------------------------------------------------------------
+    # Post-commit hooks (Issue #284)
+    # ------------------------------------------------------------------
+
+    def _regenerate_markdown_snapshot(self) -> None:
+        """Regenerate ``.state/org-state.md`` from the DB after commit.
+
+        Soft-fail like the JSON variant — DB is the SoT and the
+        markdown dump is best-effort. Hosted here (rather than in
+        ``transaction()``) so begin()/commit() callers also keep the
+        markdown SoT in sync.
+        """
+        if self._claude_org_root is None:
+            return
+        try:
+            from tools.state_db.snapshotter import post_commit_regenerate
+            post_commit_regenerate(self.conn, self._claude_org_root)
+        except Exception as exc:
+            sys.stderr.write(
+                "tools.state_db.writer: post-commit regenerate failed "
+                f"({type(exc).__name__}: {exc}); "
+                "DB is committed, markdown will catch up on the next "
+                "StateWriter commit.\n"
+            )
+
+    def _regenerate_json_snapshot(self) -> None:
+        """Regenerate ``.state/org-state.json`` from the DB after commit.
+
+        Soft-fail: any exception is logged to stderr and swallowed so a
+        converter bug never blocks a write that is already durable in
+        the DB.
+        """
+        if self._claude_org_root is None:
+            return
+        try:
+            # Lazy import: dashboard isn't a tools.state_db dependency at
+            # module load time, and import-time failures (e.g. missing
+            # optional package) must not poison the writer.
+            from dashboard.org_state_converter import convert
+            json_path = self._claude_org_root / ".state" / "org-state.json"
+            db_path = self._claude_org_root / ".state" / "state.db"
+            convert(json_path=json_path, db_path=db_path)
+        except Exception as exc:
+            sys.stderr.write(
+                "tools.state_db.writer: post-commit JSON snapshot "
+                f"regenerate failed ({type(exc).__name__}: {exc}); "
+                "DB is committed, dashboard JSON will catch up on the "
+                "next StateWriter commit.\n"
+            )
+
+    def _drain_pending_worker_archives(self) -> None:
+        """Move queued worker-state files into ``.state/workers/archive/``.
+
+        Called after commit. Idempotent: missing source file is a no-op
+        (re-completion of an already-archived run). The destination
+        directory is lazily created. Uses ``os.replace`` so the move is
+        atomic on Windows as well as POSIX.
+        """
+        if not self._pending_worker_archives:
+            return
+        pending, self._pending_worker_archives = (
+            self._pending_worker_archives, []
+        )
+        if self._claude_org_root is None:
+            return
+        workers_dir = self._claude_org_root / ".state" / "workers"
+        archive_dir = workers_dir / "archive"
+        # Codex round-2 Major: a transaction may toggle a run through
+        # ``completed`` and back to ``in_use`` / ``review`` before
+        # commit. The pending queue would still hold the task_id, so
+        # confirm the *committed* status is actually ``completed``
+        # before moving the file. ``runs`` is read after self.commit(),
+        # so this query observes the durable post-commit state.
+        # De-duplicate to avoid re-querying for repeated entries.
+        seen: set[str] = set()
+        for task_id in pending:
+            if task_id in seen:
+                continue
+            seen.add(task_id)
+            row = self.conn.execute(
+                "SELECT status FROM runs WHERE task_id = ?", (task_id,)
+            ).fetchone()
+            if row is None or row["status"] != "completed":
+                continue
+            src = workers_dir / f"worker-{task_id}.md"
+            if not src.exists():
+                continue
+            try:
+                archive_dir.mkdir(parents=True, exist_ok=True)
+                dst = archive_dir / src.name
+                os.replace(src, dst)
+            except Exception as exc:
+                sys.stderr.write(
+                    "tools.state_db.writer: failed to archive "
+                    f"{src} → {archive_dir}/ "
+                    f"({type(exc).__name__}: {exc}); leaving in place.\n"
+                )
+
+    @contextlib.contextmanager
+    def transaction(self) -> Iterator["StateWriter"]:
+        """Context-manager wrapper: BEGIN → yield → COMMIT (+ post-commit hook).
+
+        On normal exit the transaction is committed and, when
+        ``claude_org_root`` is known, ``post_commit_regenerate`` is
+        invoked to refresh `.state/org-state.md` + `.state/journal.jsonl`
+        from the DB. Regenerate failures are logged to stderr and
+        swallowed — the DB is the SoT, so the markdown / jsonl dump is
+        best-effort. The caller's ``with`` block still completes
+        normally.
+
+        On exception the transaction is rolled back and the exception
+        propagates; no regenerate is attempted.
+        """
+        self.begin()
+        try:
+            yield self
+        except BaseException:
+            self.rollback()
+            raise
+        # commit() owns the post-commit hooks (markdown regen + JSON
+        # regen + worker archive moves) so they fire for both this
+        # context-manager path and explicit begin()/commit() callers.
+        self.commit()
+
+    # ------------------------------------------------------------------
+    # org session (singleton)
+    # ------------------------------------------------------------------
+
+    _SESSION_FIELDS: tuple[str, ...] = (
+        "status", "started_at", "updated_at", "suspended_at", "resumed_at",
+        "objective", "resume_instructions",
+        "dispatcher_pane_id", "dispatcher_peer_id",
+        "curator_pane_id", "curator_peer_id",
+    )
+
+    def update_session(self, **fields: Any) -> None:
+        """Patch the org_sessions singleton with the given keyword fields.
+
+        Unknown keys raise ``ValueError`` to catch typos at write time.
+        Cross-review m2: pass ``status=None`` is treated as "caller did
+        not supply this field" and is **skipped**, not written as NULL.
+        This protects callers that pile up Optional[…] kwargs from
+        accidentally NULL-clearing every column when none of them got
+        a real value. To explicitly clear a column, use the dedicated
+        sentinel :attr:`StateWriter.CLEAR` (``writer.update_session(
+        status=StateWriter.CLEAR)``) or write raw SQL.
+        Omitted kwargs are also untouched.
+        """
+        unknown = set(fields) - set(self._SESSION_FIELDS)
+        if unknown:
+            raise ValueError(
+                f"unknown org_sessions field(s): {sorted(unknown)}; "
+                f"expected one of {list(self._SESSION_FIELDS)}"
+            )
+        # Drop implicit-None entries; only explicit CLEAR or a real value
+        # results in a column write.
+        actual: dict[str, Any] = {}
+        for k, v in fields.items():
+            if v is None:
+                continue
+            actual[k] = None if v is self.CLEAR else v
+        if not actual:
+            # No-op but still bump last_writer_at so dashboards see a write.
+            self.conn.execute(
+                "UPDATE org_sessions SET "
+                "last_writer_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+                "WHERE id = 1"
+            )
+            return
+        assigns = ", ".join(f"{k} = ?" for k in actual)
+        values = [actual[k] for k in actual]
+        self.conn.execute(
+            f"UPDATE org_sessions SET {assigns}, "
+            "last_writer_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+            "WHERE id = 1",
+            values,
+        )
+
+    def get_session(self) -> dict[str, Any]:
+        row = self.conn.execute("SELECT * FROM org_sessions WHERE id = 1").fetchone()
+        if row is None:
+            return {}
+        return {k: row[k] for k in row.keys()}
+
+    # ------------------------------------------------------------------
+    # worker_dirs
+    # ------------------------------------------------------------------
+
+    def register_worker_dir(
+        self,
+        *,
+        abs_path: str,
+        layout: Optional[str] = None,
+        is_git_repo: Optional[bool] = None,
+        is_worktree: Optional[bool] = None,
+        origin_url: Optional[str] = None,
+        current_branch: Optional[str] = None,
+        size_mb: Optional[float] = None,
+        lifecycle: Optional[str] = None,
+    ) -> int:
+        """INSERT (or differential-UPDATE) a worker_dirs row by abs_path.
+
+        Idempotent re-registration: the dispatcher / sweeper often
+        re-announces dirs on startup. Only fields the caller explicitly
+        passes are written on the UPDATE path so a status ping that omits
+        ``is_git_repo`` doesn't silently flip it back to False.
+        """
+        existing = self.conn.execute(
+            "SELECT id FROM worker_dirs WHERE abs_path = ?", (abs_path,)
+        ).fetchone()
+        if existing is None:
+            cur = self.conn.execute(
+                "INSERT INTO worker_dirs ("
+                "abs_path, layout, is_git_repo, is_worktree, origin_url, "
+                "current_branch, size_mb, lifecycle) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (abs_path, layout or "flat",
+                 int(bool(is_git_repo)) if is_git_repo is not None else 0,
+                 int(bool(is_worktree)) if is_worktree is not None else 0,
+                 origin_url, current_branch, size_mb,
+                 lifecycle or "active"),
+            )
+            return cur.lastrowid
+
+        sets: list[str] = []
+        values: list = []
+
+        def _maybe(col: str, val):
+            if val is not None:
+                sets.append(f"{col} = ?")
+                values.append(val)
+
+        _maybe("layout", layout)
+        if is_git_repo is not None:
+            sets.append("is_git_repo = ?")
+            values.append(int(bool(is_git_repo)))
+        if is_worktree is not None:
+            sets.append("is_worktree = ?")
+            values.append(int(bool(is_worktree)))
+        _maybe("origin_url", origin_url)
+        _maybe("current_branch", current_branch)
+        _maybe("size_mb", size_mb)
+        _maybe("lifecycle", lifecycle)
+        sets.append("last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')")
+        values.append(abs_path)
+        self.conn.execute(
+            f"UPDATE worker_dirs SET {', '.join(sets)} WHERE abs_path = ?",
+            values,
+        )
+        return int(existing["id"])
+
+    def update_worker_dir_lifecycle(self, abs_path: str, lifecycle: str) -> None:
+        """Move a worker dir to a different lifecycle bucket (active/archived/etc)."""
+        self.conn.execute(
+            "UPDATE worker_dirs SET lifecycle = ?, "
+            "last_seen_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+            "WHERE abs_path = ?",
+            (lifecycle, abs_path),
+        )
+
+    def remove_worker_dir(self, abs_path: str) -> None:
+        """Physically delete a worker_dirs row. Reserved for curator batch.
+
+        runs.worker_dir_id is ON DELETE SET NULL so existing run history is
+        preserved; only the FS-level metadata disappears.
+        """
+        self.conn.execute("DELETE FROM worker_dirs WHERE abs_path = ?", (abs_path,))
+
+    # ------------------------------------------------------------------
+    # projects / workstreams (lookup helpers — no creation outside importer)
+    # ------------------------------------------------------------------
+
+    def ensure_project(self, slug: str, *, display_name: Optional[str] = None,
+                       origin_url: Optional[str] = None) -> int:
+        cur = self.conn.execute(
+            "INSERT INTO projects (slug, display_name, origin_url) "
+            "VALUES (?, ?, ?) "
+            "ON CONFLICT(slug) DO UPDATE SET "
+            "  display_name = COALESCE(excluded.display_name, projects.display_name), "
+            "  origin_url = COALESCE(excluded.origin_url, projects.origin_url)",
+            (slug, display_name or slug, origin_url),
+        )
+        row = self.conn.execute(
+            "SELECT id FROM projects WHERE slug = ?", (slug,)
+        ).fetchone()
+        return int(row["id"]) if row else cur.lastrowid
+
+    # ------------------------------------------------------------------
+    # runs
+    # ------------------------------------------------------------------
+
+    # Sentinel — distinguishes "caller didn't pass this kwarg" from
+    # "caller explicitly passed None" in upsert_run's differential update.
+    _UNSET = object()
+
+    def upsert_run(
+        self,
+        *,
+        task_id: str,
+        project_slug: str,
+        pattern: Optional[str] = None,
+        title: Optional[str] = None,
+        status: Optional[str] = None,
+        branch: Optional[str] = None,
+        pr_url: Optional[str] = None,
+        pr_state: Optional[str] = None,
+        issue_refs: Optional[Iterable[str]] = None,
+        verification: Optional[str] = None,
+        worker_dir_abs_path: Optional[str] = None,
+        commit_short: Optional[str] = None,
+        commit_full: Optional[str] = None,
+        outcome_note: Optional[str] = None,
+        workstream_slug: Optional[str] = None,
+    ) -> int:
+        """Insert or update a run row keyed by ``task_id``. Returns runs.id.
+
+        Update semantics: only fields the caller explicitly passes are
+        overwritten. Omitted kwargs preserve the existing row's value;
+        passing ``None`` is treated as "caller didn't supply" and also
+        preserves the existing value. (Use raw SQL if you need to
+        explicitly NULL a field — by design, this API never silently
+        clears columns.)
+        """
+        project_id = self.ensure_project(project_slug)
+        existing = self.conn.execute(
+            "SELECT id FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+
+        worker_dir_id = self._UNSET
+        if worker_dir_abs_path is not None:
+            wd = self.conn.execute(
+                "SELECT id FROM worker_dirs WHERE abs_path = ?",
+                (worker_dir_abs_path,),
+            ).fetchone()
+            worker_dir_id = int(wd["id"]) if wd else None
+
+        workstream_id = self._UNSET
+        if workstream_slug is not None:
+            ws = self.conn.execute(
+                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
+                (project_id, workstream_slug),
+            ).fetchone()
+            workstream_id = int(ws["id"]) if ws else None
+
+        issue_refs_json: object = self._UNSET
+        if issue_refs is not None:
+            issue_refs_json = json.dumps(list(issue_refs))
+
+        if existing is None:
+            cur = self.conn.execute(
+                "INSERT INTO runs ("
+                "task_id, project_id, workstream_id, pattern, title, status, "
+                "branch, pr_url, pr_state, issue_refs, verification, "
+                "worker_dir_id, commit_short, commit_full, outcome_note) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (task_id, project_id,
+                 None if workstream_id is self._UNSET else workstream_id,
+                 pattern or "B",
+                 title or task_id,
+                 status or "in_use",
+                 branch, pr_url, pr_state,
+                 None if issue_refs_json is self._UNSET else issue_refs_json,
+                 verification or "standard",
+                 None if worker_dir_id is self._UNSET else worker_dir_id,
+                 commit_short, commit_full, outcome_note),
+            )
+            return cur.lastrowid
+
+        # Update path: build the SET clause from supplied kwargs only so
+        # omitted fields preserve their existing value.
+        sets: list[str] = []
+        values: list = []
+
+        def _maybe(col: str, val):
+            if val is not None and val is not self._UNSET:
+                sets.append(f"{col} = ?")
+                values.append(val)
+
+        # project_id is always known (we just resolved it from project_slug)
+        # and therefore safe to write.
+        _maybe("project_id", project_id)
+        _maybe("pattern", pattern)
+        _maybe("title", title)
+        _maybe("status", status)
+        _maybe("branch", branch)
+        _maybe("pr_url", pr_url)
+        _maybe("pr_state", pr_state)
+        _maybe("verification", verification)
+        _maybe("commit_short", commit_short)
+        _maybe("commit_full", commit_full)
+        _maybe("outcome_note", outcome_note)
+        if issue_refs_json is not self._UNSET:
+            sets.append("issue_refs = ?")
+            values.append(issue_refs_json)
+        if worker_dir_id is not self._UNSET:
+            sets.append("worker_dir_id = ?")
+            values.append(worker_dir_id)
+        if workstream_id is not self._UNSET:
+            sets.append("workstream_id = ?")
+            values.append(workstream_id)
+
+        if sets:
+            values.append(task_id)
+            self.conn.execute(
+                f"UPDATE runs SET {', '.join(sets)} WHERE task_id = ?",
+                values,
+            )
+        return int(existing["id"])
+
+    def set_run_pr(
+        self,
+        task_id: str,
+        *,
+        pr_url: str,
+        branch: Optional[str] = None,
+    ) -> None:
+        """Back-fill ``runs.pr_url`` (and optionally ``runs.branch``) for a run.
+
+        Called from the canonical PR-open path (Secretary's
+        ``tools/set_run_pr_open.py``) right after ``gh pr create`` returns
+        a PR number, so that ``run_complete_on_merge --pr <n>`` can later
+        auto-resolve task_id from ``runs.pr_url`` without a manual
+        ``--task-id`` (Issue #323).
+
+        Idempotent: re-issuing the same values is a no-op write. Only the
+        explicitly supplied columns are touched; ``branch`` is preserved
+        when omitted.
+        """
+        if not task_id:
+            raise ValueError("set_run_pr: task_id is required")
+        if not pr_url:
+            raise ValueError("set_run_pr: pr_url is required")
+        sets = ["pr_url = ?"]
+        values: list = [pr_url]
+        if branch is not None:
+            sets.append("branch = ?")
+            values.append(branch)
+        values.append(task_id)
+        self.conn.execute(
+            f"UPDATE runs SET {', '.join(sets)} WHERE task_id = ?",
+            values,
+        )
+
+    def update_run_status(
+        self,
+        task_id: str,
+        status: str,
+        *,
+        completed_at: Optional[str] = None,
+        outcome_note: Optional[str] = None,
+    ) -> None:
+        cur = self.conn.execute(
+            "UPDATE runs SET status = ?, "
+            "  completed_at = COALESCE(?, completed_at), "
+            "  outcome_note = COALESCE(?, outcome_note) "
+            "WHERE task_id = ?",
+            (status, completed_at, outcome_note, task_id),
+        )
+        # Issue #284: when a run actually transitions to 'completed',
+        # schedule its worker-state file for archival. The actual move
+        # runs from commit()'s post-commit phase so a rollback leaves
+        # the file in place. Gated on ``cur.rowcount > 0`` — a no-op
+        # UPDATE (typo'd task_id, run never registered) must not move
+        # a worker file in the absence of a matching DB row.
+        # Idempotent: a second completed transition queues a second
+        # move attempt that no-ops when the source file is already gone.
+        if status == "completed" and cur.rowcount > 0:
+            self._pending_worker_archives.append(task_id)
+
+    # ------------------------------------------------------------------
+    # events (append-only journal)
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        *,
+        kind: str,
+        actor: Optional[str] = None,
+        payload: Optional[dict] = None,
+        occurred_at: Optional[str] = None,
+        run_task_id: Optional[str] = None,
+        project_slug: Optional[str] = None,
+        workstream_slug: Optional[str] = None,
+    ) -> int:
+        """Insert one event row. Returns events.id.
+
+        ``payload`` is JSON-encoded; if you need to round-trip the original
+        kind/ts/actor of a legacy line, include them inside payload as well.
+        """
+        run_id: Optional[int] = None
+        project_id: Optional[int] = None
+        workstream_id: Optional[int] = None
+        if run_task_id:
+            row = self.conn.execute(
+                "SELECT id, project_id, workstream_id FROM runs WHERE task_id = ?",
+                (run_task_id,),
+            ).fetchone()
+            if row is not None:
+                run_id = int(row["id"])
+                project_id = int(row["project_id"])
+                if row["workstream_id"] is not None:
+                    workstream_id = int(row["workstream_id"])
+        if project_slug and project_id is None:
+            row = self.conn.execute(
+                "SELECT id FROM projects WHERE slug = ?", (project_slug,)
+            ).fetchone()
+            if row is not None:
+                project_id = int(row["id"])
+        if workstream_slug and workstream_id is None and project_id is not None:
+            row = self.conn.execute(
+                "SELECT id FROM workstreams WHERE project_id = ? AND slug = ?",
+                (project_id, workstream_slug),
+            ).fetchone()
+            if row is not None:
+                workstream_id = int(row["id"])
+
+        payload_json = json.dumps(
+            payload or {}, ensure_ascii=False, sort_keys=True
+        )
+        if occurred_at:
+            cur = self.conn.execute(
+                "INSERT INTO events ("
+                "occurred_at, actor, kind, run_id, workstream_id, project_id, "
+                "payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (occurred_at, actor, kind, run_id, workstream_id, project_id,
+                 payload_json),
+            )
+        else:
+            cur = self.conn.execute(
+                "INSERT INTO events ("
+                "actor, kind, run_id, workstream_id, project_id, payload_json) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (actor, kind, run_id, workstream_id, project_id, payload_json),
+            )
+        return cur.lastrowid
+
+
+def _detect_claude_org_root(conn: sqlite3.Connection) -> Optional[Path]:
+    """Best-effort: derive the claude-org repo root from a sqlite Connection.
+
+    The convention is ``<root>/.state/state.db``; we walk up two levels
+    from the connection's main database file. Returns None for
+    ``:memory:`` connections, for connections opened against a path that
+    is not under a ``.state/`` directory (most test fixtures), or when
+    the PRAGMA query fails for any reason. A None return makes
+    ``transaction()`` skip the post-commit hook silently — callers that
+    care can pass ``claude_org_root`` explicitly.
+    """
+    try:
+        row = conn.execute("PRAGMA database_list").fetchone()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    # ``sqlite3.Row`` exposes ``keys()``; tuple rows do not. ``StateWriter``
+    # forces row_factory = sqlite3.Row defensively, so this guard mostly
+    # protects callers that invoke ``_detect_claude_org_root`` against a
+    # bare connection without going through ``StateWriter``.
+    try:
+        file_path = row["file"]
+    except (IndexError, TypeError):
+        return None
+    if not file_path:
+        return None
+    p = Path(file_path).resolve()
+    if p.parent.name == ".state":
+        return p.parent.parent
+    return None
+
+
+__all__ = ["StateWriter"]

--- a/tools/test_set_run_pr_open.py
+++ b/tools/test_set_run_pr_open.py
@@ -1,0 +1,431 @@
+"""Unit + integration tests for tools/set_run_pr_open.py (Issue #323).
+
+The integration test simulates the full PR-merge auto-completion chain:
+
+    gen_delegate_payload.apply_delegate_plan
+        → set_run_pr_open                   (mock `gh pr view`, PR open)
+        → run_complete_on_merge.complete_on_merge
+                                            (mock `gh pr view`, PR merged)
+
+The chain ends with a single ``runs`` row that has ``pr_state='merged'``,
+populated ``commit_short`` / ``commit_full`` / ``pr_url`` / ``completed_at``,
+and one ``pr_merged`` event — i.e. the no-extra-flags MergeWatch path
+that PR #321 surfaced as broken.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+# Also expose tools/ on sys.path so ``import set_run_pr_open`` /
+# ``import run_complete_on_merge`` work both when this file is run
+# directly (``python tools/test_set_run_pr_open.py``) and when invoked
+# through unittest discovery (``python -m unittest tools.test_set_...``).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import set_run_pr_open  # noqa: E402  (tools/set_run_pr_open.py)
+import run_complete_on_merge  # noqa: E402  (tools/run_complete_on_merge.py)
+from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+REPO = "octo/repo"
+PR = 323
+PR_URL = f"https://github.com/{REPO}/pull/{PR}"
+TASK_ID = "issue-323-pr-watch-task-id"
+BRANCH = f"feat/{TASK_ID}"
+MERGED_AT = "2026-05-06T05:00:00Z"
+MERGE_OID = "abc1234567890abcdef0123456789abcdef01234"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for set_run_pr_open / StateWriter.set_run_pr
+# ---------------------------------------------------------------------------
+
+
+class TestStateWriterSetRunPr(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _seed(self, *, branch=BRANCH, pr_url=None) -> None:
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id=TASK_ID,
+                    project_slug="claude-org",
+                    pattern="B",
+                    title=TASK_ID,
+                    status="review",
+                    branch=branch,
+                    pr_url=pr_url,
+                )
+        finally:
+            conn.close()
+
+    def _row(self) -> dict:
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT task_id, branch, pr_url FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+            return dict(row) if row is not None else {}
+        finally:
+            conn.close()
+
+    def test_set_run_pr_writes_pr_url_and_branch(self):
+        self._seed(branch=None, pr_url=None)
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+        finally:
+            conn.close()
+        self.assertEqual(self._row()["pr_url"], PR_URL)
+        self.assertEqual(self._row()["branch"], BRANCH)
+
+    def test_set_run_pr_idempotent(self):
+        self._seed()
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+        finally:
+            conn.close()
+        self.assertEqual(self._row()["pr_url"], PR_URL)
+
+    def test_set_run_pr_preserves_branch_when_omitted(self):
+        self._seed()  # branch=BRANCH already
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL)
+        finally:
+            conn.close()
+        row = self._row()
+        self.assertEqual(row["pr_url"], PR_URL)
+        self.assertEqual(row["branch"], BRANCH)
+
+    def test_set_run_pr_rejects_empty_inputs(self):
+        self._seed()
+        conn = connect(self.db)
+        try:
+            w = StateWriter(conn)
+            with self.assertRaises(ValueError):
+                w.set_run_pr("", pr_url=PR_URL)
+            with self.assertRaises(ValueError):
+                w.set_run_pr(TASK_ID, pr_url="")
+        finally:
+            conn.close()
+
+
+class TestSetRunPrOpenHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=TASK_ID,
+                project_slug="claude-org",
+                pattern="B",
+                title=TASK_ID,
+                status="review",
+                branch=BRANCH,
+            )
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_returns_ok_and_back_fills(self):
+        view = {"url": PR_URL, "headRefName": BRANCH}
+        result = set_run_pr_open.set_run_pr_open(
+            task_id=TASK_ID, pr=PR, repo=REPO,
+            db_path=self.db, pr_view=view,
+        )
+        self.assertEqual(result, set_run_pr_open.RESULT_OK)
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT pr_url, branch FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["pr_url"], PR_URL)
+        self.assertEqual(row["branch"], BRANCH)
+
+    def test_returns_no_run_when_task_id_missing(self):
+        view = {"url": PR_URL, "headRefName": BRANCH}
+        result = set_run_pr_open.set_run_pr_open(
+            task_id="ghost-task", pr=PR, repo=REPO,
+            db_path=self.db, pr_view=view,
+        )
+        self.assertEqual(result, set_run_pr_open.RESULT_NO_RUN)
+
+    def test_raises_when_view_has_no_url(self):
+        with self.assertRaises(RuntimeError):
+            set_run_pr_open.set_run_pr_open(
+                task_id=TASK_ID, pr=PR, repo=REPO,
+                db_path=self.db, pr_view={"url": "", "headRefName": BRANCH},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration: gen_delegate_payload.apply → set_run_pr_open → run_complete_on_merge
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    """Same shape as tests/test_gen_delegate_payload.py::_Sandbox.
+
+    Duplicated locally so this file stays self-contained — pulling it
+    in via cross-test import would couple two test modules.
+    """
+
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Permission Mode\ndefault_permission_mode: auto\n"
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+
+def _pr_view_open() -> dict:
+    return {"url": PR_URL, "headRefName": BRANCH}
+
+
+def _pr_view_merged() -> dict:
+    return {
+        "number": PR,
+        "url": PR_URL,
+        "state": "MERGED",
+        "mergedAt": MERGED_AT,
+        "mergeCommit": {"oid": MERGE_OID},
+        "headRefName": BRANCH,
+    }
+
+
+class TestPrMergeAutoCompletionChain(unittest.TestCase):
+    """Acceptance test for Issue #323: ``pr-watch.ps1 <PR> -MergeWatch`` with
+    no manual --task-id drives the run to merged-state success.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _row(self) -> dict:
+        conn = sqlite3.connect(str(self.sb.db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT task_id, status, pr_state, pr_url, branch, "
+                "commit_short, commit_full, completed_at "
+                "FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+            return dict(row) if row is not None else {}
+        finally:
+            conn.close()
+
+    def _events(self, kind: str) -> list[dict]:
+        conn = sqlite3.connect(str(self.sb.db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT events.id AS id, events.kind AS kind, "
+                "events.payload_json AS payload_json "
+                "FROM events JOIN runs ON runs.id = events.run_id "
+                "WHERE events.kind = ? AND runs.task_id = ?",
+                (kind, TASK_ID),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def test_full_chain_ends_in_merged_state(self):
+        # Step 1: Secretary's apply reserves a queued row
+        # (gen_delegate_payload.apply_delegate_plan).
+        plan = gdp.build_delegate_plan(
+            task_id=TASK_ID,
+            project_slug="clock-app",
+            description="back-fill runs.pr_url at PR-open",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        row_after_apply = self._row()
+        self.assertEqual(row_after_apply["status"], "queued")
+        # branch is populated from planned_branch but pr_url is not yet
+        self.assertIsNone(row_after_apply["pr_url"])
+
+        # Step 2: Secretary creates the PR and immediately runs
+        # set_run_pr_open. Mocked `gh pr view` returns the open PR.
+        result_open = set_run_pr_open.set_run_pr_open(
+            task_id=TASK_ID, pr=PR, repo=REPO,
+            db_path=self.sb.db_path, pr_view=_pr_view_open(),
+        )
+        self.assertEqual(result_open, set_run_pr_open.RESULT_OK)
+        row_after_open = self._row()
+        self.assertEqual(row_after_open["pr_url"], PR_URL)
+        self.assertEqual(row_after_open["branch"], BRANCH)
+
+        # Step 3: pr-watch's MergeWatch loop calls
+        # run_complete_on_merge.complete_on_merge with NO --task-id.
+        # The auto-resolver hits runs.pr_url first, so the call must
+        # succeed without a manual override.
+        result_merge = run_complete_on_merge.complete_on_merge(
+            pr=PR, repo=REPO,
+            db_path=self.sb.db_path,
+            pr_view=_pr_view_merged(),
+        )
+        self.assertEqual(result_merge, run_complete_on_merge.RESULT_MERGED)
+
+        # Final assertions: pr_state='merged', commit_short, pr_url,
+        # completed_at all populated; exactly one pr_merged event.
+        final = self._row()
+        self.assertEqual(final["pr_state"], "merged")
+        self.assertEqual(final["pr_url"], PR_URL)
+        self.assertEqual(final["commit_full"], MERGE_OID)
+        self.assertEqual(final["commit_short"], MERGE_OID[:7])
+        self.assertEqual(final["completed_at"], MERGED_AT)
+        # runs.status is intentionally NOT flipped here — that's the
+        # secretary's manual step (delegation-lifecycle-contract §T5).
+        self.assertEqual(final["status"], "queued")
+
+        events = self._events("pr_merged")
+        self.assertEqual(len(events), 1)
+        payload = json.loads(events[0]["payload_json"])
+        self.assertEqual(payload["task"], TASK_ID)
+        self.assertEqual(payload["pr"], PR)
+        self.assertEqual(payload["merge_commit"], MERGE_OID)
+
+        # Step 4: idempotency — a re-run of run_complete_on_merge must
+        # not duplicate the event row.
+        result_again = run_complete_on_merge.complete_on_merge(
+            pr=PR, repo=REPO,
+            db_path=self.sb.db_path,
+            pr_view=_pr_view_merged(),
+        )
+        self.assertEqual(result_again, run_complete_on_merge.RESULT_ALREADY)
+        self.assertEqual(len(self._events("pr_merged")), 1)
+
+    def test_pr_url_is_load_bearing_when_branch_cannot_resolve(self):
+        """Codex round-1 Major: the basic chain test passes even without
+        set_run_pr_open because run_complete_on_merge falls back on
+        runs.branch. To prove the back-fill is actually load-bearing,
+        construct a state where the branch fallback cannot resolve
+        (apply reserved branch=X, but the merged PR's headRefName is Y
+        — e.g. dispatcher renamed the branch before the push). With
+        set_run_pr_open the merge is auto-completed via runs.pr_url;
+        without it, complete_on_merge returns RESULT_NO_RUN.
+        """
+        plan = gdp.build_delegate_plan(
+            task_id=TASK_ID,
+            project_slug="clock-app",
+            description="branch divergence scenario",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+        # Sanity: without back-fill AND with a divergent headRefName,
+        # the helper must report no_run. This proves the gap exists
+        # (and therefore that the back-fill is doing real work below).
+        diverged_view = {
+            "number": PR,
+            "url": PR_URL,
+            "state": "MERGED",
+            "mergedAt": MERGED_AT,
+            "mergeCommit": {"oid": MERGE_OID},
+            "headRefName": "feat/renamed-after-delegate",
+        }
+        self.assertEqual(
+            run_complete_on_merge.complete_on_merge(
+                pr=PR, repo=REPO,
+                db_path=self.sb.db_path,
+                pr_view=diverged_view,
+            ),
+            run_complete_on_merge.RESULT_NO_RUN,
+        )
+
+        # Now run set_run_pr_open with the (also divergent) PR-open
+        # view and confirm the merged-PR resolution succeeds via pr_url.
+        open_view_diverged = {
+            "url": PR_URL,
+            "headRefName": "feat/renamed-after-delegate",
+        }
+        self.assertEqual(
+            set_run_pr_open.set_run_pr_open(
+                task_id=TASK_ID, pr=PR, repo=REPO,
+                db_path=self.sb.db_path, pr_view=open_view_diverged,
+            ),
+            set_run_pr_open.RESULT_OK,
+        )
+        self.assertEqual(
+            run_complete_on_merge.complete_on_merge(
+                pr=PR, repo=REPO,
+                db_path=self.sb.db_path,
+                pr_view=diverged_view,
+            ),
+            run_complete_on_merge.RESULT_MERGED,
+        )
+        final = self._row()
+        self.assertEqual(final["pr_state"], "merged")
+        self.assertEqual(final["pr_url"], PR_URL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#325](https://github.com/suisya-systems/claude-org-ja/pull/325)

Merge SHA: `18d0c0a537e56c607799eea7a9e9386ebd6baccd`

Source: ja PR [#325](https://github.com/suisya-systems/claude-org-ja/pull/325)
Merge SHA: `18d0c0a537e56c607799eea7a9e9386ebd6baccd`

| class | count |
|---|---|
| runtime | 3 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tools/set_run_pr_open.py`
- `tools/state_db/writer.py`
- `tools/test_set_run_pr_open.py`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-pull-request/SKILL.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
