### PR TITLE
auto-mirror: ja#327 fix(claude): pr-watch notifies Secretary via renga-peers (Closes #326)

### DIFF
--- a/tools/peer_notify.py
+++ b/tools/peer_notify.py
@@ -1,0 +1,195 @@
+"""Best-effort renga-peers message dispatch from CLI subprocesses.
+
+Issue #326. ``mcp__renga-peers__send_message`` is only reachable from
+inside a Claude Code session — a CLI helper like ``tools/pr_watch.py``
+cannot call MCP tools directly. The renga binary, however, ships an
+``mcp-peer`` subcommand that runs the same MCP server over stdio, so
+spawning it as a subprocess and driving a one-shot JSON-RPC handshake
+is the simplest reliable bridge from a Python CLI back into the
+peer-message channel.
+
+When ``RENGA_SOCKET`` is unset (plain shell, CI, etc.), this helper is a
+silent no-op so the calling tool keeps working in non-renga
+environments. All failures (binary missing, handshake error, timeout,
+peer not found, backend unreachable) are swallowed — peer notification
+is decoration on top of the canonical event row, never a precondition.
+
+Failure handling notes:
+* ``stdout.readline()`` would block indefinitely on a renga binary that
+  starts but never replies. The reader runs in a background thread so
+  the caller-supplied ``timeout`` is actually enforced.
+* Renga currently returns the backend-unreachable case as ok-text
+  ``"(message dropped — renga not reachable: <reason>)"`` rather than
+  a JSON-RPC error (transitional shim per
+  ``docs/contracts/backend-interface-contract.md`` §2.1 / Issue #242).
+  This helper inspects the result text and rejects that shape so a
+  silent backend failure isn't reported as confirmed delivery.
+"""
+from __future__ import annotations
+
+import json
+import os
+import queue
+import shutil
+import subprocess
+import threading
+from typing import Optional
+
+_RENGA_BIN = "renga"
+_HANDSHAKE_TIMEOUT_SEC = 5.0
+_DROPPED_PREFIX = "(message dropped"
+
+
+def notify_peer(
+    to_id: str,
+    message: str,
+    *,
+    timeout: float = _HANDSHAKE_TIMEOUT_SEC,
+    renga_bin: str = _RENGA_BIN,
+) -> bool:
+    """Send a peer message via ``renga mcp-peer``. Best-effort.
+
+    Returns ``True`` only on confirmed (non-error, non-dropped) delivery
+    from the MCP server. Returns ``False`` for every other outcome —
+    RENGA_SOCKET unset, renga binary missing, subprocess crash, JSON-RPC
+    error, read timeout, ``(message dropped — ...)`` backend-unreachable
+    shim. Never raises.
+    """
+    if not os.environ.get("RENGA_SOCKET"):
+        return False
+    if shutil.which(renga_bin) is None:
+        return False
+    try:
+        proc = subprocess.Popen(
+            [renga_bin, "mcp-peer"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            env=os.environ.copy(),
+        )
+    except (OSError, ValueError):
+        return False
+
+    line_q: "queue.Queue[Optional[str]]" = queue.Queue()
+
+    def reader() -> None:
+        try:
+            assert proc.stdout is not None
+            for raw in proc.stdout:
+                line_q.put(raw)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            line_q.put(None)  # EOF sentinel
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+    try:
+        return _drive_send(proc, line_q, to_id, message, timeout)
+    except Exception:  # noqa: BLE001 — best-effort, swallow everything
+        return False
+    finally:
+        _shutdown(proc, timeout)
+
+
+def _read_response(
+    line_q: "queue.Queue[Optional[str]]",
+    target_id: int,
+    timeout: float,
+) -> Optional[dict]:
+    """Drain lines until one matches ``id == target_id``, or timeout.
+
+    Notifications and lines for other ids are skipped. Returns the
+    parsed dict on match, ``None`` on timeout / EOF / parse error.
+    """
+    import time as _time
+
+    deadline = _time.monotonic() + timeout
+    while True:
+        remaining = deadline - _time.monotonic()
+        if remaining <= 0:
+            return None
+        try:
+            raw = line_q.get(timeout=remaining)
+        except queue.Empty:
+            return None
+        if raw is None:
+            return None  # EOF
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("id") == target_id:
+            return msg
+
+
+def _drive_send(
+    proc: subprocess.Popen,
+    line_q: "queue.Queue[Optional[str]]",
+    to_id: str,
+    message: str,
+    timeout: float,
+) -> bool:
+    def write(req: dict) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(req) + "\n")
+        proc.stdin.flush()
+
+    write({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "pr_watch", "version": "0.1"},
+        },
+    })
+    init = _read_response(line_q, target_id=1, timeout=timeout)
+    if init is None or "result" not in init:
+        return False
+
+    write({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    write({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {
+            "name": "send_message",
+            "arguments": {"to_id": to_id, "message": message},
+        },
+    })
+    resp = _read_response(line_q, target_id=2, timeout=timeout)
+    if resp is None:
+        return False
+
+    result = resp.get("result")
+    if not isinstance(result, dict):
+        return False
+    if result.get("isError"):
+        return False
+    # Renga's backend-unreachable shim returns ok-text rather than a
+    # JSON-RPC error (Issue #242). Reject "(message dropped — ..." so
+    # a silent backend failure isn't reported as success.
+    for chunk in result.get("content", []) or []:
+        if isinstance(chunk, dict):
+            text = chunk.get("text") or ""
+            if isinstance(text, str) and text.lstrip().startswith(_DROPPED_PREFIX):
+                return False
+    return True
+
+
+def _shutdown(proc: subprocess.Popen, timeout: float) -> None:
+    for stream in (proc.stdin, proc.stdout, proc.stderr):
+        try:
+            if stream is not None:
+                stream.close()
+        except Exception:  # noqa: BLE001
+            pass
+    try:
+        proc.wait(timeout=timeout)
+    except Exception:  # noqa: BLE001
+        try:
+            proc.kill()
+        except Exception:  # noqa: BLE001
+            pass

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI checks and emit a journal event when finished.
+
+Cross-platform helper for the secretary role: after creating a PR,
+invoke this script to block on ``gh pr checks --watch`` and record a
+``ci_completed`` event in ``.state/state.db`` (events table).
+
+Usage::
+
+    py -3 tools/pr_watch.py --pr <PR> [--repo OWNER/REPO] [--interval SEC]
+
+Behavior:
+
+* Resolves the repo via ``gh repo view --json nameWithOwner`` when
+  ``--repo`` is omitted.
+* Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
+  its stdout/stderr.
+* After the watch loop returns, queries
+  ``gh pr checks <PR> --json bucket,state,name`` for per-check
+  ``bucket`` (gh's documented bucket values are
+  ``{pass, fail, pending, skipping, cancel}``) so the journal status
+  reflects what CI actually decided rather than just the gh process'
+  exit code (gh exits non-zero on a transient watch error too, and
+  exit 8 specifically means "Checks pending", not "failed").
+  Classifies as ``passed`` (all pass/skipping), ``failed``
+  (≥1 fail/cancel), ``incomplete`` (any pending / unknown bucket /
+  empty list), or ``canceled`` (parent SIGINT). Falls back to
+  exit-code-based classification only if the JSON probe itself
+  fails. Appends one row to the ``events`` table in
+  ``<repo_root>/.state/state.db`` (anchored to ``tools/..`` so cwd
+  doesn't matter).
+* Prints the final status as a single line on stdout and exits with
+  the gh process' exit code.
+
+M4 (Issue #267): events flow through the SQLite DB only —
+``.state/journal.jsonl`` is decommissioned. The recorder uses the same
+``StateWriter.append_event`` path as ``tools/journal_append.py``.
+
+The event payload shape is::
+
+    {"event": "ci_completed", "ts": "<ISO8601>",
+     "pr": <int>, "repo": "<owner/repo>",
+     "status": "passed|failed|incomplete|canceled",
+     "duration_sec": <int>}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Bound on the post-CI merge-watch loop. Issue #317: after CI passes we
+# keep polling `gh pr view --json mergedAt` until the PR is merged or
+# this many seconds elapse, whichever comes first. 24h matches the
+# upper end of the org-delegate Step 5 2b-ii idle window so the
+# secretary can intervene manually past that.
+MERGE_WATCH_MAX_SECONDS = 24 * 60 * 60
+
+# Make `tools.state_db.*` importable when running this script directly.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Path used by tests via mock.patch — kept as a module-level Path so the
+# legacy test seam (`mock.patch.object(pr_watch, "JOURNAL_PATH", ...)`)
+# continues to redirect writes at the tempdir. M4 made the file be the
+# state DB rather than journal.jsonl.
+JOURNAL_PATH = REPO_ROOT / ".state" / "state.db"
+
+# Issue #326: after writing a CI-completion / merge / timeout event,
+# also push a peer message to secretary so it doesn't have to poll the
+# DB. The dispatch is wrapped in a tiny module-level seam so tests can
+# mock it without poking subprocess.Popen of the real renga binary.
+_PEER_NOTIFY_TARGET = "secretary"
+
+
+def _notify_peer(message: str, to_id: str = _PEER_NOTIFY_TARGET) -> bool:
+    """Best-effort peer-message dispatch. Never raises.
+
+    Returns True on confirmed delivery, False otherwise (RENGA_SOCKET
+    unset, renga binary missing, transport error, recipient unknown).
+    Wrapped here so tests can patch a single seam.
+    """
+    try:
+        from tools.peer_notify import notify_peer
+    except Exception:  # noqa: BLE001
+        return False
+    try:
+        return notify_peer(to_id, message)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
+                         status: str, duration: int) -> None:
+    """Append a ``ci_completed`` event to the DB events table."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        writer.append_event(
+            kind="ci_completed",
+            actor="pr_watch",
+            payload={
+                "pr": pr,
+                "repo": repo,
+                "status": status,
+                "duration_sec": duration,
+            },
+        )
+        writer.commit()
+    finally:
+        conn.close()
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: GitHub CLI (gh) not found in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: failed to auto-detect repo via "
+            f"`gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        data = json.loads(result.stdout)
+        repo = data["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: unexpected `gh repo view` output: "
+            f"{exc}\n"
+        )
+        sys.exit(2)
+    if not isinstance(repo, str) or "/" not in repo:
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: invalid repo {repo!r}\n"
+        )
+        sys.exit(2)
+    return repo
+
+
+# gh's `bucket` field (see `gh pr checks --help`) categorizes a check's
+# `state` into one of these buckets: "pass", "fail", "pending",
+# "skipping", "cancel". We treat fail+cancel as failure signals,
+# pass+skipping as success, and pending as still-running.
+_FAILED_BUCKETS = frozenset({"fail", "cancel"})
+_PASSED_BUCKETS = frozenset({"pass", "skipping"})
+_PENDING_BUCKETS = frozenset({"pending"})
+
+
+def _classify(exit_code: int) -> str:
+    """Fallback classifier used only when the JSON probe is unavailable.
+
+    Reference: https://cli.github.com/manual/gh_help_exit-codes and
+    https://cli.github.com/manual/gh_pr_checks. With ``--watch`` gh
+    blocks until pending checks resolve and then returns 0 (all
+    checks passed). Exit code 2 is gh's standard cancellation code
+    (e.g. user interrupt). Exit code 8 means "Checks pending" per
+    gh's docs (NOT failure). Other non-zero values most likely
+    indicate an internal gh error rather than a CI verdict, so they
+    map to the conservative ``incomplete`` status — refusing to
+    silently turn a transient error into "passed" while also not
+    libelling green CI as "failed".
+
+    SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
+    normalized to 2 in :func:`main` before reaching this function.
+
+    Note: as of Issue #224 the primary classifier is
+    :func:`_classify_from_checks`, which inspects per-check JSON. This
+    fallback is only used when the JSON probe itself is unavailable.
+    """
+    if exit_code == 0:
+        return "passed"
+    if exit_code == 2:
+        return "canceled"
+    if exit_code == 8:
+        return "incomplete"
+    return "incomplete"
+
+
+def _classify_from_checks(checks: "list[dict]") -> str:
+    """Classify CI status from `gh pr checks --json bucket,state,name` output.
+
+    gh's documented ``bucket`` values are
+    ``{pass, fail, pending, skipping, cancel}``.
+
+    * Empty list → ``incomplete`` (no checks reported).
+    * Any bucket in :data:`_FAILED_BUCKETS` (``fail``/``cancel``) →
+      ``failed``.
+    * Any bucket in :data:`_PENDING_BUCKETS` → ``incomplete``.
+    * All buckets in :data:`_PASSED_BUCKETS` (``pass``/``skipping``)
+      → ``passed``.
+    * Anything else (unrecognized bucket) → ``incomplete``
+      (conservative).
+    """
+    if not checks:
+        return "incomplete"
+    has_pending_or_unknown = False
+    for chk in checks:
+        bucket = (chk.get("bucket") or "").lower()
+        if bucket in _FAILED_BUCKETS:
+            return "failed"
+        if bucket in _PASSED_BUCKETS:
+            continue
+        # pending, empty, or any unrecognized bucket → conservative incomplete.
+        has_pending_or_unknown = True
+    return "incomplete" if has_pending_or_unknown else "passed"
+
+
+def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
+    """Return parsed `gh pr checks <pr> --json` results, or ``None`` on error.
+
+    Requests ``bucket,state,name``: ``bucket`` is the only field we
+    classify on (see :func:`_classify_from_checks`); ``state`` and
+    ``name`` are fetched purely to aid debugging when something goes
+    sideways.
+
+    ``gh pr checks`` exits non-zero on multiple non-error conditions:
+    ``8`` for "Checks pending" and ``1`` when at least one check has
+    failed (gh treats a red PR as a CLI error too). In both cases
+    gh still writes the requested JSON to stdout. So we trust the
+    JSON whenever it parses as a list, and only fall back when the
+    output is unparseable or the binary is missing entirely — that's
+    the only condition under which downgrading to the exit-code
+    classifier is appropriate.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "checks", str(pr),
+                "--repo", repo,
+                "--json", "bucket,state,name",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(result.stdout or "")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    return [c for c in data if isinstance(c, dict)]
+
+
+def _watch_for_merge(
+    *,
+    pr: int,
+    repo: str,
+    interval: int,
+    db_path: Path,
+    max_seconds: int = MERGE_WATCH_MAX_SECONDS,
+    sleeper=time.sleep,
+    monotonic=time.monotonic,
+) -> str:
+    """Poll `gh pr view --json mergedAt` until merged or bound elapses.
+
+    Issue #317. On the first poll that returns a non-null ``mergedAt``,
+    invoke :func:`tools.run_complete_on_merge.complete_on_merge` to
+    drive the run row to its terminal state and return its result.
+    On bound exhaustion, append a ``pr_merge_watch_timeout`` event to
+    the DB and return ``"timeout"``. ``sleeper`` and ``monotonic`` are
+    injectable for tests.
+    """
+    from tools.run_complete_on_merge import (
+        complete_on_merge, fetch_pr_view, RESULT_ALREADY, RESULT_MERGED,
+        RESULT_MERGED_PENDING_CLEANUP, RESULT_NO_RUN, RESULT_NOT_YET,
+    )
+
+    deadline = monotonic() + max_seconds
+    while True:
+        try:
+            view = fetch_pr_view(pr, repo)
+        except RuntimeError as exc:
+            sys.stderr.write(
+                f"pr_watch: merge-watch: gh pr view failed: {exc}\n"
+            )
+            view = None
+
+        if view is not None and view.get("mergedAt"):
+            try:
+                result = complete_on_merge(
+                    pr=pr, repo=repo, db_path=db_path, pr_view=view,
+                )
+            except Exception as exc:  # noqa: BLE001
+                sys.stderr.write(
+                    f"pr_watch: merge-watch: complete_on_merge raised: {exc}\n"
+                )
+                return "error"
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch result: {result}\n"
+            )
+            if result in (
+                RESULT_MERGED, RESULT_MERGED_PENDING_CLEANUP,
+                RESULT_ALREADY, RESULT_NO_RUN,
+            ):
+                # Issue #326: notify secretary when we observe the
+                # merge so it can kick off post-merge cleanup without
+                # waiting for a human to refresh. NO_RUN means the
+                # merge was observed but no matching run row was found
+                # — Secretary must NOT treat it as the post-merge
+                # cleanup signal, so we surface a distinct error
+                # variant instead of PR_MERGED.
+                if result == RESULT_NO_RUN:
+                    _notify_peer(f"PR_MERGED_NO_RUN: PR #{pr}")
+                else:
+                    _notify_peer(f"PR_MERGED: PR #{pr}")
+                return result
+            # RESULT_NOT_YET shouldn't occur once mergedAt is set; treat
+            # defensively as "keep polling".
+
+        if monotonic() >= deadline:
+            _record_event(
+                db_path=db_path,
+                kind="pr_merge_watch_timeout",
+                payload={
+                    "pr": pr, "repo": repo,
+                    "max_seconds": max_seconds,
+                },
+            )
+            # Issue #326: surface the 24h bound to secretary so a stuck
+            # PR doesn't sit silently after the loop releases.
+            _notify_peer(f"PR_MERGE_WATCH_TIMEOUT: PR #{pr}")
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch timed out after "
+                f"{max_seconds}s\n"
+            )
+            return "timeout"
+
+        sleeper(interval)
+
+
+def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
+    """Append a single event row via StateWriter (used for merge-watch timeout)."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        writer.append_event(kind=kind, actor="pr_watch", payload=payload)
+        writer.commit()
+    finally:
+        conn.close()
+
+
+def _pr_exists(pr: int, repo: str) -> bool:
+    try:
+        subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "number"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/pr_watch.py",
+        description="Watch a GitHub PR's CI checks and journal the result.",
+    )
+    # Accept both `--pr <n>` (preferred, unambiguous on PowerShell) and the
+    # legacy positional form `<n>` so direct python/bash invocations keep
+    # working. Exactly one of the two must be supplied.
+    parser.add_argument(
+        "--pr",
+        dest="pr_flag",
+        type=int,
+        default=None,
+        help="pull request number",
+    )
+    parser.add_argument(
+        "pr_positional",
+        nargs="?",
+        type=int,
+        default=None,
+        metavar="PR",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="OWNER/REPO; auto-detected via `gh repo view` if omitted",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=30,
+        help="poll interval in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--merge-watch",
+        action="store_true",
+        help=(
+            "After CI passes, keep polling `gh pr view --json mergedAt` "
+            "for up to 24h and invoke tools/run_complete_on_merge.py on "
+            "the first mergedAt (Issue #317). Off by default — pr_watch "
+            "is otherwise a CI-only blocking call, and a 24h wall is "
+            "incompatible with the secretary's 2c/T6 review-feedback "
+            "loop. Opt in only when secretary actually wants to wait."
+        ),
+    )
+    # --no-merge-watch is kept as a no-op alias for back-compat with
+    # callers / tests that already opted out. The default is off either
+    # way; this keeps argv compatible with the prior turn's commits.
+    parser.add_argument(
+        "--no-merge-watch",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+
+    if args.pr_flag is not None and args.pr_positional is not None:
+        parser.error("specify the PR number once (either --pr or positional)")
+    pr_number = args.pr_flag if args.pr_flag is not None else args.pr_positional
+    if pr_number is None:
+        parser.error("missing PR number (use --pr <n>)")
+    if pr_number <= 0:
+        parser.error("PR number must be a positive integer")
+    if args.interval <= 0:
+        parser.error("--interval must be a positive integer")
+    args.pr = pr_number
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    if not _pr_exists(args.pr, repo):
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: PR #{args.pr} not found in {repo}\n"
+        )
+        return 2
+
+    cmd = [
+        "gh", "pr", "checks", str(args.pr),
+        "--repo", repo,
+        "--watch",
+        "--interval", str(args.interval),
+    ]
+    started = time.monotonic()
+    canceled = False
+    try:
+        completed = subprocess.run(cmd)
+        exit_code = completed.returncode
+    except KeyboardInterrupt:
+        # Normalize parent-side cancellation to gh's standard exit code 2
+        # so callers (and the journal status mapping) see a portable signal.
+        exit_code = 2
+        canceled = True
+    duration = int(round(time.monotonic() - started))
+
+    # gh's documented cancellation exit code is 2 (parent SIGINT or
+    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
+    # genuine cancellation with whatever the JSON probe returns.
+    if canceled or exit_code == 2:
+        status = "canceled"
+    else:
+        # Issue #224: gh exit 1 from a transient watch-loop error must not
+        # be conflated with "CI failed". Re-derive the status from the
+        # per-check JSON; only fall back to the exit code if the probe
+        # itself fails.
+        checks = _fetch_checks(args.pr, repo)
+        if checks is None:
+            sys.stderr.write(
+                "tools/pr_watch.py: warning: could not query check results "
+                "via `gh pr checks --json`; falling back to exit-code "
+                "classification.\n"
+            )
+            status = _classify(exit_code)
+        else:
+            status = _classify_from_checks(checks)
+
+    _record_ci_completed(
+        db_path=JOURNAL_PATH,
+        pr=args.pr,
+        repo=repo,
+        status=status,
+        duration=duration,
+    )
+
+    # Issue #326: nudge secretary as soon as the CI verdict is recorded
+    # so it doesn't have to poll the DB. Best-effort — silent fallback
+    # in non-renga environments (RENGA_SOCKET unset).
+    _notify_peer(
+        f"CI_COMPLETED: PR #{args.pr} {status} "
+        f"(duration {duration}s, repo {repo})"
+    )
+
+    sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
+
+    # Issue #317: only enter merge-watch when CI actually passed and
+    # the caller explicitly opted in via --merge-watch. The default is
+    # off so pr_watch stays a "CI passed → return" command compatible
+    # with secretary's 2c/T6 review-feedback loop.
+    if status == "passed" and args.merge_watch and not args.no_merge_watch:
+        merge_result = _watch_for_merge(
+            pr=args.pr,
+            repo=repo,
+            interval=args.interval,
+            db_path=JOURNAL_PATH,
+        )
+        # Codex Major: surface merge-watch failure modes via exit code
+        # so callers can distinguish "CI passed but PR did not merge in
+        # 24h" / "helper raised" from "CI passed and we successfully
+        # transitioned the run". Don't override a non-zero CI exit
+        # code — that already signaled trouble.
+        if exit_code == 0 and merge_result in ("timeout", "error", "no_run"):
+            # Codex round-2 Major: no_run means we observed a merge but
+            # could not resolve the PR back to a runs row, so the
+            # status flip didn't happen and the secretary needs to
+            # intervene. Surface that as exit 9 so callers don't treat
+            # it as success.
+            exit_code = 9
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_peer_notify.py
+++ b/tools/test_peer_notify.py
@@ -1,0 +1,249 @@
+"""Direct unit tests for tools/peer_notify.py (Issue #326).
+
+These exercise the JSON-RPC handshake, timeout, and the ok-text
+``(message dropped — …)`` rejection without invoking the real renga
+binary. The helper spawns ``renga mcp-peer`` with subprocess.Popen,
+so we substitute a fake Popen that wires its stdin/stdout to in-memory
+streams scripted by each test.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+from pathlib import Path
+from typing import Callable, List, Optional
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import peer_notify  # noqa: E402
+
+
+class _FakeProc:
+    """Minimal subprocess.Popen stand-in driven by a server callback."""
+
+    def __init__(self, server: Callable[[dict], "Optional[dict | List[dict]]"],
+                 stall: bool = False) -> None:
+        self._server = server
+        self._stall = stall
+        self._in_r, self._in_w = os.pipe()
+        self._out_r, self._out_w = os.pipe()
+        self.stdin = os.fdopen(self._in_w, "w", encoding="utf-8")
+        self.stdout = os.fdopen(self._out_r, "r", encoding="utf-8")
+        self.stderr = io.StringIO()
+        self._reader_in = os.fdopen(self._in_r, "r", encoding="utf-8")
+        self._writer_out = os.fdopen(self._out_w, "w", encoding="utf-8")
+        self._t = threading.Thread(target=self._serve, daemon=True)
+        self._t.start()
+        self.returncode: Optional[int] = None
+
+    def _serve(self) -> None:
+        try:
+            for line in self._reader_in:
+                if not line.strip():
+                    continue
+                try:
+                    req = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if self._stall:
+                    # Simulate an unresponsive server: read but never reply.
+                    continue
+                resp = self._server(req)
+                if resp is None:
+                    continue
+                payloads = resp if isinstance(resp, list) else [resp]
+                for p in payloads:
+                    self._writer_out.write(json.dumps(p) + "\n")
+                    self._writer_out.flush()
+        except Exception:
+            pass
+        finally:
+            try:
+                self._writer_out.close()
+            except Exception:
+                pass
+
+    def wait(self, timeout: Optional[float] = None) -> int:
+        self._t.join(timeout=timeout)
+        self.returncode = 0
+        return 0
+
+    def kill(self) -> None:
+        try:
+            self._writer_out.close()
+        except Exception:
+            pass
+        try:
+            self._reader_in.close()
+        except Exception:
+            pass
+
+
+def _ok_init(req: dict) -> dict:
+    return {
+        "jsonrpc": "2.0", "id": req["id"],
+        "result": {"protocolVersion": "2025-03-26",
+                   "capabilities": {}, "serverInfo": {"name": "fake"}},
+    }
+
+
+class NotifyPeerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Pretend renga is on PATH and RENGA_SOCKET is set so the
+        # short-circuit guards don't fire.
+        self._env = mock.patch.dict(
+            os.environ, {"RENGA_SOCKET": r"\\.\pipe\fake"}, clear=False,
+        )
+        self._env.start()
+        self._which = mock.patch.object(
+            peer_notify.shutil, "which", return_value="/fake/renga",
+        )
+        self._which.start()
+
+    def tearDown(self) -> None:
+        self._which.stop()
+        self._env.stop()
+
+    def _patch_popen(self, server) -> mock._patch:
+        def _popen(*_a, **_kw):
+            return _FakeProc(server)
+        return mock.patch.object(peer_notify.subprocess, "Popen",
+                                 side_effect=_popen)
+
+    def test_no_socket_returns_false(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "RENGA_SOCKET"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertFalse(peer_notify.notify_peer("secretary", "x"))
+
+    def test_renga_missing_returns_false(self) -> None:
+        with mock.patch.object(peer_notify.shutil, "which", return_value=None):
+            self.assertFalse(peer_notify.notify_peer("secretary", "x"))
+
+    def test_successful_delivery(self) -> None:
+        def server(req: dict) -> Optional[dict]:
+            if req.get("method") == "initialize":
+                return _ok_init(req)
+            if req.get("method") == "tools/call":
+                return {
+                    "jsonrpc": "2.0", "id": req["id"],
+                    "result": {"isError": False,
+                               "content": [{"type": "text",
+                                            "text": "Delivered to 1."}]},
+                }
+            return None
+
+        with self._patch_popen(server):
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_message_dropped_ok_text_is_rejected(self) -> None:
+        """Renga's backend-unreachable shim returns ok-text rather
+        than a JSON-RPC error. notify_peer must NOT report success."""
+        def server(req: dict) -> Optional[dict]:
+            if req.get("method") == "initialize":
+                return _ok_init(req)
+            if req.get("method") == "tools/call":
+                return {
+                    "jsonrpc": "2.0", "id": req["id"],
+                    "result": {"isError": False,
+                               "content": [{"type": "text",
+                                            "text": "(message dropped — renga not reachable: foo)"}]},
+                }
+            return None
+
+        with self._patch_popen(server):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_is_error_true_returns_false(self) -> None:
+        def server(req: dict) -> Optional[dict]:
+            if req.get("method") == "initialize":
+                return _ok_init(req)
+            if req.get("method") == "tools/call":
+                return {
+                    "jsonrpc": "2.0", "id": req["id"],
+                    "result": {"isError": True,
+                               "content": [{"type": "text", "text": "boom"}]},
+                }
+            return None
+
+        with self._patch_popen(server):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_unrelated_lines_are_skipped(self) -> None:
+        """Notifications and unrelated id lines must not fool the reader."""
+        def server(req: dict) -> Optional[list]:
+            if req.get("method") == "initialize":
+                return [
+                    {"jsonrpc": "2.0", "method": "notifications/log",
+                     "params": {"msg": "noise"}},
+                    {"jsonrpc": "2.0", "id": 999,
+                     "result": {"unrelated": True}},
+                    _ok_init(req),
+                ]
+            if req.get("method") == "tools/call":
+                return [
+                    {"jsonrpc": "2.0", "method": "notifications/progress"},
+                    {"jsonrpc": "2.0", "id": req["id"],
+                     "result": {"isError": False,
+                                "content": [{"type": "text",
+                                             "text": "Delivered to 1."}]}},
+                ]
+            return None
+
+        with self._patch_popen(server):
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_initialize_request_uses_modern_protocol_version(self) -> None:
+        """Regression guard against drifting back to 2024-11-05.
+
+        Should match the version sent by tools/check_renga_compat.py so a
+        future renga that tightens version negotiation doesn't silently
+        downgrade peer_notify to a no-op.
+        """
+        seen: list[dict] = []
+
+        def server(req: dict) -> Optional[dict]:
+            seen.append(req)
+            if req.get("method") == "initialize":
+                return _ok_init(req)
+            if req.get("method") == "tools/call":
+                return {
+                    "jsonrpc": "2.0", "id": req["id"],
+                    "result": {"isError": False,
+                               "content": [{"type": "text",
+                                            "text": "Delivered to 1."}]},
+                }
+            return None
+
+        with self._patch_popen(server):
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+
+        init_calls = [r for r in seen if r.get("method") == "initialize"]
+        self.assertEqual(len(init_calls), 1)
+        self.assertEqual(
+            init_calls[0]["params"]["protocolVersion"], "2025-03-26",
+        )
+
+    def test_unresponsive_server_times_out(self) -> None:
+        """An unresponsive `renga mcp-peer` must not hang the caller."""
+        def _popen(*_a, **_kw):
+            return _FakeProc(server=lambda r: None, stall=True)
+
+        with mock.patch.object(peer_notify.subprocess, "Popen",
+                               side_effect=_popen):
+            t0 = time.monotonic()
+            ok = peer_notify.notify_peer("secretary", "hi", timeout=0.3)
+            elapsed = time.monotonic() - t0
+        self.assertFalse(ok)
+        self.assertLess(elapsed, 5.0,
+                        f"timeout not enforced; elapsed={elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1,0 +1,962 @@
+"""Unit tests for tools/pr_watch.py (Issue #204, Issue #224, M4 Issue #267).
+
+Mocks the gh CLI subprocess via monkey-patching so the suite stays
+hermetic. M4 (Issue #267) routes ``ci_completed`` to the DB events
+table; the test helper ``_read_ci_event`` reads back via sqlite3.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_watch  # noqa: E402
+
+
+def _read_ci_event(db_path: Path) -> dict:
+    """Return the (single) ci_completed event from the DB as a payload dict
+    flattened with the ``ts`` / ``event`` keys the tests expect."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT occurred_at, kind, payload_json FROM events "
+            "WHERE kind = 'ci_completed' ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    if len(rows) != 1:
+        raise AssertionError(f"expected 1 ci_completed row, got {len(rows)}")
+    row = rows[0]
+    payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+    out = dict(payload)
+    out["event"] = row["kind"]
+    out["ts"] = row["occurred_at"]
+    return out
+
+
+def _count_ci_events(db_path: Path) -> int:
+    if not db_path.exists():
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(conn.execute(
+            "SELECT COUNT(*) FROM events WHERE kind = 'ci_completed'"
+        ).fetchone()[0])
+    finally:
+        conn.close()
+
+
+class ClassifyTests(unittest.TestCase):
+    """Fallback classifier (used only when JSON probe is unavailable).
+
+    Per `gh help exit-codes`, exit 8 is "Checks pending" — NOT failure.
+    Issue #224 corrects the prior mapping.
+    """
+
+    def test_zero_is_passed(self) -> None:
+        self.assertEqual(pr_watch._classify(0), "passed")
+
+    def test_eight_is_incomplete(self) -> None:
+        # gh exit 8 = "Checks pending", per gh's help text.
+        self.assertEqual(pr_watch._classify(8), "incomplete")
+
+    def test_two_is_canceled(self) -> None:
+        self.assertEqual(pr_watch._classify(2), "canceled")
+
+    def test_other_nonzero_is_incomplete(self) -> None:
+        # Conservative: treat unknown gh errors as incomplete rather
+        # than libelling the PR as failed.
+        self.assertEqual(pr_watch._classify(1), "incomplete")
+        self.assertEqual(pr_watch._classify(127), "incomplete")
+
+
+def _make_fake_run(
+    watch_exit: int = 0,
+    checks_json: "list[dict] | None" = None,
+    checks_raises: "Exception | None" = None,
+    checks_json_exit: "int | None" = None,
+):
+    """Build a `subprocess.run` stub matching the call sites in pr_watch.
+
+    Recognized commands:
+
+    * ``gh pr view ... --json number`` → success (PR exists probe)
+    * ``gh pr checks <pr> --json ...`` → ``checks_json`` (or raise)
+    * ``gh pr checks <pr> --watch ...`` → returncode = ``watch_exit``
+    """
+    if checks_json is None:
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+
+    # gh exits non-zero (1) when at least one check is failing, and 8
+    # when checks are still pending — but in both cases it still writes
+    # the requested JSON. Mirror that here so the tests exercise the
+    # real protocol, not an idealized one.
+    def _gh_exit_for_checks(payload):
+        if checks_json_exit is not None:
+            return checks_json_exit
+        for chk in payload:
+            b = (chk.get("bucket") or "").lower()
+            if b in ("fail", "cancel"):
+                return 1
+            if b == "pending":
+                return 8
+        return 0
+
+    def fake_run(cmd, *args, **kwargs):
+        if "view" in cmd and "--json" in cmd and "number" in cmd:
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+        if "checks" in cmd and "--json" in cmd:
+            if checks_raises is not None:
+                raise checks_raises
+            return mock.Mock(
+                returncode=_gh_exit_for_checks(checks_json),
+                stdout=json.dumps(checks_json),
+                stderr="",
+            )
+        # The watched run.
+        return mock.Mock(returncode=watch_exit)
+
+    return fake_run
+
+
+class ArgFormTests(unittest.TestCase):
+    """Both `--pr <n>` and the legacy positional form must parse identically."""
+
+    def _run(self, argv: "list[str]") -> "tuple[int, dict]":
+        fake_run = _make_fake_run(watch_exit=0)
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                # Issue #317: existing CI-only tests opt out of the
+                # post-CI merge-watch loop; that path is exercised
+                # separately in MergeWatchTests below.
+                # Issue #317 round 3: merge-watch is now off by default,
+                # so existing CI-only tests don't need an opt-out flag.
+                rc = pr_watch.main(argv)
+            rec = _read_ci_event(journal)
+            return rc, rec
+
+    def test_long_form(self) -> None:
+        rc, rec = self._run(["--pr", "42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_positional_form(self) -> None:
+        rc, rec = self._run(["42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_both_forms_rejected(self) -> None:
+        with self.assertRaises(SystemExit):
+            pr_watch.main(["7", "--pr", "9", "--repo", "octo/repo"])
+
+
+class JournalEmitTests(unittest.TestCase):
+    def _run(
+        self,
+        tmp_journal: Path,
+        gh_exit: int,
+        checks_json: "list[dict] | None" = None,
+        checks_raises: "Exception | None" = None,
+    ) -> int:
+        fake_run = _make_fake_run(
+            watch_exit=gh_exit,
+            checks_json=checks_json,
+            checks_raises=checks_raises,
+        )
+        with mock.patch.object(pr_watch, "JOURNAL_PATH", tmp_journal), \
+             mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
+            return pr_watch.main([
+                "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+            ])
+
+    def test_passed_emits_ci_completed(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(journal, gh_exit=0)
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["event"], "ci_completed")
+            self.assertEqual(rec["pr"], 205)
+            self.assertEqual(rec["repo"], "octo/repo")
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["duration_sec"], 42)
+            self.assertIn("ts", rec)
+
+    def test_failed_status_from_check_bucket(self) -> None:
+        """A `fail` bucket in the JSON probe → status=failed."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=8,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+
+    def test_transient_gh_error_is_not_failed(self) -> None:
+        """Issue #224: gh exit 1 with all checks `pass` must classify as passed.
+
+        Regression: the old code conflated any non-zero exit with CI
+        failure, so a transient error in `gh pr checks --watch` (e.g.
+        a brief network blip) would be journaled as ``status=failed``
+        even when CI itself was green.
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=1,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "pass"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+
+    def test_pending_check_is_incomplete(self) -> None:
+        """A still-running check → status=incomplete (new in #224)."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_empty_checks_is_incomplete(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(journal, gh_exit=0, checks_json=[])
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_failed_check_with_gh_json_exit_1(self) -> None:
+        """gh exits 1 when a check failed but still emits JSON.
+
+        Regression: the previous implementation only trusted the JSON
+        when gh exited 0 or 8, so a real CI failure (gh exit 1 + valid
+        JSON listing a `fail` bucket) would be discarded and fall
+        through to the exit-code classifier — defeating Issue #224(a).
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=1,  # watch loop saw the failure too
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
+                ],
+                # `_gh_exit_for_checks` will emit 1 for this payload
+                # (failure present), matching real gh behavior.
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+
+    def test_gh_exit_2_is_canceled(self) -> None:
+        """gh exit 2 = cancellation. Must NOT be overwritten by JSON probe.
+
+        Regression: an earlier draft only honored Python-side
+        KeyboardInterrupt, so a Ctrl-C delivered to gh itself (exit 2)
+        would have been re-classified as passed/failed/incomplete by
+        the JSON probe. The journal must reflect cancellation so the
+        secretary can distinguish "user aborted" from "CI verdict".
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=2,
+                checks_json=[{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "canceled")
+
+    def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
+        """If `gh pr checks --json` itself fails, use exit-code mapping."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_raises=FileNotFoundError("gh missing"),
+            )
+            rec = _read_ci_event(journal)
+            # exit 0 → passed via _classify fallback.
+            self.assertEqual(rec["status"], "passed")
+
+
+class ClassifyFromChecksTests(unittest.TestCase):
+    def test_all_pass(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "pass"}]
+            ),
+            "passed",
+        )
+
+    def test_skipping_counts_as_passed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "skipping"}]
+            ),
+            "passed",
+        )
+
+    def test_fail_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "fail"}]
+            ),
+            "failed",
+        )
+
+    def test_cancel_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "cancel"}]
+            ),
+            "failed",
+        )
+
+    def test_pending_is_incomplete(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "pending"}]
+            ),
+            "incomplete",
+        )
+
+    def test_empty_is_incomplete(self) -> None:
+        self.assertEqual(pr_watch._classify_from_checks([]), "incomplete")
+
+    def test_unknown_bucket_is_incomplete(self) -> None:
+        # Conservative: unrecognized bucket → don't claim "passed".
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"bucket": "mystery"}]),
+            "incomplete",
+        )
+
+    def test_case_insensitive_bucket(self) -> None:
+        # gh emits lowercase, but be defensive.
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"bucket": "PASS"}]),
+            "passed",
+        )
+
+
+class PowerShellInterpreterProbeTests(unittest.TestCase):
+    """Issue #224 (b): pr-watch.ps1 must reject Pythons that lack core_harness.
+
+    These tests exercise the actual PowerShell script via pwsh; they are
+    skipped on hosts where pwsh isn't available (e.g. minimal CI images).
+    The probe logic itself is small and self-contained, so we extract just
+    the Test-Interpreter function and call it with synthetic shim
+    interpreters.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if not cls.pwsh:
+            raise unittest.SkipTest("pwsh/powershell not available")
+        cls.script = (
+            Path(__file__).resolve().parent / "pr-watch.ps1"
+        )
+        if not cls.script.exists():
+            raise unittest.SkipTest("pr-watch.ps1 not found")
+
+    def _run_probe(self, shim_body: str) -> bool:
+        """Write a fake interpreter shim, source Test-Interpreter, return result."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            if os.name == "nt":
+                shim = tdp / "fakepy.cmd"
+                shim.write_text(shim_body, encoding="ascii")
+                exe_arg = str(shim)
+            else:
+                shim = tdp / "fakepy"
+                shim.write_text("#!/usr/bin/env bash\n" + shim_body, encoding="ascii")
+                shim.chmod(0o755)
+                exe_arg = str(shim)
+            # We can't dot-source pr-watch.ps1 directly (it has a mandatory
+            # -PR param that would error out), so extract just the
+            # Test-Interpreter function block via regex and Invoke-Expression.
+            extract = (
+                "$src = Get-Content -Raw '" + str(self.script).replace("'", "''") + "'; "
+                "if ($src -match '(?ms)function Test-Interpreter \\{.*?^\\}') "
+                "{ Invoke-Expression $Matches[0] } "
+                "else { Write-Error 'function not found'; exit 99 }; "
+                "if (Test-Interpreter -Exe '" + exe_arg.replace("'", "''") + "' -Prefix @()) "
+                "{ exit 0 } else { exit 1 }"
+            )
+            res = subprocess.run(
+                [self.pwsh, "-NoProfile", "-Command", extract],
+                capture_output=True,
+                text=True,
+            )
+            return res.returncode == 0
+
+    def test_version_ok_import_fail_is_rejected(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( echo ImportError 1>&2 & exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then echo 'ImportError' 1>&2; exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter should reject a Python that fails the import check",
+        )
+
+    def test_python_2_is_rejected(self) -> None:
+        """A `--version`-passing Python 2 must not be accepted.
+
+        The combined `-c` probe asserts sys.version_info[0]==3, so a
+        shim that simulates Py2 by exiting nonzero on the `-c` call
+        should be rejected even though `--version` succeeds.
+        """
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 2.7.18 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 2.7.18'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter must reject Python 2 even if --version exits 0",
+        )
+
+    def test_version_ok_import_ok_is_accepted(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 0 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 0; fi\n"
+                "exit 2\n"
+            )
+        self.assertTrue(
+            self._run_probe(shim_body),
+            "Test-Interpreter should accept a Python that passes both probes",
+        )
+
+
+class TempDir:
+    def __enter__(self) -> Path:
+        import tempfile
+        self._dir = tempfile.TemporaryDirectory()
+        return Path(self._dir.name)
+
+    def __exit__(self, *exc) -> None:
+        self._dir.cleanup()
+
+
+class MergeWatchTests(unittest.TestCase):
+    """Issue #317: post-CI merge-watch loop in pr_watch.main."""
+
+    def _seed_run_for_merge(self, db: Path, *, pr_url: str,
+                            pattern: str = "A") -> None:
+        """Seed a run pointing at the PR. Default pattern='A' so the
+        helper performs the full status transition; pass 'B' to test
+        the pending-cleanup path."""
+        from tools.state_db import apply_schema, connect
+        from tools.state_db.writer import StateWriter
+
+        apply_schema(connect(db))
+        conn = connect(db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id="t-merge-watch",
+                    project_slug="claude-org",
+                    pattern=pattern,
+                    title="merge-watch test",
+                    status="review",
+                    branch="feat/merge-watch",
+                    pr_url=pr_url,
+                    pr_state="open",
+                )
+        finally:
+            conn.close()
+
+    def _build_run_with_view_sequence(
+        self,
+        watch_exit: int,
+        view_sequence: "list[dict | None]",
+    ):
+        """Like _make_fake_run but threads a sequence of `gh pr view --json`
+        responses for the merge-watch loop. The first `gh pr view --json
+        number` (PR-exists probe) returns success; the *second* and
+        subsequent `view --json` calls cycle through ``view_sequence``."""
+        # Default check JSON for the CI-watch portion (status=passed).
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+
+        # Mutable index threaded across closures — track which entry of
+        # view_sequence the next merge-watch poll should consume.
+        view_idx = {"i": 0}
+        seen_existence_probe = {"v": False}
+
+        def fake_run(cmd, *args, **kwargs):
+            # PR-exists probe: `gh pr view <pr> --repo <r> --json number`.
+            if (cmd[:3] == ["gh", "pr", "view"]
+                    and "--json" in cmd
+                    and cmd[cmd.index("--json") + 1] == "number"):
+                seen_existence_probe["v"] = True
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # Merge-watch probe: `gh pr view <pr> --json number,url,...`
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                idx = view_idx["i"]
+                if idx >= len(view_sequence):
+                    payload = view_sequence[-1]
+                else:
+                    payload = view_sequence[idx]
+                    view_idx["i"] += 1
+                if payload is None:
+                    return mock.Mock(returncode=1, stdout="", stderr="boom")
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(payload),
+                    stderr="",
+                )
+            # `gh pr checks --json` for CI classification.
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(checks_json),
+                    stderr="",
+                )
+            # The watched `gh pr checks --watch` run.
+            return mock.Mock(returncode=watch_exit)
+
+        return fake_run
+
+    def test_ci_pass_then_merged_records_metadata(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            pr_url = "https://github.com/octo/repo/pull/777"
+            self._seed_run_for_merge(db, pr_url=pr_url)
+
+            view_merged = {
+                "number": 777, "url": pr_url, "state": "MERGED",
+                "mergedAt": "2026-05-06T03:21:00Z",
+                "mergeCommit": {"oid": "f" * 40},
+                "headRefName": "feat/merge-watch",
+            }
+            fake_run = self._build_run_with_view_sequence(
+                watch_exit=0, view_sequence=[view_merged],
+            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "777", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+            self.assertEqual(rc, 0)
+
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status, pr_state, completed_at "
+                    "FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                # status stays in 'review' — secretary owns the flip.
+                self.assertEqual(row["status"], "review")
+                self.assertEqual(row["pr_state"], "merged")
+                self.assertEqual(row["completed_at"], "2026-05-06T03:21:00Z")
+                merged_count = conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE kind = 'pr_merged'"
+                ).fetchone()[0]
+                self.assertEqual(merged_count, 1)
+            finally:
+                conn.close()
+
+    def test_default_skips_merge_watch(self) -> None:
+        """Issue #317 round 3: merge-watch is opt-in, off by default.
+
+        Without `--merge-watch`, even on CI pass pr_watch must NOT
+        poll `gh pr view --json mergedAt`.
+        """
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/111",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "111", "--repo", "octo/repo", "--interval", "1",
+                ])
+
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
+
+    def test_ci_fail_skips_merge_watch(self) -> None:
+        """When CI did not pass, pr_watch must not poll for merge."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+
+            # Fail the CI; assert no further `view --json` call is made.
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=1,
+                        stdout=json.dumps([
+                            {"name": "ci", "state": "COMPLETED",
+                             "bucket": "fail"}
+                        ]),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=1)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "888", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+
+            # CI failed → no merge-watch even with --merge-watch on.
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
+
+    def test_no_merge_watch_flag_skips_loop(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/999",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "999", "--repo", "octo/repo", "--interval", "1",
+                    "--no-merge-watch",
+                ])
+
+            # Run row must NOT have been completed.
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                self.assertEqual(row["status"], "review")
+            finally:
+                conn.close()
+
+    def test_watch_for_merge_timeout_records_event(self) -> None:
+        """Bound exhaustion appends pr_merge_watch_timeout."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            view_pending = {
+                "number": 555, "url": "https://github.com/octo/repo/pull/555",
+                "state": "OPEN", "mergedAt": None,
+                "mergeCommit": None, "headRefName": "feat/x",
+            }
+
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            # Patch view fetch + monotonic so the loop exhausts after
+            # one iteration. monotonic side_effect: start=0.0, then
+            # 99999.0 to immediately exceed deadline.
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_pending),
+                        stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            with mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=555, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 100.0, 100.0]),
+                )
+            self.assertEqual(result, "timeout")
+
+            conn = sqlite3.connect(str(db))
+            try:
+                cnt = conn.execute(
+                    "SELECT COUNT(*) FROM events "
+                    "WHERE kind = 'pr_merge_watch_timeout'"
+                ).fetchone()[0]
+                self.assertEqual(cnt, 1)
+            finally:
+                conn.close()
+
+
+class PeerNotifyTests(unittest.TestCase):
+    """Issue #326: pr_watch dispatches peer messages to secretary on
+    CI completion / merge detection / merge-watch timeout. Mocks the
+    `_notify_peer` seam so the test suite doesn't spawn renga."""
+
+    def test_ci_completed_dispatches_peer_message(self) -> None:
+        fake_run = _make_fake_run(watch_exit=0)
+        captured: list[str] = []
+
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 7.0]):
+                rc = pr_watch.main(["--pr", "326", "--repo", "octo/repo"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(captured), 1)
+            self.assertIn("CI_COMPLETED", captured[0])
+            self.assertIn("PR #326", captured[0])
+            self.assertIn("passed", captured[0])
+            self.assertIn("octo/repo", captured[0])
+
+    def test_pr_merged_dispatches_peer_message(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            pr_url = "https://github.com/octo/repo/pull/777"
+            mw_tests = MergeWatchTests()
+            mw_tests._seed_run_for_merge(db, pr_url=pr_url)
+
+            view_merged = {
+                "number": 777, "url": pr_url, "state": "MERGED",
+                "mergedAt": "2026-05-06T03:21:00Z",
+                "mergeCommit": {"oid": "f" * 40},
+                "headRefName": "feat/merge-watch",
+            }
+            fake_run = mw_tests._build_run_with_view_sequence(
+                watch_exit=0, view_sequence=[view_merged],
+            )
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "777", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+            # Expect both CI_COMPLETED and PR_MERGED in captured.
+            self.assertTrue(any("CI_COMPLETED" in m for m in captured),
+                            f"missing CI_COMPLETED: {captured}")
+            self.assertTrue(any("PR_MERGED: PR #777" in m for m in captured),
+                            f"missing PR_MERGED: {captured}")
+
+    def test_merge_watch_timeout_dispatches_peer_message(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            view_pending = {
+                "number": 555, "url": "https://github.com/octo/repo/pull/555",
+                "state": "OPEN", "mergedAt": None,
+                "mergeCommit": None, "headRefName": "feat/x",
+            }
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_pending),
+                        stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=555, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 100.0, 100.0]),
+                )
+            self.assertEqual(result, "timeout")
+            self.assertEqual(captured, ["PR_MERGE_WATCH_TIMEOUT: PR #555"])
+
+    def test_no_run_dispatches_distinct_message(self) -> None:
+        """When complete_on_merge returns no_run, pr-watch must NOT
+        send PR_MERGED (which would mislead secretary into starting
+        post-merge cleanup). It surfaces a PR_MERGED_NO_RUN variant."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+            view_merged = {
+                "number": 444,
+                "url": "https://github.com/octo/repo/pull/444",
+                "state": "MERGED",
+                "mergedAt": "2026-05-06T03:21:00Z",
+                "mergeCommit": {"oid": "a" * 40},
+                "headRefName": "feat/x",
+            }
+
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_merged),
+                        stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            captured: list[str] = []
+            with mock.patch.object(pr_watch, "_notify_peer",
+                                   side_effect=lambda msg, *a, **kw: captured.append(msg) or True), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                # No seeded run for PR #444 → complete_on_merge → no_run.
+                result = pr_watch._watch_for_merge(
+                    pr=444, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 0.0, 100.0]),
+                )
+            self.assertEqual(result, "no_run")
+            self.assertEqual(captured, ["PR_MERGED_NO_RUN: PR #444"])
+
+    def test_no_renga_socket_silent_fallback(self) -> None:
+        """With RENGA_SOCKET unset, _notify_peer must return False
+        without raising or spawning anything, and pr_watch.main must
+        complete normally."""
+        from tools import peer_notify
+
+        env = {k: v for k, v in os.environ.items() if k != "RENGA_SOCKET"}
+
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertFalse(peer_notify.notify_peer("secretary", "x"))
+            self.assertFalse(pr_watch._notify_peer("x"))
+
+        # And run pr_watch.main end-to-end with the helper unmocked but
+        # RENGA_SOCKET cleared — no exception, ci_completed event still
+        # written.
+        fake_run = _make_fake_run(watch_exit=0)
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            with mock.patch.dict(os.environ, env, clear=True), \
+                 mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main(["--pr", "10", "--repo", "octo/repo"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(_count_ci_events(db), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#327](https://github.com/suisya-systems/claude-org-ja/pull/327)

Merge SHA: `b073e15ed1900cb7cc509e558fdc9fe527c50453`

Source: ja PR [#327](https://github.com/suisya-systems/claude-org-ja/pull/327)
Merge SHA: `b073e15ed1900cb7cc509e558fdc9fe527c50453`

| class | count |
|---|---|
| runtime | 4 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tools/peer_notify.py`
- `tools/pr_watch.py`
- `tools/test_peer_notify.py`
- `tools/test_pr_watch.py`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-pull-request/SKILL.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
