### PR TITLE
auto-mirror: ja#319 feat(claude): auto-complete run on PR merge (Closes #317)

### DIFF
--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -1,0 +1,87 @@
+#!/usr/bin/env pwsh
+# Thin PowerShell wrapper around tools/pr_watch.py.
+# Usage: tools/pr-watch.ps1 -PR <PR> [-Repo OWNER/REPO] [-Interval SEC] [-MergeWatch] [-NoMergeWatch]
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [int]$PR,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Repo,
+
+    [Parameter(Mandatory = $false)]
+    [int]$Interval = 30,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$MergeWatch,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$NoMergeWatch
+)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
+
+# Probe interpreters by actually running `--version`, not just by checking
+# Get-Command. Some Windows boxes have a stale `py.exe` whose default 3.x
+# target points at a moved python.exe — Get-Command says "yes, py is there"
+# but invoking it fails with "Unable to create process". Verifying with a
+# real exec lets us fall through to plain `python` / `python3` in that case.
+#
+# Issue #224: `--version` passing is necessary but not sufficient — pr_watch.py
+# does `from core_harness.audit import Journal`, so a Python whose
+# site-packages lacks core_harness will exit 1 with a confusing ImportError
+# at runtime. Probe the import too so we fall through to a sibling
+# interpreter that *does* have core_harness installed.
+function Test-Interpreter {
+    param([string]$Exe, [string[]]$Prefix)
+    if (-not (Get-Command $Exe -ErrorAction SilentlyContinue)) { return $false }
+    try {
+        $null = & $Exe @Prefix '--version' 2>&1
+        if ($LASTEXITCODE -ne 0) { return $false }
+        # Combined probe: require Python 3 AND core_harness.audit importable.
+        # Bare `python`/`python3` on some systems still aliases to Python 2,
+        # which would pass `--version` but die on pr_watch.py's f-strings.
+        $probe = 'import sys; assert sys.version_info[0] == 3; import core_harness.audit'
+        $null = & $Exe @Prefix '-c' $probe 2>&1
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+$candidates = @(
+    @{ Exe = 'py';      Prefix = @('-3') },
+    @{ Exe = 'python';  Prefix = @() },
+    @{ Exe = 'python3'; Prefix = @() }
+)
+
+$pyExec = $null
+$pyArgsPrefix = @()
+foreach ($cand in $candidates) {
+    if (Test-Interpreter -Exe $cand.Exe -Prefix $cand.Prefix) {
+        $pyExec = $cand.Exe
+        $pyArgsPrefix = $cand.Prefix
+        break
+    }
+}
+
+if (-not $pyExec) {
+    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python interpreter found with core_harness.audit installed (tried py -3, python, python3).')
+    exit 127
+}
+
+$forwardArgs = $pyArgsPrefix + @($ScriptPath, '--pr', $PR, '--interval', $Interval)
+if ($PSBoundParameters.ContainsKey('Repo') -and $Repo) {
+    $forwardArgs += @('--repo', $Repo)
+}
+if ($MergeWatch) {
+    $forwardArgs += @('--merge-watch')
+}
+if ($NoMergeWatch) {
+    $forwardArgs += @('--no-merge-watch')
+}
+
+& $pyExec @forwardArgs
+exit $LASTEXITCODE

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI checks and emit a journal event when finished.
+
+Cross-platform helper for the secretary role: after creating a PR,
+invoke this script to block on ``gh pr checks --watch`` and record a
+``ci_completed`` event in ``.state/state.db`` (events table).
+
+Usage::
+
+    py -3 tools/pr_watch.py --pr <PR> [--repo OWNER/REPO] [--interval SEC]
+
+Behavior:
+
+* Resolves the repo via ``gh repo view --json nameWithOwner`` when
+  ``--repo`` is omitted.
+* Spawns ``gh pr checks <PR> --watch --interval <SEC>`` and forwards
+  its stdout/stderr.
+* After the watch loop returns, queries
+  ``gh pr checks <PR> --json bucket,state,name`` for per-check
+  ``bucket`` (gh's documented bucket values are
+  ``{pass, fail, pending, skipping, cancel}``) so the journal status
+  reflects what CI actually decided rather than just the gh process'
+  exit code (gh exits non-zero on a transient watch error too, and
+  exit 8 specifically means "Checks pending", not "failed").
+  Classifies as ``passed`` (all pass/skipping), ``failed``
+  (≥1 fail/cancel), ``incomplete`` (any pending / unknown bucket /
+  empty list), or ``canceled`` (parent SIGINT). Falls back to
+  exit-code-based classification only if the JSON probe itself
+  fails. Appends one row to the ``events`` table in
+  ``<repo_root>/.state/state.db`` (anchored to ``tools/..`` so cwd
+  doesn't matter).
+* Prints the final status as a single line on stdout and exits with
+  the gh process' exit code.
+
+M4 (Issue #267): events flow through the SQLite DB only —
+``.state/journal.jsonl`` is decommissioned. The recorder uses the same
+``StateWriter.append_event`` path as ``tools/journal_append.py``.
+
+The event payload shape is::
+
+    {"event": "ci_completed", "ts": "<ISO8601>",
+     "pr": <int>, "repo": "<owner/repo>",
+     "status": "passed|failed|incomplete|canceled",
+     "duration_sec": <int>}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Bound on the post-CI merge-watch loop. Issue #317: after CI passes we
+# keep polling `gh pr view --json mergedAt` until the PR is merged or
+# this many seconds elapse, whichever comes first. 24h matches the
+# upper end of the org-delegate Step 5 2b-ii idle window so the
+# secretary can intervene manually past that.
+MERGE_WATCH_MAX_SECONDS = 24 * 60 * 60
+
+# Make `tools.state_db.*` importable when running this script directly.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# Path used by tests via mock.patch — kept as a module-level Path so the
+# legacy test seam (`mock.patch.object(pr_watch, "JOURNAL_PATH", ...)`)
+# continues to redirect writes at the tempdir. M4 made the file be the
+# state DB rather than journal.jsonl.
+JOURNAL_PATH = REPO_ROOT / ".state" / "state.db"
+
+
+def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
+                         status: str, duration: int) -> None:
+    """Append a ``ci_completed`` event to the DB events table."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        writer.append_event(
+            kind="ci_completed",
+            actor="pr_watch",
+            payload={
+                "pr": pr,
+                "repo": repo,
+                "status": status,
+                "duration_sec": duration,
+            },
+        )
+        writer.commit()
+    finally:
+        conn.close()
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: GitHub CLI (gh) not found in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: failed to auto-detect repo via "
+            f"`gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        data = json.loads(result.stdout)
+        repo = data["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/pr_watch.py: error: unexpected `gh repo view` output: "
+            f"{exc}\n"
+        )
+        sys.exit(2)
+    if not isinstance(repo, str) or "/" not in repo:
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: invalid repo {repo!r}\n"
+        )
+        sys.exit(2)
+    return repo
+
+
+# gh's `bucket` field (see `gh pr checks --help`) categorizes a check's
+# `state` into one of these buckets: "pass", "fail", "pending",
+# "skipping", "cancel". We treat fail+cancel as failure signals,
+# pass+skipping as success, and pending as still-running.
+_FAILED_BUCKETS = frozenset({"fail", "cancel"})
+_PASSED_BUCKETS = frozenset({"pass", "skipping"})
+_PENDING_BUCKETS = frozenset({"pending"})
+
+
+def _classify(exit_code: int) -> str:
+    """Fallback classifier used only when the JSON probe is unavailable.
+
+    Reference: https://cli.github.com/manual/gh_help_exit-codes and
+    https://cli.github.com/manual/gh_pr_checks. With ``--watch`` gh
+    blocks until pending checks resolve and then returns 0 (all
+    checks passed). Exit code 2 is gh's standard cancellation code
+    (e.g. user interrupt). Exit code 8 means "Checks pending" per
+    gh's docs (NOT failure). Other non-zero values most likely
+    indicate an internal gh error rather than a CI verdict, so they
+    map to the conservative ``incomplete`` status — refusing to
+    silently turn a transient error into "passed" while also not
+    libelling green CI as "failed".
+
+    SIGINT raised in the parent (Python ``KeyboardInterrupt``) is
+    normalized to 2 in :func:`main` before reaching this function.
+
+    Note: as of Issue #224 the primary classifier is
+    :func:`_classify_from_checks`, which inspects per-check JSON. This
+    fallback is only used when the JSON probe itself is unavailable.
+    """
+    if exit_code == 0:
+        return "passed"
+    if exit_code == 2:
+        return "canceled"
+    if exit_code == 8:
+        return "incomplete"
+    return "incomplete"
+
+
+def _classify_from_checks(checks: "list[dict]") -> str:
+    """Classify CI status from `gh pr checks --json bucket,state,name` output.
+
+    gh's documented ``bucket`` values are
+    ``{pass, fail, pending, skipping, cancel}``.
+
+    * Empty list → ``incomplete`` (no checks reported).
+    * Any bucket in :data:`_FAILED_BUCKETS` (``fail``/``cancel``) →
+      ``failed``.
+    * Any bucket in :data:`_PENDING_BUCKETS` → ``incomplete``.
+    * All buckets in :data:`_PASSED_BUCKETS` (``pass``/``skipping``)
+      → ``passed``.
+    * Anything else (unrecognized bucket) → ``incomplete``
+      (conservative).
+    """
+    if not checks:
+        return "incomplete"
+    has_pending_or_unknown = False
+    for chk in checks:
+        bucket = (chk.get("bucket") or "").lower()
+        if bucket in _FAILED_BUCKETS:
+            return "failed"
+        if bucket in _PASSED_BUCKETS:
+            continue
+        # pending, empty, or any unrecognized bucket → conservative incomplete.
+        has_pending_or_unknown = True
+    return "incomplete" if has_pending_or_unknown else "passed"
+
+
+def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
+    """Return parsed `gh pr checks <pr> --json` results, or ``None`` on error.
+
+    Requests ``bucket,state,name``: ``bucket`` is the only field we
+    classify on (see :func:`_classify_from_checks`); ``state`` and
+    ``name`` are fetched purely to aid debugging when something goes
+    sideways.
+
+    ``gh pr checks`` exits non-zero on multiple non-error conditions:
+    ``8`` for "Checks pending" and ``1`` when at least one check has
+    failed (gh treats a red PR as a CLI error too). In both cases
+    gh still writes the requested JSON to stdout. So we trust the
+    JSON whenever it parses as a list, and only fall back when the
+    output is unparseable or the binary is missing entirely — that's
+    the only condition under which downgrading to the exit-code
+    classifier is appropriate.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "checks", str(pr),
+                "--repo", repo,
+                "--json", "bucket,state,name",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    try:
+        data = json.loads(result.stdout or "")
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    return [c for c in data if isinstance(c, dict)]
+
+
+def _watch_for_merge(
+    *,
+    pr: int,
+    repo: str,
+    interval: int,
+    db_path: Path,
+    max_seconds: int = MERGE_WATCH_MAX_SECONDS,
+    sleeper=time.sleep,
+    monotonic=time.monotonic,
+) -> str:
+    """Poll `gh pr view --json mergedAt` until merged or bound elapses.
+
+    Issue #317. On the first poll that returns a non-null ``mergedAt``,
+    invoke :func:`tools.run_complete_on_merge.complete_on_merge` to
+    drive the run row to its terminal state and return its result.
+    On bound exhaustion, append a ``pr_merge_watch_timeout`` event to
+    the DB and return ``"timeout"``. ``sleeper`` and ``monotonic`` are
+    injectable for tests.
+    """
+    from tools.run_complete_on_merge import (
+        complete_on_merge, fetch_pr_view, RESULT_ALREADY, RESULT_MERGED,
+        RESULT_MERGED_PENDING_CLEANUP, RESULT_NO_RUN, RESULT_NOT_YET,
+    )
+
+    deadline = monotonic() + max_seconds
+    while True:
+        try:
+            view = fetch_pr_view(pr, repo)
+        except RuntimeError as exc:
+            sys.stderr.write(
+                f"pr_watch: merge-watch: gh pr view failed: {exc}\n"
+            )
+            view = None
+
+        if view is not None and view.get("mergedAt"):
+            try:
+                result = complete_on_merge(
+                    pr=pr, repo=repo, db_path=db_path, pr_view=view,
+                )
+            except Exception as exc:  # noqa: BLE001
+                sys.stderr.write(
+                    f"pr_watch: merge-watch: complete_on_merge raised: {exc}\n"
+                )
+                return "error"
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch result: {result}\n"
+            )
+            if result in (
+                RESULT_MERGED, RESULT_MERGED_PENDING_CLEANUP,
+                RESULT_ALREADY, RESULT_NO_RUN,
+            ):
+                return result
+            # RESULT_NOT_YET shouldn't occur once mergedAt is set; treat
+            # defensively as "keep polling".
+
+        if monotonic() >= deadline:
+            _record_event(
+                db_path=db_path,
+                kind="pr_merge_watch_timeout",
+                payload={
+                    "pr": pr, "repo": repo,
+                    "max_seconds": max_seconds,
+                },
+            )
+            sys.stdout.write(
+                f"pr_watch: PR #{pr} merge-watch timed out after "
+                f"{max_seconds}s\n"
+            )
+            return "timeout"
+
+        sleeper(interval)
+
+
+def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
+    """Append a single event row via StateWriter (used for merge-watch timeout)."""
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+        writer = StateWriter(conn)
+        writer.append_event(kind=kind, actor="pr_watch", payload=payload)
+        writer.commit()
+    finally:
+        conn.close()
+
+
+def _pr_exists(pr: int, repo: str) -> bool:
+    try:
+        subprocess.run(
+            ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "number"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        return False
+    return True
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/pr_watch.py",
+        description="Watch a GitHub PR's CI checks and journal the result.",
+    )
+    # Accept both `--pr <n>` (preferred, unambiguous on PowerShell) and the
+    # legacy positional form `<n>` so direct python/bash invocations keep
+    # working. Exactly one of the two must be supplied.
+    parser.add_argument(
+        "--pr",
+        dest="pr_flag",
+        type=int,
+        default=None,
+        help="pull request number",
+    )
+    parser.add_argument(
+        "pr_positional",
+        nargs="?",
+        type=int,
+        default=None,
+        metavar="PR",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="OWNER/REPO; auto-detected via `gh repo view` if omitted",
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=30,
+        help="poll interval in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--merge-watch",
+        action="store_true",
+        help=(
+            "After CI passes, keep polling `gh pr view --json mergedAt` "
+            "for up to 24h and invoke tools/run_complete_on_merge.py on "
+            "the first mergedAt (Issue #317). Off by default — pr_watch "
+            "is otherwise a CI-only blocking call, and a 24h wall is "
+            "incompatible with the secretary's 2c/T6 review-feedback "
+            "loop. Opt in only when secretary actually wants to wait."
+        ),
+    )
+    # --no-merge-watch is kept as a no-op alias for back-compat with
+    # callers / tests that already opted out. The default is off either
+    # way; this keeps argv compatible with the prior turn's commits.
+    parser.add_argument(
+        "--no-merge-watch",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+
+    if args.pr_flag is not None and args.pr_positional is not None:
+        parser.error("specify the PR number once (either --pr or positional)")
+    pr_number = args.pr_flag if args.pr_flag is not None else args.pr_positional
+    if pr_number is None:
+        parser.error("missing PR number (use --pr <n>)")
+    if pr_number <= 0:
+        parser.error("PR number must be a positive integer")
+    if args.interval <= 0:
+        parser.error("--interval must be a positive integer")
+    args.pr = pr_number
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    if not _pr_exists(args.pr, repo):
+        sys.stderr.write(
+            f"tools/pr_watch.py: error: PR #{args.pr} not found in {repo}\n"
+        )
+        return 2
+
+    cmd = [
+        "gh", "pr", "checks", str(args.pr),
+        "--repo", repo,
+        "--watch",
+        "--interval", str(args.interval),
+    ]
+    started = time.monotonic()
+    canceled = False
+    try:
+        completed = subprocess.run(cmd)
+        exit_code = completed.returncode
+    except KeyboardInterrupt:
+        # Normalize parent-side cancellation to gh's standard exit code 2
+        # so callers (and the journal status mapping) see a portable signal.
+        exit_code = 2
+        canceled = True
+    duration = int(round(time.monotonic() - started))
+
+    # gh's documented cancellation exit code is 2 (parent SIGINT or
+    # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
+    # genuine cancellation with whatever the JSON probe returns.
+    if canceled or exit_code == 2:
+        status = "canceled"
+    else:
+        # Issue #224: gh exit 1 from a transient watch-loop error must not
+        # be conflated with "CI failed". Re-derive the status from the
+        # per-check JSON; only fall back to the exit code if the probe
+        # itself fails.
+        checks = _fetch_checks(args.pr, repo)
+        if checks is None:
+            sys.stderr.write(
+                "tools/pr_watch.py: warning: could not query check results "
+                "via `gh pr checks --json`; falling back to exit-code "
+                "classification.\n"
+            )
+            status = _classify(exit_code)
+        else:
+            status = _classify_from_checks(checks)
+
+    _record_ci_completed(
+        db_path=JOURNAL_PATH,
+        pr=args.pr,
+        repo=repo,
+        status=status,
+        duration=duration,
+    )
+
+    sys.stdout.write(f"pr_watch: PR #{args.pr} {status} ({duration}s)\n")
+
+    # Issue #317: only enter merge-watch when CI actually passed and
+    # the caller explicitly opted in via --merge-watch. The default is
+    # off so pr_watch stays a "CI passed → return" command compatible
+    # with secretary's 2c/T6 review-feedback loop.
+    if status == "passed" and args.merge_watch and not args.no_merge_watch:
+        merge_result = _watch_for_merge(
+            pr=args.pr,
+            repo=repo,
+            interval=args.interval,
+            db_path=JOURNAL_PATH,
+        )
+        # Codex Major: surface merge-watch failure modes via exit code
+        # so callers can distinguish "CI passed but PR did not merge in
+        # 24h" / "helper raised" from "CI passed and we successfully
+        # transitioned the run". Don't override a non-zero CI exit
+        # code — that already signaled trouble.
+        if exit_code == 0 and merge_result in ("timeout", "error", "no_run"):
+            # Codex round-2 Major: no_run means we observed a merge but
+            # could not resolve the PR back to a runs row, so the
+            # status flip didn't happen and the secretary needs to
+            # intervene. Surface that as exit 9 so callers don't treat
+            # it as success.
+            exit_code = 9
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""PR-merge auto-completion helper (Issue #317).
+
+Given a PR number, resolves the merge metadata via ``gh pr view`` and,
+if the PR is merged, runs the canonical ``StateWriter.transaction()``
+to drive the run row to its terminal state:
+
+* ``runs.status = 'completed'``
+* ``runs.pr_state = 'merged'``
+* ``runs.pr_url`` and ``runs.commit_short`` / ``runs.commit_full`` set
+  from the PR view payload
+* ``runs.completed_at`` set to the PR's ``mergedAt``
+* one ``pr_merged`` event appended to the events table
+
+The helper replaces the inline ``python -c`` block that used to live
+in ``.claude/skills/org-delegate/SKILL.md`` Step 5 2b-ii. The legacy
+hand-rolled snippet is preserved verbatim under
+``docs/legacy/pr-merge-completion-manual.md`` for archaeology only.
+
+Usage::
+
+    python tools/run_complete_on_merge.py --pr <N> \\
+        [--repo OWNER/REPO] [--task-id <id>] [--db-path <path>]
+
+The helper is **idempotent**: running it twice for the same PR is a
+no-op on the second call (no double event row, no status flip).
+
+Also exported as :func:`complete_on_merge` for in-process callers
+(e.g. ``tools/pr_watch.py``'s merge-watch loop).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+DEFAULT_DB_PATH = REPO_ROOT / ".state" / "state.db"
+
+
+# Return codes for :func:`complete_on_merge`. Stable strings so callers
+# (pr_watch's merge-watch loop, tests) can branch without parsing logs.
+RESULT_MERGED = "merged"        # PR was merged this call; PR metadata recorded.
+RESULT_ALREADY = "already"      # PR was merged previously; DB already has metadata + event.
+RESULT_NOT_YET = "not_yet"      # PR is open / draft; nothing written.
+RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
+# Codex review (rounds 1-3): the helper records the merge fact
+# (pr_state='merged', commit, completed_at, pr_merged event) but never
+# flips runs.status itself. The status transition is gated on the
+# secretary running worktree remove / CLOSE_PANE / remove_worker_dir
+# and on the dispatcher closing the pane / writing the worker-state
+# final update (delegation-lifecycle-contract §T5, state-schema-contract
+# §3.1). Owning all of that from a one-shot subprocess is out of scope.
+# RESULT_MERGED_PENDING_CLEANUP is kept as an alias for
+# back-compat with callers that imported the symbol.
+RESULT_MERGED_PENDING_CLEANUP = RESULT_MERGED
+
+
+def _ensure_gh_installed() -> None:
+    if shutil.which("gh") is None:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: GitHub CLI (gh) not "
+            "found in PATH.\n"
+        )
+        sys.exit(127)
+
+
+def _resolve_repo() -> str:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: failed to auto-detect "
+            f"repo via `gh repo view`: {exc.stderr.strip() or exc}\n"
+        )
+        sys.exit(2)
+    try:
+        return json.loads(result.stdout)["nameWithOwner"]
+    except (json.JSONDecodeError, KeyError) as exc:
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: error: unexpected `gh repo "
+            f"view` output: {exc}\n"
+        )
+        sys.exit(2)
+
+
+def fetch_pr_view(pr: int, repo: str) -> dict:
+    """Return the parsed `gh pr view` payload for the given PR.
+
+    Fields requested: ``number,url,state,mergedAt,mergeCommit,headRefName``.
+    Raises ``RuntimeError`` if gh fails or the JSON is unparseable —
+    callers (CLI / merge-watch) are expected to surface that and retry
+    or exit.
+    """
+    proc = subprocess.run(
+        [
+            "gh", "pr", "view", str(pr),
+            "--repo", repo,
+            "--json", "number,url,state,mergedAt,mergeCommit,headRefName",
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr view {pr} (repo={repo}) failed: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh pr view {pr} returned unparseable JSON: {exc}"
+        ) from None
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"gh pr view {pr} returned non-object JSON: {type(data).__name__}"
+        )
+    return data
+
+
+def _resolve_task_id(conn, *, pr: int, repo: str, pr_url: str,
+                     head_ref: Optional[str]) -> Optional[str]:
+    """Look up the task_id for a PR. Tries ``runs.pr_url`` then ``runs.branch``.
+
+    Returns None if no candidate row exists; the caller should warn and
+    exit with :data:`RESULT_NO_RUN`. We do not invent a row — the helper's
+    contract is to drive an *existing* run to terminal, not to retroactively
+    create state.
+    """
+    if pr_url:
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE pr_url = ? LIMIT 1", (pr_url,)
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+        # gh sometimes returns a URL with trailing slash variations; try
+        # a substring match on the canonical /pull/<n> tail.
+        tail = f"/{repo}/pull/{pr}"
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE pr_url LIKE ? LIMIT 1",
+            (f"%{tail}",),
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+    if head_ref:
+        # Codex Major: scope branch fallback to non-terminal runs so a
+        # past completed run with the same branch can't be mistakenly
+        # re-completed and have a stray pr_merged event appended.
+        row = conn.execute(
+            "SELECT task_id FROM runs WHERE branch = ? "
+            "AND status NOT IN ('completed','failed','abandoned') "
+            "ORDER BY id DESC LIMIT 1",
+            (head_ref,),
+        ).fetchone()
+        if row is not None:
+            return row["task_id"]
+    return None
+
+
+def _short_sha(full: Optional[str]) -> Optional[str]:
+    if not full:
+        return None
+    return full[:7]
+
+
+def complete_on_merge(
+    *,
+    pr: int,
+    repo: str,
+    task_id: Optional[str] = None,
+    db_path: Optional[Path] = None,
+    pr_view: Optional[dict] = None,
+) -> str:
+    """Drive the run for ``pr`` to its terminal merged state.
+
+    Returns one of :data:`RESULT_MERGED`, :data:`RESULT_ALREADY`,
+    :data:`RESULT_NOT_YET`, :data:`RESULT_NO_RUN`.
+
+    ``pr_view`` may be supplied by callers that already fetched the
+    payload (e.g. pr_watch's merge-watch loop); when omitted the helper
+    fetches it via :func:`fetch_pr_view`.
+    """
+    db_path = Path(db_path) if db_path is not None else DEFAULT_DB_PATH
+    if pr_view is None:
+        pr_view = fetch_pr_view(pr, repo)
+
+    merged_at = pr_view.get("mergedAt")
+    if not merged_at:
+        return RESULT_NOT_YET
+
+    pr_url = pr_view.get("url") or ""
+    head_ref = pr_view.get("headRefName")
+    merge_commit = pr_view.get("mergeCommit") or {}
+    commit_full = (merge_commit.get("oid") if isinstance(merge_commit, dict)
+                   else None)
+    commit_short = _short_sha(commit_full)
+
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    is_new_db = not db_path.exists()
+    conn = connect(db_path)
+    try:
+        if is_new_db:
+            apply_schema(conn)
+
+        resolved_task_id = task_id or _resolve_task_id(
+            conn, pr=pr, repo=repo, pr_url=pr_url, head_ref=head_ref,
+        )
+        if resolved_task_id is None:
+            sys.stderr.write(
+                "tools/run_complete_on_merge.py: warning: no run row "
+                f"matches PR #{pr} (pr_url={pr_url!r}, head_ref="
+                f"{head_ref!r}); skipping.\n"
+            )
+            return RESULT_NO_RUN
+
+        run_row = conn.execute(
+            "SELECT r.task_id, r.status, r.pr_state, r.pattern, "
+            "p.slug AS project_slug "
+            "FROM runs r JOIN projects p ON p.id = r.project_id "
+            "WHERE r.task_id = ?",
+            (resolved_task_id,),
+        ).fetchone()
+        if run_row is None:
+            sys.stderr.write(
+                "tools/run_complete_on_merge.py: warning: task_id "
+                f"{resolved_task_id!r} resolved but row vanished; skipping.\n"
+            )
+            return RESULT_NO_RUN
+
+        already_event = conn.execute(
+            "SELECT 1 FROM events e JOIN runs r ON r.id = e.run_id "
+            "WHERE r.task_id = ? AND e.kind = 'pr_merged' LIMIT 1",
+            (resolved_task_id,),
+        ).fetchone()
+        if (run_row["pr_state"] == "merged"
+                and already_event is not None):
+            # Either the run is fully completed (Pattern A auto-close
+            # path) or it has been left in 'review' awaiting secretary
+            # cleanup (Pattern B/C/D). Either way, we already wrote
+            # the PR metadata and the event row; do not double-write.
+            return RESULT_ALREADY
+
+        project_slug = run_row["project_slug"]
+        pattern = (run_row["pattern"] or "B").upper()
+        # Codex round 3 Blocker: even Pattern A close requires
+        # dispatcher-side pane close / worker_closed / worker-state
+        # final update (delegation-lifecycle-contract §T5). A
+        # subprocess helper cannot orchestrate those, so the helper
+        # records the merge fact (pr_state, commit, completed_at,
+        # pr_merged event) and leaves the runs.status flip to the
+        # secretary's manual cleanup step in 2b-ii.
+
+        # claude_org_root=None lets StateWriter auto-detect from the
+        # connection's database file (`<root>/.state/state.db`). That
+        # keeps the post-commit snapshot regen pointed at the same
+        # repo as the DB we just wrote to — important when pr_watch
+        # invokes us from a worker dir, and important for tests that
+        # use a temp state.db path.
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=resolved_task_id,
+                project_slug=project_slug,
+                pr_url=pr_url or None,
+                pr_state="merged",
+                commit_short=commit_short,
+                commit_full=commit_full,
+            )
+            # Always record completed_at without flipping runs.status —
+            # secretary owns the status transition (see comment above).
+            w.conn.execute(
+                "UPDATE runs SET completed_at = COALESCE(completed_at, ?) "
+                "WHERE task_id = ?",
+                (merged_at, resolved_task_id),
+            )
+            w.append_event(
+                kind="pr_merged",
+                actor="run_complete_on_merge",
+                payload={
+                    # `task` matches docs/journal-events.md §PR / push.
+                    "task": resolved_task_id,
+                    "pr": pr,
+                    "repo": repo,
+                    "pr_url": pr_url,
+                    "merge_commit": commit_full,
+                    "merged_at": merged_at,
+                    "pattern": pattern,
+                    "auto_completed": False,
+                },
+                run_task_id=resolved_task_id,
+            )
+        sys.stderr.write(
+            "tools/run_complete_on_merge.py: notice: PR merged for "
+            f"task {resolved_task_id} (pattern {pattern}); pr_state set "
+            "to 'merged' and completed_at recorded, but runs.status "
+            "left untouched — secretary must complete worktree remove / "
+            "CLOSE_PANE / remove_worker_dir and call "
+            "update_run_status('<task>', 'completed') (Step 5 2b-ii / "
+            "delegation-lifecycle-contract §T5).\n"
+        )
+        return RESULT_MERGED
+    finally:
+        conn.close()
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/run_complete_on_merge.py",
+        description=(
+            "Mark a run completed when its PR has been merged on GitHub."
+        ),
+    )
+    parser.add_argument("--pr", type=int, required=True,
+                        help="pull request number")
+    parser.add_argument("--repo", default=None,
+                        help="OWNER/REPO; auto-detected via gh repo view")
+    parser.add_argument("--task-id", default=None,
+                        help="task_id of the run to complete; auto-resolved "
+                             "from runs.pr_url / runs.branch when omitted")
+    parser.add_argument("--db-path", default=None,
+                        help=f"path to state.db (default: {DEFAULT_DB_PATH})")
+    args = parser.parse_args(argv)
+
+    if args.pr <= 0:
+        parser.error("--pr must be a positive integer")
+
+    _ensure_gh_installed()
+    repo = args.repo or _resolve_repo()
+
+    try:
+        result = complete_on_merge(
+            pr=args.pr,
+            repo=repo,
+            task_id=args.task_id,
+            db_path=Path(args.db_path) if args.db_path else None,
+        )
+    except RuntimeError as exc:
+        sys.stderr.write(f"tools/run_complete_on_merge.py: error: {exc}\n")
+        return 2
+
+    sys.stdout.write(f"run_complete_on_merge: PR #{args.pr} {result}\n")
+    # not_yet is not a failure — the caller polls. Codex round-3 Major:
+    # no_run IS a failure (PR merged but no run row matched), so the
+    # secretary's manual invocation must see a non-zero exit code.
+    if result == RESULT_NO_RUN:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -1,0 +1,802 @@
+"""Unit tests for tools/pr_watch.py (Issue #204, Issue #224, M4 Issue #267).
+
+Mocks the gh CLI subprocess via monkey-patching so the suite stays
+hermetic. M4 (Issue #267) routes ``ci_completed`` to the DB events
+table; the test helper ``_read_ci_event`` reads back via sqlite3.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import pr_watch  # noqa: E402
+
+
+def _read_ci_event(db_path: Path) -> dict:
+    """Return the (single) ci_completed event from the DB as a payload dict
+    flattened with the ``ts`` / ``event`` keys the tests expect."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT occurred_at, kind, payload_json FROM events "
+            "WHERE kind = 'ci_completed' ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    if len(rows) != 1:
+        raise AssertionError(f"expected 1 ci_completed row, got {len(rows)}")
+    row = rows[0]
+    payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+    out = dict(payload)
+    out["event"] = row["kind"]
+    out["ts"] = row["occurred_at"]
+    return out
+
+
+def _count_ci_events(db_path: Path) -> int:
+    if not db_path.exists():
+        return 0
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return int(conn.execute(
+            "SELECT COUNT(*) FROM events WHERE kind = 'ci_completed'"
+        ).fetchone()[0])
+    finally:
+        conn.close()
+
+
+class ClassifyTests(unittest.TestCase):
+    """Fallback classifier (used only when JSON probe is unavailable).
+
+    Per `gh help exit-codes`, exit 8 is "Checks pending" — NOT failure.
+    Issue #224 corrects the prior mapping.
+    """
+
+    def test_zero_is_passed(self) -> None:
+        self.assertEqual(pr_watch._classify(0), "passed")
+
+    def test_eight_is_incomplete(self) -> None:
+        # gh exit 8 = "Checks pending", per gh's help text.
+        self.assertEqual(pr_watch._classify(8), "incomplete")
+
+    def test_two_is_canceled(self) -> None:
+        self.assertEqual(pr_watch._classify(2), "canceled")
+
+    def test_other_nonzero_is_incomplete(self) -> None:
+        # Conservative: treat unknown gh errors as incomplete rather
+        # than libelling the PR as failed.
+        self.assertEqual(pr_watch._classify(1), "incomplete")
+        self.assertEqual(pr_watch._classify(127), "incomplete")
+
+
+def _make_fake_run(
+    watch_exit: int = 0,
+    checks_json: "list[dict] | None" = None,
+    checks_raises: "Exception | None" = None,
+    checks_json_exit: "int | None" = None,
+):
+    """Build a `subprocess.run` stub matching the call sites in pr_watch.
+
+    Recognized commands:
+
+    * ``gh pr view ... --json number`` → success (PR exists probe)
+    * ``gh pr checks <pr> --json ...`` → ``checks_json`` (or raise)
+    * ``gh pr checks <pr> --watch ...`` → returncode = ``watch_exit``
+    """
+    if checks_json is None:
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+
+    # gh exits non-zero (1) when at least one check is failing, and 8
+    # when checks are still pending — but in both cases it still writes
+    # the requested JSON. Mirror that here so the tests exercise the
+    # real protocol, not an idealized one.
+    def _gh_exit_for_checks(payload):
+        if checks_json_exit is not None:
+            return checks_json_exit
+        for chk in payload:
+            b = (chk.get("bucket") or "").lower()
+            if b in ("fail", "cancel"):
+                return 1
+            if b == "pending":
+                return 8
+        return 0
+
+    def fake_run(cmd, *args, **kwargs):
+        if "view" in cmd and "--json" in cmd and "number" in cmd:
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+        if "checks" in cmd and "--json" in cmd:
+            if checks_raises is not None:
+                raise checks_raises
+            return mock.Mock(
+                returncode=_gh_exit_for_checks(checks_json),
+                stdout=json.dumps(checks_json),
+                stderr="",
+            )
+        # The watched run.
+        return mock.Mock(returncode=watch_exit)
+
+    return fake_run
+
+
+class ArgFormTests(unittest.TestCase):
+    """Both `--pr <n>` and the legacy positional form must parse identically."""
+
+    def _run(self, argv: "list[str]") -> "tuple[int, dict]":
+        fake_run = _make_fake_run(watch_exit=0)
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                # Issue #317: existing CI-only tests opt out of the
+                # post-CI merge-watch loop; that path is exercised
+                # separately in MergeWatchTests below.
+                # Issue #317 round 3: merge-watch is now off by default,
+                # so existing CI-only tests don't need an opt-out flag.
+                rc = pr_watch.main(argv)
+            rec = _read_ci_event(journal)
+            return rc, rec
+
+    def test_long_form(self) -> None:
+        rc, rec = self._run(["--pr", "42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_positional_form(self) -> None:
+        rc, rec = self._run(["42", "--repo", "octo/repo"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(rec["pr"], 42)
+
+    def test_both_forms_rejected(self) -> None:
+        with self.assertRaises(SystemExit):
+            pr_watch.main(["7", "--pr", "9", "--repo", "octo/repo"])
+
+
+class JournalEmitTests(unittest.TestCase):
+    def _run(
+        self,
+        tmp_journal: Path,
+        gh_exit: int,
+        checks_json: "list[dict] | None" = None,
+        checks_raises: "Exception | None" = None,
+    ) -> int:
+        fake_run = _make_fake_run(
+            watch_exit=gh_exit,
+            checks_json=checks_json,
+            checks_raises=checks_raises,
+        )
+        with mock.patch.object(pr_watch, "JOURNAL_PATH", tmp_journal), \
+             mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+             mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+             mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
+            return pr_watch.main([
+                "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+            ])
+
+    def test_passed_emits_ci_completed(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(journal, gh_exit=0)
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["event"], "ci_completed")
+            self.assertEqual(rec["pr"], 205)
+            self.assertEqual(rec["repo"], "octo/repo")
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(rec["duration_sec"], 42)
+            self.assertIn("ts", rec)
+
+    def test_failed_status_from_check_bucket(self) -> None:
+        """A `fail` bucket in the JSON probe → status=failed."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=8,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+
+    def test_transient_gh_error_is_not_failed(self) -> None:
+        """Issue #224: gh exit 1 with all checks `pass` must classify as passed.
+
+        Regression: the old code conflated any non-zero exit with CI
+        failure, so a transient error in `gh pr checks --watch` (e.g.
+        a brief network blip) would be journaled as ``status=failed``
+        even when CI itself was green.
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=1,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "pass"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+
+    def test_pending_check_is_incomplete(self) -> None:
+        """A still-running check → status=incomplete (new in #224)."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
+                ],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_empty_checks_is_incomplete(self) -> None:
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(journal, gh_exit=0, checks_json=[])
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "incomplete")
+
+    def test_failed_check_with_gh_json_exit_1(self) -> None:
+        """gh exits 1 when a check failed but still emits JSON.
+
+        Regression: the previous implementation only trusted the JSON
+        when gh exited 0 or 8, so a real CI failure (gh exit 1 + valid
+        JSON listing a `fail` bucket) would be discarded and fall
+        through to the exit-code classifier — defeating Issue #224(a).
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=1,  # watch loop saw the failure too
+                checks_json=[
+                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                    {"name": "test", "state": "COMPLETED", "bucket": "fail"},
+                ],
+                # `_gh_exit_for_checks` will emit 1 for this payload
+                # (failure present), matching real gh behavior.
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+
+    def test_gh_exit_2_is_canceled(self) -> None:
+        """gh exit 2 = cancellation. Must NOT be overwritten by JSON probe.
+
+        Regression: an earlier draft only honored Python-side
+        KeyboardInterrupt, so a Ctrl-C delivered to gh itself (exit 2)
+        would have been re-classified as passed/failed/incomplete by
+        the JSON probe. The journal must reflect cancellation so the
+        secretary can distinguish "user aborted" from "CI verdict".
+        """
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=2,
+                checks_json=[{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
+            )
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "canceled")
+
+    def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
+        """If `gh pr checks --json` itself fails, use exit-code mapping."""
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            self._run(
+                journal,
+                gh_exit=0,
+                checks_raises=FileNotFoundError("gh missing"),
+            )
+            rec = _read_ci_event(journal)
+            # exit 0 → passed via _classify fallback.
+            self.assertEqual(rec["status"], "passed")
+
+
+class ClassifyFromChecksTests(unittest.TestCase):
+    def test_all_pass(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "pass"}]
+            ),
+            "passed",
+        )
+
+    def test_skipping_counts_as_passed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "skipping"}]
+            ),
+            "passed",
+        )
+
+    def test_fail_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "fail"}]
+            ),
+            "failed",
+        )
+
+    def test_cancel_bucket_is_failed(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "cancel"}]
+            ),
+            "failed",
+        )
+
+    def test_pending_is_incomplete(self) -> None:
+        self.assertEqual(
+            pr_watch._classify_from_checks(
+                [{"bucket": "pass"}, {"bucket": "pending"}]
+            ),
+            "incomplete",
+        )
+
+    def test_empty_is_incomplete(self) -> None:
+        self.assertEqual(pr_watch._classify_from_checks([]), "incomplete")
+
+    def test_unknown_bucket_is_incomplete(self) -> None:
+        # Conservative: unrecognized bucket → don't claim "passed".
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"bucket": "mystery"}]),
+            "incomplete",
+        )
+
+    def test_case_insensitive_bucket(self) -> None:
+        # gh emits lowercase, but be defensive.
+        self.assertEqual(
+            pr_watch._classify_from_checks([{"bucket": "PASS"}]),
+            "passed",
+        )
+
+
+class PowerShellInterpreterProbeTests(unittest.TestCase):
+    """Issue #224 (b): pr-watch.ps1 must reject Pythons that lack core_harness.
+
+    These tests exercise the actual PowerShell script via pwsh; they are
+    skipped on hosts where pwsh isn't available (e.g. minimal CI images).
+    The probe logic itself is small and self-contained, so we extract just
+    the Test-Interpreter function and call it with synthetic shim
+    interpreters.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.pwsh = shutil.which("pwsh") or shutil.which("powershell")
+        if not cls.pwsh:
+            raise unittest.SkipTest("pwsh/powershell not available")
+        cls.script = (
+            Path(__file__).resolve().parent / "pr-watch.ps1"
+        )
+        if not cls.script.exists():
+            raise unittest.SkipTest("pr-watch.ps1 not found")
+
+    def _run_probe(self, shim_body: str) -> bool:
+        """Write a fake interpreter shim, source Test-Interpreter, return result."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            tdp = Path(td)
+            if os.name == "nt":
+                shim = tdp / "fakepy.cmd"
+                shim.write_text(shim_body, encoding="ascii")
+                exe_arg = str(shim)
+            else:
+                shim = tdp / "fakepy"
+                shim.write_text("#!/usr/bin/env bash\n" + shim_body, encoding="ascii")
+                shim.chmod(0o755)
+                exe_arg = str(shim)
+            # We can't dot-source pr-watch.ps1 directly (it has a mandatory
+            # -PR param that would error out), so extract just the
+            # Test-Interpreter function block via regex and Invoke-Expression.
+            extract = (
+                "$src = Get-Content -Raw '" + str(self.script).replace("'", "''") + "'; "
+                "if ($src -match '(?ms)function Test-Interpreter \\{.*?^\\}') "
+                "{ Invoke-Expression $Matches[0] } "
+                "else { Write-Error 'function not found'; exit 99 }; "
+                "if (Test-Interpreter -Exe '" + exe_arg.replace("'", "''") + "' -Prefix @()) "
+                "{ exit 0 } else { exit 1 }"
+            )
+            res = subprocess.run(
+                [self.pwsh, "-NoProfile", "-Command", extract],
+                capture_output=True,
+                text=True,
+            )
+            return res.returncode == 0
+
+    def test_version_ok_import_fail_is_rejected(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( echo ImportError 1>&2 & exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then echo 'ImportError' 1>&2; exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter should reject a Python that fails the import check",
+        )
+
+    def test_python_2_is_rejected(self) -> None:
+        """A `--version`-passing Python 2 must not be accepted.
+
+        The combined `-c` probe asserts sys.version_info[0]==3, so a
+        shim that simulates Py2 by exiting nonzero on the `-c` call
+        should be rejected even though `--version` succeeds.
+        """
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 2.7.18 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 1 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 2.7.18'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 1; fi\n"
+                "exit 2\n"
+            )
+        self.assertFalse(
+            self._run_probe(shim_body),
+            "Test-Interpreter must reject Python 2 even if --version exits 0",
+        )
+
+    def test_version_ok_import_ok_is_accepted(self) -> None:
+        if os.name == "nt":
+            shim_body = (
+                "@echo off\r\n"
+                "if \"%~1\"==\"--version\" ( echo Python 3.10.0 & exit /b 0 )\r\n"
+                "if \"%~1\"==\"-c\" ( exit /b 0 )\r\n"
+                "exit /b 2\r\n"
+            )
+        else:
+            shim_body = (
+                "if [ \"$1\" = \"--version\" ]; then echo 'Python 3.10.0'; exit 0; fi\n"
+                "if [ \"$1\" = \"-c\" ]; then exit 0; fi\n"
+                "exit 2\n"
+            )
+        self.assertTrue(
+            self._run_probe(shim_body),
+            "Test-Interpreter should accept a Python that passes both probes",
+        )
+
+
+class TempDir:
+    def __enter__(self) -> Path:
+        import tempfile
+        self._dir = tempfile.TemporaryDirectory()
+        return Path(self._dir.name)
+
+    def __exit__(self, *exc) -> None:
+        self._dir.cleanup()
+
+
+class MergeWatchTests(unittest.TestCase):
+    """Issue #317: post-CI merge-watch loop in pr_watch.main."""
+
+    def _seed_run_for_merge(self, db: Path, *, pr_url: str,
+                            pattern: str = "A") -> None:
+        """Seed a run pointing at the PR. Default pattern='A' so the
+        helper performs the full status transition; pass 'B' to test
+        the pending-cleanup path."""
+        from tools.state_db import apply_schema, connect
+        from tools.state_db.writer import StateWriter
+
+        apply_schema(connect(db))
+        conn = connect(db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.upsert_run(
+                    task_id="t-merge-watch",
+                    project_slug="claude-org",
+                    pattern=pattern,
+                    title="merge-watch test",
+                    status="review",
+                    branch="feat/merge-watch",
+                    pr_url=pr_url,
+                    pr_state="open",
+                )
+        finally:
+            conn.close()
+
+    def _build_run_with_view_sequence(
+        self,
+        watch_exit: int,
+        view_sequence: "list[dict | None]",
+    ):
+        """Like _make_fake_run but threads a sequence of `gh pr view --json`
+        responses for the merge-watch loop. The first `gh pr view --json
+        number` (PR-exists probe) returns success; the *second* and
+        subsequent `view --json` calls cycle through ``view_sequence``."""
+        # Default check JSON for the CI-watch portion (status=passed).
+        checks_json = [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}]
+
+        # Mutable index threaded across closures — track which entry of
+        # view_sequence the next merge-watch poll should consume.
+        view_idx = {"i": 0}
+        seen_existence_probe = {"v": False}
+
+        def fake_run(cmd, *args, **kwargs):
+            # PR-exists probe: `gh pr view <pr> --repo <r> --json number`.
+            if (cmd[:3] == ["gh", "pr", "view"]
+                    and "--json" in cmd
+                    and cmd[cmd.index("--json") + 1] == "number"):
+                seen_existence_probe["v"] = True
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            # Merge-watch probe: `gh pr view <pr> --json number,url,...`
+            if cmd[:3] == ["gh", "pr", "view"] and "--json" in cmd:
+                idx = view_idx["i"]
+                if idx >= len(view_sequence):
+                    payload = view_sequence[-1]
+                else:
+                    payload = view_sequence[idx]
+                    view_idx["i"] += 1
+                if payload is None:
+                    return mock.Mock(returncode=1, stdout="", stderr="boom")
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(payload),
+                    stderr="",
+                )
+            # `gh pr checks --json` for CI classification.
+            if "checks" in cmd and "--json" in cmd:
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(checks_json),
+                    stderr="",
+                )
+            # The watched `gh pr checks --watch` run.
+            return mock.Mock(returncode=watch_exit)
+
+        return fake_run
+
+    def test_ci_pass_then_merged_records_metadata(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            pr_url = "https://github.com/octo/repo/pull/777"
+            self._seed_run_for_merge(db, pr_url=pr_url)
+
+            view_merged = {
+                "number": 777, "url": pr_url, "state": "MERGED",
+                "mergedAt": "2026-05-06T03:21:00Z",
+                "mergeCommit": {"oid": "f" * 40},
+                "headRefName": "feat/merge-watch",
+            }
+            fake_run = self._build_run_with_view_sequence(
+                watch_exit=0, view_sequence=[view_merged],
+            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "777", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+            self.assertEqual(rc, 0)
+
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status, pr_state, completed_at "
+                    "FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                # status stays in 'review' — secretary owns the flip.
+                self.assertEqual(row["status"], "review")
+                self.assertEqual(row["pr_state"], "merged")
+                self.assertEqual(row["completed_at"], "2026-05-06T03:21:00Z")
+                merged_count = conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE kind = 'pr_merged'"
+                ).fetchone()[0]
+                self.assertEqual(merged_count, 1)
+            finally:
+                conn.close()
+
+    def test_default_skips_merge_watch(self) -> None:
+        """Issue #317 round 3: merge-watch is opt-in, off by default.
+
+        Without `--merge-watch`, even on CI pass pr_watch must NOT
+        poll `gh pr view --json mergedAt`.
+        """
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/111",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "111", "--repo", "octo/repo", "--interval", "1",
+                ])
+
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
+
+    def test_ci_fail_skips_merge_watch(self) -> None:
+        """When CI did not pass, pr_watch must not poll for merge."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+
+            # Fail the CI; assert no further `view --json` call is made.
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=1,
+                        stdout=json.dumps([
+                            {"name": "ci", "state": "COMPLETED",
+                             "bucket": "fail"}
+                        ]),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=1)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "888", "--repo", "octo/repo", "--interval", "1",
+                    "--merge-watch",
+                ])
+
+            # CI failed → no merge-watch even with --merge-watch on.
+            view_calls = [c for c in calls
+                          if c[:3] == ["gh", "pr", "view"]
+                          and "url" in str(c)]
+            self.assertEqual(view_calls, [])
+
+    def test_no_merge_watch_flag_skips_loop(self) -> None:
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            self._seed_run_for_merge(
+                db, pr_url="https://github.com/octo/repo/pull/999",
+            )
+
+            calls: list[list[str]] = []
+
+            def fake_run(cmd, *args, **kwargs):
+                calls.append(list(cmd))
+                if (cmd[:3] == ["gh", "pr", "view"]
+                        and "number" in cmd):
+                    return mock.Mock(returncode=0, stdout="{}", stderr="")
+                if "checks" in cmd and "--json" in cmd:
+                    return mock.Mock(
+                        returncode=0,
+                        stdout=json.dumps(
+                            [{"name": "ci", "state": "COMPLETED",
+                              "bucket": "pass"}]
+                        ),
+                        stderr="",
+                    )
+                return mock.Mock(returncode=0)
+
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
+                pr_watch.main([
+                    "--pr", "999", "--repo", "octo/repo", "--interval", "1",
+                    "--no-merge-watch",
+                ])
+
+            # Run row must NOT have been completed.
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT status FROM runs WHERE task_id = 't-merge-watch'"
+                ).fetchone()
+                self.assertEqual(row["status"], "review")
+            finally:
+                conn.close()
+
+    def test_watch_for_merge_timeout_records_event(self) -> None:
+        """Bound exhaustion appends pr_merge_watch_timeout."""
+        with TempDir() as tmp:
+            db = tmp / ".state" / "state.db"
+            db.parent.mkdir(parents=True)
+            view_pending = {
+                "number": 555, "url": "https://github.com/octo/repo/pull/555",
+                "state": "OPEN", "mergedAt": None,
+                "mergeCommit": None, "headRefName": "feat/x",
+            }
+
+            from tools.state_db import apply_schema, connect
+            apply_schema(connect(db))
+
+            # Patch view fetch + monotonic so the loop exhausts after
+            # one iteration. monotonic side_effect: start=0.0, then
+            # 99999.0 to immediately exceed deadline.
+            def fake_run(cmd, *args, **kwargs):
+                if cmd[:3] == ["gh", "pr", "view"]:
+                    return mock.Mock(
+                        returncode=0, stdout=json.dumps(view_pending),
+                        stderr="",
+                    )
+                raise AssertionError(f"unexpected cmd: {cmd}")
+
+            with mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                result = pr_watch._watch_for_merge(
+                    pr=555, repo="octo/repo", interval=0,
+                    db_path=db, max_seconds=60,
+                    sleeper=lambda _s: None,
+                    monotonic=mock.Mock(side_effect=[0.0, 100.0, 100.0]),
+                )
+            self.assertEqual(result, "timeout")
+
+            conn = sqlite3.connect(str(db))
+            try:
+                cnt = conn.execute(
+                    "SELECT COUNT(*) FROM events "
+                    "WHERE kind = 'pr_merge_watch_timeout'"
+                ).fetchone()[0]
+                self.assertEqual(cnt, 1)
+            finally:
+                conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -1,0 +1,329 @@
+"""Unit tests for tools/run_complete_on_merge.py (Issue #317).
+
+The gh CLI is mocked via subprocess.run side_effect; the DB writes go
+to a temp state.db built from schema.sql.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import run_complete_on_merge  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+REPO = "octo/repo"
+PR = 317
+PR_URL = f"https://github.com/{REPO}/pull/{PR}"
+BRANCH = "feat/issue-317-pr-merge-helper"
+TASK_ID = "issue-317-pr-merge-helper"
+MERGED_AT = "2026-05-06T03:21:00Z"
+MERGE_OID = "abcdef0123456789abcdef0123456789abcdef01"
+
+
+def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH,
+              pattern: str = "A") -> None:
+    """Create a fresh DB with one in-progress run row pointing at the PR.
+
+    Default pattern is 'A' so the helper performs the full status
+    transition; pattern-B tests opt in explicitly via ``pattern='B'``.
+    """
+    apply_schema(connect(db_path))
+    conn = connect(db_path)
+    try:
+        with StateWriter(conn).transaction() as w:
+            w.upsert_run(
+                task_id=TASK_ID,
+                project_slug="claude-org",
+                pattern=pattern,
+                title="PR-merge auto-completion helper",
+                status="review",
+                branch=branch,
+                pr_url=pr_url,
+                pr_state="open",
+            )
+    finally:
+        conn.close()
+
+
+def _make_pr_view(*, merged_at=MERGED_AT, merge_oid=MERGE_OID) -> dict:
+    return {
+        "number": PR,
+        "url": PR_URL,
+        "state": "MERGED" if merged_at else "OPEN",
+        "mergedAt": merged_at,
+        "mergeCommit": {"oid": merge_oid} if merge_oid else None,
+        "headRefName": BRANCH,
+    }
+
+
+def _fake_subprocess_run(view_payload):
+    """Build a subprocess.run stub that responds to gh pr view calls."""
+    def fake(cmd, *args, **kwargs):
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return mock.Mock(
+                returncode=0,
+                stdout=json.dumps(view_payload),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected cmd: {cmd}")
+    return fake
+
+
+def _events_of_kind(db: Path, kind: str) -> list[dict]:
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        return [
+            dict(row) for row in conn.execute(
+                "SELECT id, kind, payload_json, run_id FROM events "
+                "WHERE kind = ? ORDER BY id", (kind,)
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def _run_row(db: Path, task_id: str = TASK_ID) -> dict:
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute(
+            "SELECT * FROM runs WHERE task_id = ?", (task_id,)
+        ).fetchone()
+        return dict(row) if row is not None else {}
+    finally:
+        conn.close()
+
+
+class TempDB:
+    def __enter__(self) -> Path:
+        self._tmp = tempfile.TemporaryDirectory()
+        return Path(self._tmp.name) / "state.db"
+
+    def __exit__(self, *exc) -> None:
+        self._tmp.cleanup()
+
+
+class CompleteOnMergeTests(unittest.TestCase):
+    def test_records_merge_metadata_without_flipping_status(self) -> None:
+        """Codex round-3 Blocker: helper never flips runs.status itself.
+
+        It records pr_state='merged', commit_short/full, pr_url,
+        completed_at, and appends one pr_merged event. The status
+        transition to 'completed' is the secretary's manual step
+        once worktree / pane / worker_dir cleanup is done.
+        """
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+            row = _run_row(db)
+            # status must NOT be flipped — secretary owns the transition.
+            self.assertEqual(row["status"], "review")
+            self.assertEqual(row["pr_state"], "merged")
+            self.assertEqual(row["pr_url"], PR_URL)
+            self.assertEqual(row["commit_full"], MERGE_OID)
+            self.assertEqual(row["commit_short"], MERGE_OID[:7])
+            self.assertEqual(row["completed_at"], MERGED_AT)
+
+            evts = _events_of_kind(db, "pr_merged")
+            self.assertEqual(len(evts), 1)
+            payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["task"], TASK_ID)
+            self.assertEqual(payload["pr"], PR)
+            self.assertEqual(payload["repo"], REPO)
+            self.assertEqual(payload["merge_commit"], MERGE_OID)
+            self.assertEqual(payload["merged_at"], MERGED_AT)
+            self.assertFalse(payload["auto_completed"])
+
+    def test_pattern_b_records_metadata_without_status_flip(self) -> None:
+        """Pattern B / C / D path is identical to Pattern A: status untouched."""
+        with TempDB() as db:
+            _seed_run(db, pattern="B")
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+            row = _run_row(db)
+            self.assertEqual(row["status"], "review")
+            self.assertEqual(row["pr_state"], "merged")
+            self.assertEqual(row["completed_at"], MERGED_AT)
+            payload = json.loads(
+                _events_of_kind(db, "pr_merged")[0]["payload_json"]
+            )
+            self.assertEqual(payload["pattern"], "B")
+            self.assertFalse(payload["auto_completed"])
+
+    def test_idempotent_second_call_is_noop(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                first = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+                # Simulate the secretary completing the manual close
+                # between calls — the helper must still detect that the
+                # event was already recorded and no-op.
+                conn = connect(db)
+                try:
+                    with StateWriter(conn).transaction() as w:
+                        w.update_run_status(TASK_ID, "completed")
+                finally:
+                    conn.close()
+                second = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(first, run_complete_on_merge.RESULT_MERGED)
+            self.assertEqual(second, run_complete_on_merge.RESULT_ALREADY)
+            # No double event row.
+            self.assertEqual(len(_events_of_kind(db, "pr_merged")), 1)
+
+    def test_not_merged_is_no_op(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            view = _make_pr_view(merged_at=None, merge_oid=None)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(view),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_NOT_YET)
+            self.assertEqual(_run_row(db)["status"], "review")
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_branch_fallback_skips_terminal_runs(self) -> None:
+        """Codex Major: branch lookup must ignore completed/failed/abandoned runs.
+
+        A historical completed run with the same branch as the live PR
+        must not be re-completed and have a stray pr_merged event
+        appended to it.
+        """
+        with TempDB() as db:
+            _seed_run(db, pr_url="", branch=BRANCH, pattern="A")
+            # Flip the seeded row to completed so it should be skipped
+            # by the branch fallback.
+            conn = connect(db)
+            try:
+                with StateWriter(conn).transaction() as w:
+                    w.update_run_status(TASK_ID, "completed")
+            finally:
+                conn.close()
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            # No active run row matched (the only row is terminal).
+            self.assertEqual(result, run_complete_on_merge.RESULT_NO_RUN)
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_resolves_task_id_via_branch_when_pr_url_absent(self) -> None:
+        """If the seeded run has no pr_url, fall back to branch lookup."""
+        with TempDB() as db:
+            _seed_run(db, pr_url="")
+            self.assertIn(_run_row(db)["pr_url"], (None, ""))
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+            row = _run_row(db)
+            self.assertEqual(row["pr_state"], "merged")
+            # status remains 'review' — secretary owns the flip.
+            self.assertEqual(row["status"], "review")
+
+    def test_no_matching_run_returns_no_run(self) -> None:
+        with TempDB() as db:
+            apply_schema(connect(db))  # empty DB, no runs
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_NO_RUN)
+            self.assertEqual(_events_of_kind(db, "pr_merged"), [])
+
+    def test_explicit_task_id_skips_resolution(self) -> None:
+        with TempDB() as db:
+            _seed_run(db, pr_url="", branch="other-branch")
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ):
+                result = run_complete_on_merge.complete_on_merge(
+                    pr=PR, repo=REPO, db_path=db, task_id=TASK_ID,
+                )
+            self.assertEqual(result, run_complete_on_merge.RESULT_MERGED)
+
+
+class CLITests(unittest.TestCase):
+    def test_cli_invokes_helper(self) -> None:
+        with TempDB() as db:
+            _seed_run(db)
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ), mock.patch.object(
+                run_complete_on_merge.shutil, "which", return_value="/usr/bin/gh",
+            ):
+                rc = run_complete_on_merge.main([
+                    "--pr", str(PR),
+                    "--repo", REPO,
+                    "--db-path", str(db),
+                ])
+            self.assertEqual(rc, 0)
+            self.assertEqual(_run_row(db)["pr_state"], "merged")
+
+    def test_cli_no_run_exits_nonzero(self) -> None:
+        """Codex round-3 Major: CLI must surface no_run as a failure exit."""
+        with TempDB() as db:
+            apply_schema(connect(db))  # empty DB, no runs match
+            with mock.patch.object(
+                run_complete_on_merge.subprocess, "run",
+                side_effect=_fake_subprocess_run(_make_pr_view()),
+            ), mock.patch.object(
+                run_complete_on_merge.shutil, "which", return_value="/usr/bin/gh",
+            ):
+                rc = run_complete_on_merge.main([
+                    "--pr", str(PR),
+                    "--repo", REPO,
+                    "--db-path", str(db),
+                ])
+            self.assertEqual(rc, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#319](https://github.com/suisya-systems/claude-org-ja/pull/319)

Merge SHA: `f2014d147e91a321d4a14b70b4044584c3b2e4f4`

Source: ja PR [#319](https://github.com/suisya-systems/claude-org-ja/pull/319)
Merge SHA: `f2014d147e91a321d4a14b70b4044584c3b2e4f4`

| class | count |
|---|---|
| runtime | 5 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (5)</summary>

- `tools/pr-watch.ps1`
- `tools/pr_watch.py`
- `tools/run_complete_on_merge.py`
- `tools/test_pr_watch.py`
- `tools/test_run_complete_on_merge.py`

</details>
<details><summary>translation (2)</summary>

- `.claude/skills/org-delegate/SKILL.md`
- `docs/legacy/pr-merge-completion-manual.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
