### PR TITLE
auto-mirror: ja#332 feat(claude): cover --repo cross-repo path in set_run_pr_open tests (Closes #331)

### DIFF
--- a/tools/set_run_pr_open.py
+++ b/tools/set_run_pr_open.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""PR-open back-fill helper (Issue #323).
+
+Closes the auto-completion gap that surfaced on PR #321: when Secretary
+runs ``gh pr create`` immediately after a worker reports done, the
+freshly-created PR's ``url`` is not yet recorded on ``runs``. The
+``-MergeWatch`` path of ``pr-watch.ps1`` later calls
+``run_complete_on_merge --pr <N>``, which resolves ``task_id`` by
+matching ``runs.pr_url`` (or ``runs.branch``); without a back-fill the
+helper returns ``no_run`` and Secretary has to recover by hand.
+
+This helper is the canonical action Secretary runs right after
+``gh pr create`` succeeds. It:
+
+1. shells ``gh pr view <PR> --json url,headRefName`` to get the PR URL
+   and head branch (authoritative — what GitHub actually recorded);
+2. opens a ``StateWriter.transaction()`` and calls
+   :meth:`StateWriter.set_run_pr` to update ``runs.pr_url`` (and
+   ``runs.branch`` re-asserted from gh's ``headRefName``).
+
+Idempotent: a second invocation rewrites the same values and adds no
+journal entry — back-fill is metadata, not a new lifecycle event.
+
+Usage::
+
+    python tools/set_run_pr_open.py --task-id <id> --pr <N> \\
+        [--repo OWNER/REPO] [--db-path <path>]
+
+Exit codes: 0 on success, 2 on gh / DB failure, 3 when the run row for
+``task_id`` is missing (so Secretary sees the misalignment instead of a
+silent no-op), 127 when the ``gh`` CLI is not installed.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: GitHub CLI (gh) not found "
+            "in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: failed to auto-detect repo "
+            f"via `gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        return json.loads(result.stdout)["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/set_run_pr_open.py: error: unexpected `gh repo view` "
+            f"output: {exc}\n"
+        )
+        sys.exit(2)
+
+
+def fetch_pr_view(pr: int, repo: str) -> dict:
+    """Return the parsed ``gh pr view`` payload (url + headRefName)."""
+    proc = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr),
+            "--repo", repo,
+            "--json", "url,headRefName",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view {pr} (repo={repo}) failed: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh pr view {pr} returned unparseable JSON: {exc}"
+        ) from None
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"gh pr view {pr} returned non-object JSON: {type(data).__name__}"
+        )
+    return data
+
+
+# Stable result strings — callers (tests, future automation) can branch
+# without parsing log lines.
+RESULT_OK = "ok"
+RESULT_NO_RUN = "no_run"
+
+
+def set_run_pr_open(
+    *,
+    task_id: str,
+    pr: int,
+    repo: str,
+    db_path: Optional[Path] = None,
+    pr_view: Optional[dict] = None,
+) -> str:
+    """Back-fill ``runs.pr_url`` / ``runs.branch`` for ``task_id``.
+
+    Returns :data:`RESULT_OK` on success or :data:`RESULT_NO_RUN` if the
+    run row is missing (caller decides whether to abort).
+
+    ``pr_view`` may be supplied by callers that already fetched the
+    payload; otherwise it is fetched via :func:`fetch_pr_view`.
+    """
+    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    if pr_view is None:
+        pr_view = fetch_pr_view(pr, repo)
+
+    pr_url = (pr_view.get("url") or "").strip()
+    head_ref = pr_view.get("headRefName") or None
+    if not pr_url:
+        raise RuntimeError(
+            f"gh pr view {pr} returned no url field; refusing to write "
+            "an empty pr_url."
+        )
+
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+
+        row = conn.execute(
+            "SELECT 1 FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            sys.stderr.write(
+                "tools/set_run_pr_open.py: warning: no run row for "
+                f"task_id={task_id!r}; skipping back-fill.\n"
+            )
+            return RESULT_NO_RUN
+
+        with StateWriter(conn).transaction() as w:
+            w.set_run_pr(task_id, pr_url=pr_url, branch=head_ref)
+        return RESULT_OK
+    finally:
+        conn.close()
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/set_run_pr_open.py",
+        description=(
+            "Back-fill runs.pr_url (and runs.branch) right after Secretary "
+            "creates the PR, so run_complete_on_merge can auto-resolve "
+            "task_id on merge."
+        ),
+    )
+    parser.add_argument("--task-id", required=True,
+                        help="task_id of the run to back-fill")
+    parser.add_argument("--pr", type=int, required=True,
+                        help="pull request number")
+    parser.add_argument("--repo", default=None,
+                        help=("OWNER/REPO for cross-repo PRs; "
+                              "auto-detected via gh repo view when omitted"))
+    parser.add_argument("--db-path", default=None,
+                        help=f"path to state.db (default: {DEFAULT_DB_PATH})")
+    args = parser.parse_args(argv)
+
+    if args.pr <= 0:
+        parser.error("--pr must be a positive integer")
+    if not args.task_id.strip():
+        parser.error("--task-id must be non-empty")
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    try:
+        result = set_run_pr_open(
+            task_id=args.task_id,
+            pr=args.pr,
+            repo=repo,
+            db_path=Path(args.db_path) if args.db_path else None,
+        )
+    except RuntimeError as exc:
+        sys.stderr.write(f"tools/set_run_pr_open.py: error: {exc}\n")
+        return 2
+
+    sys.stdout.write(
+        f"set_run_pr_open: task_id={args.task_id} PR #{args.pr} {result}\n"
+    )
+    if result == RESULT_NO_RUN:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_set_run_pr_open.py
+++ b/tools/test_set_run_pr_open.py
@@ -1,0 +1,566 @@
+"""Unit + integration tests for tools/set_run_pr_open.py (Issue #323).
+
+The integration test simulates the full PR-merge auto-completion chain:
+
+    gen_delegate_payload.apply_delegate_plan
+        → set_run_pr_open                   (mock `gh pr view`, PR open)
+        → run_complete_on_merge.complete_on_merge
+                                            (mock `gh pr view`, PR merged)
+
+The chain ends with a single ``runs`` row that has ``pr_state='merged'``,
+populated ``commit_short`` / ``commit_full`` / ``pr_url`` / ``completed_at``,
+and one ``pr_merged`` event — i.e. the no-extra-flags MergeWatch path
+that PR #321 surfaced as broken.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+# Also expose tools/ on sys.path so ``import set_run_pr_open`` /
+# ``import run_complete_on_merge`` work both when this file is run
+# directly (``python tools/test_set_run_pr_open.py``) and when invoked
+# through unittest discovery (``python -m unittest tools.test_set_...``).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import set_run_pr_open  # noqa: E402  (tools/set_run_pr_open.py)
+import run_complete_on_merge  # noqa: E402  (tools/run_complete_on_merge.py)
+from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+REPO = "octo/repo"
+PR = 323
+PR_URL = f"https://github.com/{REPO}/pull/{PR}"
+TASK_ID = "issue-323-pr-watch-task-id"
+BRANCH = f"feat/{TASK_ID}"
+MERGED_AT = "2026-05-06T05:00:00Z"
+MERGE_OID = "abc1234567890abcdef0123456789abcdef01234"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for set_run_pr_open / StateWriter.set_run_pr
+# ---------------------------------------------------------------------------
+
+
+class TestStateWriterSetRunPr(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _seed(self, *, branch=BRANCH, pr_url=None) -> None:
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id=TASK_ID,
+                    project_slug="claude-org",
+                    pattern="B",
+                    title=TASK_ID,
+                    status="review",
+                    branch=branch,
+                    pr_url=pr_url,
+                )
+        finally:
+            conn.close()
+
+    def _row(self) -> dict:
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT task_id, branch, pr_url FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+            return dict(row) if row is not None else {}
+        finally:
+            conn.close()
+
+    def test_set_run_pr_writes_pr_url_and_branch(self):
+        self._seed(branch=None, pr_url=None)
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+        finally:
+            conn.close()
+        self.assertEqual(self._row()["pr_url"], PR_URL)
+        self.assertEqual(self._row()["branch"], BRANCH)
+
+    def test_set_run_pr_idempotent(self):
+        self._seed()
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+                w.set_run_pr(TASK_ID, pr_url=PR_URL, branch=BRANCH)
+        finally:
+            conn.close()
+        self.assertEqual(self._row()["pr_url"], PR_URL)
+
+    def test_set_run_pr_preserves_branch_when_omitted(self):
+        self._seed()  # branch=BRANCH already
+        conn = connect(self.db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.set_run_pr(TASK_ID, pr_url=PR_URL)
+        finally:
+            conn.close()
+        row = self._row()
+        self.assertEqual(row["pr_url"], PR_URL)
+        self.assertEqual(row["branch"], BRANCH)
+
+    def test_set_run_pr_rejects_empty_inputs(self):
+        self._seed()
+        conn = connect(self.db)
+        try:
+            w = StateWriter(conn)
+            with self.assertRaises(ValueError):
+                w.set_run_pr("", pr_url=PR_URL)
+            with self.assertRaises(ValueError):
+                w.set_run_pr(TASK_ID, pr_url="")
+        finally:
+            conn.close()
+
+
+class TestSetRunPrOpenHelper(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=TASK_ID,
+                project_slug="claude-org",
+                pattern="B",
+                title=TASK_ID,
+                status="review",
+                branch=BRANCH,
+            )
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_returns_ok_and_back_fills(self):
+        view = {"url": PR_URL, "headRefName": BRANCH}
+        result = set_run_pr_open.set_run_pr_open(
+            task_id=TASK_ID, pr=PR, repo=REPO,
+            db_path=self.db, pr_view=view,
+        )
+        self.assertEqual(result, set_run_pr_open.RESULT_OK)
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT pr_url, branch FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["pr_url"], PR_URL)
+        self.assertEqual(row["branch"], BRANCH)
+
+    def test_returns_no_run_when_task_id_missing(self):
+        view = {"url": PR_URL, "headRefName": BRANCH}
+        result = set_run_pr_open.set_run_pr_open(
+            task_id="ghost-task", pr=PR, repo=REPO,
+            db_path=self.db, pr_view=view,
+        )
+        self.assertEqual(result, set_run_pr_open.RESULT_NO_RUN)
+
+    def test_raises_when_view_has_no_url(self):
+        with self.assertRaises(RuntimeError):
+            set_run_pr_open.set_run_pr_open(
+                task_id=TASK_ID, pr=PR, repo=REPO,
+                db_path=self.db, pr_view={"url": "", "headRefName": BRANCH},
+            )
+
+
+class TestSetRunPrOpenCrossRepoCli(unittest.TestCase):
+    """Issue #331: --repo flag must be forwarded to ``gh pr view`` so the
+    helper can back-fill cross-repo PRs (e.g. delegating into another
+    repo) instead of querying the cwd-resolved repo and failing with
+    GraphQL "Could not resolve to a PullRequest"."""
+
+    FOREIGN_REPO = "suisya-systems/renga"
+    FOREIGN_PR = 216
+    FOREIGN_BRANCH = "feat/renga-214-files-pane-handle"
+    FOREIGN_TASK_ID = "renga-214-files-pane-handle"
+    FOREIGN_URL = (
+        f"https://github.com/{FOREIGN_REPO}/pull/{FOREIGN_PR}"
+    )
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.db = Path(self._td.name) / "state.db"
+        conn = connect(self.db)
+        apply_schema(conn)
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=self.FOREIGN_TASK_ID,
+                project_slug="renga",
+                pattern="B",
+                title=self.FOREIGN_TASK_ID,
+                status="review",
+                branch=self.FOREIGN_BRANCH,
+            )
+        conn.close()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _fake_run_factory(self, captured: list):
+        """Return a subprocess.run stand-in that records argv lists and
+        emits a ``gh pr view`` payload for the foreign PR."""
+
+        class _Result:
+            def __init__(self, stdout: str):
+                self.stdout = stdout
+                self.stderr = ""
+                self.returncode = 0
+
+        def _fake_run(argv, *args, **kwargs):
+            captured.append(list(argv))
+            if argv[:3] == ["gh", "pr", "view"]:
+                payload = json.dumps({
+                    "url": self.FOREIGN_URL,
+                    "headRefName": self.FOREIGN_BRANCH,
+                })
+                return _Result(payload)
+            if argv[:3] == ["gh", "repo", "view"]:
+                payload = json.dumps({"nameWithOwner": "octo/cwd-repo"})
+                return _Result(payload)
+            raise AssertionError(f"unexpected argv: {argv}")
+
+        return _fake_run
+
+    def test_repo_flag_is_forwarded_to_gh_pr_view(self):
+        captured: list = []
+        argv = [
+            "--task-id", self.FOREIGN_TASK_ID,
+            "--pr", str(self.FOREIGN_PR),
+            "--repo", self.FOREIGN_REPO,
+            "--db-path", str(self.db),
+        ]
+        with mock.patch.object(
+            set_run_pr_open.subprocess, "run",
+            side_effect=self._fake_run_factory(captured),
+        ), mock.patch.object(
+            set_run_pr_open.shutil, "which", return_value="/usr/bin/gh",
+        ):
+            rc = set_run_pr_open.main(argv)
+        self.assertEqual(rc, 0)
+
+        pr_view_calls = [a for a in captured if a[:3] == ["gh", "pr", "view"]]
+        self.assertEqual(len(pr_view_calls), 1)
+        self.assertEqual(
+            pr_view_calls[0],
+            [
+                "gh", "pr", "view", str(self.FOREIGN_PR),
+                "--repo", self.FOREIGN_REPO,
+                "--json", "url,headRefName",
+            ],
+        )
+        # No cwd-resolution call should have been made when --repo is set.
+        self.assertEqual(
+            [a for a in captured if a[:3] == ["gh", "repo", "view"]], [],
+        )
+
+        conn = sqlite3.connect(str(self.db))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT pr_url, branch FROM runs WHERE task_id = ?",
+                (self.FOREIGN_TASK_ID,),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row["pr_url"], self.FOREIGN_URL)
+        self.assertEqual(row["branch"], self.FOREIGN_BRANCH)
+
+    def test_no_repo_flag_falls_back_to_cwd_resolution(self):
+        captured: list = []
+        argv = [
+            "--task-id", self.FOREIGN_TASK_ID,
+            "--pr", str(self.FOREIGN_PR),
+            "--db-path", str(self.db),
+        ]
+        with mock.patch.object(
+            set_run_pr_open.subprocess, "run",
+            side_effect=self._fake_run_factory(captured),
+        ), mock.patch.object(
+            set_run_pr_open.shutil, "which", return_value="/usr/bin/gh",
+        ):
+            rc = set_run_pr_open.main(argv)
+        self.assertEqual(rc, 0)
+
+        # cwd auto-resolve must run, then pr view uses the resolved repo.
+        repo_view_calls = [
+            a for a in captured if a[:3] == ["gh", "repo", "view"]
+        ]
+        self.assertEqual(len(repo_view_calls), 1)
+        pr_view_calls = [a for a in captured if a[:3] == ["gh", "pr", "view"]]
+        self.assertEqual(len(pr_view_calls), 1)
+        self.assertEqual(
+            pr_view_calls[0],
+            [
+                "gh", "pr", "view", str(self.FOREIGN_PR),
+                "--repo", "octo/cwd-repo",
+                "--json", "url,headRefName",
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: gen_delegate_payload.apply → set_run_pr_open → run_complete_on_merge
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    """Same shape as tests/test_gen_delegate_payload.py::_Sandbox.
+
+    Duplicated locally so this file stays self-contained — pulling it
+    in via cross-test import would couple two test modules.
+    """
+
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Permission Mode\ndefault_permission_mode: auto\n"
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+
+def _pr_view_open() -> dict:
+    return {"url": PR_URL, "headRefName": BRANCH}
+
+
+def _pr_view_merged() -> dict:
+    return {
+        "number": PR,
+        "url": PR_URL,
+        "state": "MERGED",
+        "mergedAt": MERGED_AT,
+        "mergeCommit": {"oid": MERGE_OID},
+        "headRefName": BRANCH,
+    }
+
+
+class TestPrMergeAutoCompletionChain(unittest.TestCase):
+    """Acceptance test for Issue #323: ``pr-watch.ps1 <PR> -MergeWatch`` with
+    no manual --task-id drives the run to merged-state success.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _row(self) -> dict:
+        conn = sqlite3.connect(str(self.sb.db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                "SELECT task_id, status, pr_state, pr_url, branch, "
+                "commit_short, commit_full, completed_at "
+                "FROM runs WHERE task_id = ?",
+                (TASK_ID,),
+            ).fetchone()
+            return dict(row) if row is not None else {}
+        finally:
+            conn.close()
+
+    def _events(self, kind: str) -> list[dict]:
+        conn = sqlite3.connect(str(self.sb.db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT events.id AS id, events.kind AS kind, "
+                "events.payload_json AS payload_json "
+                "FROM events JOIN runs ON runs.id = events.run_id "
+                "WHERE events.kind = ? AND runs.task_id = ?",
+                (kind, TASK_ID),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def test_full_chain_ends_in_merged_state(self):
+        # Step 1: Secretary's apply reserves a queued row
+        # (gen_delegate_payload.apply_delegate_plan).
+        plan = gdp.build_delegate_plan(
+            task_id=TASK_ID,
+            project_slug="clock-app",
+            description="back-fill runs.pr_url at PR-open",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        row_after_apply = self._row()
+        self.assertEqual(row_after_apply["status"], "queued")
+        # branch is populated from planned_branch but pr_url is not yet
+        self.assertIsNone(row_after_apply["pr_url"])
+
+        # Step 2: Secretary creates the PR and immediately runs
+        # set_run_pr_open. Mocked `gh pr view` returns the open PR.
+        result_open = set_run_pr_open.set_run_pr_open(
+            task_id=TASK_ID, pr=PR, repo=REPO,
+            db_path=self.sb.db_path, pr_view=_pr_view_open(),
+        )
+        self.assertEqual(result_open, set_run_pr_open.RESULT_OK)
+        row_after_open = self._row()
+        self.assertEqual(row_after_open["pr_url"], PR_URL)
+        self.assertEqual(row_after_open["branch"], BRANCH)
+
+        # Step 3: pr-watch's MergeWatch loop calls
+        # run_complete_on_merge.complete_on_merge with NO --task-id.
+        # The auto-resolver hits runs.pr_url first, so the call must
+        # succeed without a manual override.
+        result_merge = run_complete_on_merge.complete_on_merge(
+            pr=PR, repo=REPO,
+            db_path=self.sb.db_path,
+            pr_view=_pr_view_merged(),
+        )
+        self.assertEqual(result_merge, run_complete_on_merge.RESULT_MERGED)
+
+        # Final assertions: pr_state='merged', commit_short, pr_url,
+        # completed_at all populated; exactly one pr_merged event.
+        final = self._row()
+        self.assertEqual(final["pr_state"], "merged")
+        self.assertEqual(final["pr_url"], PR_URL)
+        self.assertEqual(final["commit_full"], MERGE_OID)
+        self.assertEqual(final["commit_short"], MERGE_OID[:7])
+        self.assertEqual(final["completed_at"], MERGED_AT)
+        # runs.status is intentionally NOT flipped here — that's the
+        # secretary's manual step (delegation-lifecycle-contract §T5).
+        self.assertEqual(final["status"], "queued")
+
+        events = self._events("pr_merged")
+        self.assertEqual(len(events), 1)
+        payload = json.loads(events[0]["payload_json"])
+        self.assertEqual(payload["task"], TASK_ID)
+        self.assertEqual(payload["pr"], PR)
+        self.assertEqual(payload["merge_commit"], MERGE_OID)
+
+        # Step 4: idempotency — a re-run of run_complete_on_merge must
+        # not duplicate the event row.
+        result_again = run_complete_on_merge.complete_on_merge(
+            pr=PR, repo=REPO,
+            db_path=self.sb.db_path,
+            pr_view=_pr_view_merged(),
+        )
+        self.assertEqual(result_again, run_complete_on_merge.RESULT_ALREADY)
+        self.assertEqual(len(self._events("pr_merged")), 1)
+
+    def test_pr_url_is_load_bearing_when_branch_cannot_resolve(self):
+        """Codex round-1 Major: the basic chain test passes even without
+        set_run_pr_open because run_complete_on_merge falls back on
+        runs.branch. To prove the back-fill is actually load-bearing,
+        construct a state where the branch fallback cannot resolve
+        (apply reserved branch=X, but the merged PR's headRefName is Y
+        — e.g. dispatcher renamed the branch before the push). With
+        set_run_pr_open the merge is auto-completed via runs.pr_url;
+        without it, complete_on_merge returns RESULT_NO_RUN.
+        """
+        plan = gdp.build_delegate_plan(
+            task_id=TASK_ID,
+            project_slug="clock-app",
+            description="branch divergence scenario",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+        # Sanity: without back-fill AND with a divergent headRefName,
+        # the helper must report no_run. This proves the gap exists
+        # (and therefore that the back-fill is doing real work below).
+        diverged_view = {
+            "number": PR,
+            "url": PR_URL,
+            "state": "MERGED",
+            "mergedAt": MERGED_AT,
+            "mergeCommit": {"oid": MERGE_OID},
+            "headRefName": "feat/renamed-after-delegate",
+        }
+        self.assertEqual(
+            run_complete_on_merge.complete_on_merge(
+                pr=PR, repo=REPO,
+                db_path=self.sb.db_path,
+                pr_view=diverged_view,
+            ),
+            run_complete_on_merge.RESULT_NO_RUN,
+        )
+
+        # Now run set_run_pr_open with the (also divergent) PR-open
+        # view and confirm the merged-PR resolution succeeds via pr_url.
+        open_view_diverged = {
+            "url": PR_URL,
+            "headRefName": "feat/renamed-after-delegate",
+        }
+        self.assertEqual(
+            set_run_pr_open.set_run_pr_open(
+                task_id=TASK_ID, pr=PR, repo=REPO,
+                db_path=self.sb.db_path, pr_view=open_view_diverged,
+            ),
+            set_run_pr_open.RESULT_OK,
+        )
+        self.assertEqual(
+            run_complete_on_merge.complete_on_merge(
+                pr=PR, repo=REPO,
+                db_path=self.sb.db_path,
+                pr_view=diverged_view,
+            ),
+            run_complete_on_merge.RESULT_MERGED,
+        )
+        final = self._row()
+        self.assertEqual(final["pr_state"], "merged")
+        self.assertEqual(final["pr_url"], PR_URL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#332](https://github.com/suisya-systems/claude-org-ja/pull/332)

Merge SHA: `1a3b3a311714bf4e5ec9f071ba4c274a631d1ffb`

Source: ja PR [#332](https://github.com/suisya-systems/claude-org-ja/pull/332)
Merge SHA: `1a3b3a311714bf4e5ec9f071ba4c274a631d1ffb`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tools/set_run_pr_open.py`
- `tools/test_set_run_pr_open.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
