### PR TITLE
auto-mirror: ja#311 fix(claude): create git worktree during Pattern B apply

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1,0 +1,1027 @@
+"""Tests for tools/gen_delegate_payload.py (Issue #283 Stage 3).
+
+Coverage:
+- preview is non-destructive (no DB / no files)
+- apply reserves a runs.status='queued' row (Codex Blocker B-1)
+- apply does NOT write Active Work Items (no writes outside the queued row)
+- DELEGATE body contains all required rows: pattern / role / Permission Mode
+  / 検証深度 / planned_branch
+- Snapshot tests for each Pattern + role variant
+- preview --json emits a structured object
+- --skip-settings / runtime missing → graceful (apply still succeeds)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+GOLDEN_DIR = REPO_ROOT / "tests" / "fixtures" / "delegate_payload"
+
+
+# ---------------------------------------------------------------------------
+# Sandbox
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        self.claude_org_root = td / "claude-org"
+        (self.claude_org_root / ".state").mkdir(parents=True)
+        (self.claude_org_root / "registry").mkdir()
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Permission Mode\ndefault_permission_mode: auto\n"
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n"
+            f"| claude-org-ja | claude-org-ja | {self.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+    def add_active_run(self, *, task_id: str, project_slug: str, worker_dir: str) -> None:
+        conn = connect(self.db_path)
+        w = StateWriter(conn)
+        with w.transaction() as tx:
+            tx.register_worker_dir(abs_path=worker_dir, layout="flat")
+            tx.upsert_run(
+                task_id=task_id,
+                project_slug=project_slug,
+                pattern="A",
+                title=task_id,
+                status="in_use",
+                worker_dir_abs_path=worker_dir,
+            )
+        conn.close()
+
+    def list_runs(self) -> list[dict]:
+        conn = connect(self.db_path)
+        try:
+            rows = conn.execute(
+                "SELECT task_id, status, pattern, branch FROM runs"
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure planner
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDelegatePlan(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _build(self, **kwargs) -> gdp.DelegatePlan:
+        defaults = dict(
+            task_id="demo-task",
+            project_slug="clock-app",
+            description="add a feature",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(kwargs)
+        return gdp.build_delegate_plan(**defaults)
+
+    def test_pattern_a_default_role_full(self):
+        plan = self._build()
+        body = plan.delegate_body
+        # Required rows per org-delegate Step 2 template
+        self.assertIn("DELEGATE: 以下のワーカーを派遣してください", body)
+        self.assertIn("ワーカーディレクトリ:", body)
+        self.assertIn("ディレクトリパターン: A: プロジェクトディレクトリ", body)
+        self.assertIn("Permission Mode: auto", body)
+        self.assertIn("検証深度: full", body)
+        self.assertIn("ブランチ (planned): feat/demo-task", body)
+        self.assertIn("窓口ペイン名: `secretary`", body)
+        # Brief path uses CLAUDE.md (not self_edit)
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+    def test_pattern_b_when_concurrent_active_run(self):
+        self.sb.add_active_run(
+            task_id="other-task",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = self._build()
+        body = plan.delegate_body
+        self.assertIn("ディレクトリパターン: B: worktree", body)
+        self.assertEqual(plan.layout.pattern, "B")
+
+    def test_pattern_c_ephemeral_for_unknown_slug(self):
+        plan = self._build(project_slug="unknown-thing")
+        body = plan.delegate_body
+        self.assertIn("ディレクトリパターン: C: エフェメラル", body)
+        self.assertIn("Pattern C", body)  # branch line carries the Pattern C note
+
+    def test_self_edit_brief_path_is_local_md(self):
+        plan = self._build(
+            project_slug="claude-org-ja",
+            description="edit a doc",
+        )
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.local.md")
+        self.assertEqual(plan.layout.role, "claude-org-self-edit")
+
+    def test_audit_mode_emits_doc_audit_role(self):
+        plan = self._build(mode="audit", project_slug="claude-org-ja")
+        self.assertEqual(plan.layout.role, "doc-audit")
+        # Should still be a CLAUDE.local.md because gitignored sub-mode
+        # logic only triggers self_edit for the claude-org-self-edit role,
+        # but doc-audit is not a self-edit. So plain CLAUDE.md is fine for
+        # audit on Pattern A worker dir (which is outside claude-org).
+        # (claude-org-ja audit uses Pattern A → workers/claude-org-ja/.)
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+
+# ---------------------------------------------------------------------------
+# Apply — side effects
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDelegatePlan(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _apply(self, **plan_kwargs):
+        defaults = dict(
+            task_id="apply-test",
+            project_slug="clock-app",
+            description="implement something",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(plan_kwargs)
+        plan = gdp.build_delegate_plan(**defaults)
+        return plan, gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+    def test_apply_reserves_queued_row(self):
+        _, result = self._apply()
+        runs = self.sb.list_runs()
+        match = [r for r in runs if r["task_id"] == "apply-test"]
+        self.assertEqual(len(match), 1)
+        row = match[0]
+        self.assertEqual(row["status"], "queued")
+        self.assertEqual(row["pattern"], "A")
+        self.assertEqual(row["branch"], "feat/apply-test")
+        self.assertEqual(result.db_reservation["status"], "queued")
+
+    def test_apply_writes_brief_and_send_plan(self):
+        plan, result = self._apply()
+        self.assertTrue(result.brief_path.exists())
+        text = result.brief_path.read_text(encoding="utf-8")
+        self.assertIn("apply-test", text)
+        self.assertTrue(result.send_plan_path.exists())
+        send_plan = json.loads(result.send_plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(send_plan["to_id"], "dispatcher")
+        self.assertIn("DELEGATE:", send_plan["message"])
+        # The summary block in send_plan carries the layout for audit.
+        self.assertEqual(send_plan["summary"]["pattern"], "A")
+        self.assertEqual(send_plan["summary"]["task_id"], "apply-test")
+
+    def test_apply_skips_settings_gracefully(self):
+        _, result = self._apply()
+        self.assertIsNone(result.settings_path)
+        self.assertEqual(result.settings_skipped_reason, "skip_settings flag set")
+
+    def test_apply_does_not_write_active_work_items(self):
+        """Codex Blocker B-1: Active Work Items is dispatcher's T2.
+
+        We assert this indirectly by checking no run row has a non-queued
+        status after apply, and that the only run created is the queued
+        one we just added.
+        """
+        _, _ = self._apply()
+        runs = self.sb.list_runs()
+        statuses = {r["status"] for r in runs}
+        # Only the queued reservation; no in_use/review (= Active Work Items)
+        # rows were created by apply.
+        self.assertEqual(statuses, {"queued"})
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests (preview + apply paths)
+# ---------------------------------------------------------------------------
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _common_args(self) -> list[str]:
+        return [
+            "--task-id", "cli-task",
+            "--project-slug", "clock-app",
+            "--description", "do the thing",
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ]
+
+    def test_preview_writes_no_files_no_db(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        worker_dir = self.sb.workers / "clock-app"
+        # Pre-condition: the worker dir doesn't exist yet
+        self.assertFalse(worker_dir.exists())
+        runs_before = len(self.sb.list_runs())
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *self._common_args()])
+        self.assertEqual(rc, 0)
+        self.assertFalse(worker_dir.exists())
+        self.assertEqual(len(self.sb.list_runs()), runs_before)
+        out = buf.getvalue()
+        self.assertIn("DELEGATE body (preview, no writes)", out)
+        self.assertIn("Permission Mode: auto", out)
+        self.assertIn("検証深度: full", out)
+
+    def test_preview_json_emits_structured_object(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *self._common_args(), "--json"])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertIn("delegate_body", data)
+        self.assertIn("summary", data)
+        self.assertEqual(data["summary"]["pattern"], "A")
+
+    def test_apply_creates_brief_and_reserves(self):
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "apply",
+                *self._common_args(),
+                "--skip-settings",
+            ])
+        self.assertEqual(rc, 0)
+        runs = self.sb.list_runs()
+        self.assertTrue(any(r["task_id"] == "cli-task" and r["status"] == "queued" for r in runs))
+        brief = self.sb.workers / "clock-app" / "CLAUDE.md"
+        self.assertTrue(brief.exists())
+        send_plan = brief.with_name("send_plan.json")
+        self.assertTrue(send_plan.exists())
+
+
+# ---------------------------------------------------------------------------
+# Snapshot tests against goldens
+# ---------------------------------------------------------------------------
+
+
+def _normalize_body(text: str, sandbox_root: Path) -> str:
+    """Replace sandbox-specific paths with stable placeholders before snapshotting."""
+    text = text.replace(str(sandbox_root.resolve()), "<SANDBOX>")
+    # Windows backslashes vs forward slashes
+    text = text.replace("\\", "/")
+    return text
+
+
+class TestGoldenSnapshots(unittest.TestCase):
+    """Render DELEGATE bodies for each (pattern, role) combo and compare
+    against committed goldens. Update goldens with::
+
+        UPDATE_GOLDENS=1 python -m unittest tests.test_gen_delegate_payload
+
+    Goldens live in tests/fixtures/delegate_payload/ and intentionally
+    NORMALIZE absolute paths to ``<SANDBOX>`` placeholders to keep them
+    stable across machines/OSes.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _check(self, name: str, body: str) -> None:
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        path = GOLDEN_DIR / f"delegate_payload_{name}.golden.md"
+        normalized = _normalize_body(body, self.sb.root)
+        if not path.exists() or _env_update_goldens():
+            path.write_text(normalized, encoding="utf-8")
+            return
+        expected = path.read_text(encoding="utf-8")
+        self.assertEqual(
+            normalized,
+            expected,
+            f"DELEGATE body drift in {path}; rerun with UPDATE_GOLDENS=1 to refresh.",
+        )
+
+    def test_golden_pattern_a_default_full(self):
+        plan = gdp.build_delegate_plan(
+            task_id="snap-a-default",
+            project_slug="clock-app",
+            description="add a sparkline",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_a_default_full", plan.delegate_body)
+
+    def test_golden_pattern_b_self_edit_full(self):
+        # claude-org-ja with concurrent active run forces Pattern B
+        self.sb.add_active_run(
+            task_id="self-edit-other",
+            project_slug="claude-org-ja",
+            worker_dir=str(self.sb.workers / "claude-org-ja"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="snap-b-self-edit",
+            project_slug="claude-org-ja",
+            description="refactor a skill",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_b_self_edit_full", plan.delegate_body)
+
+    def test_golden_pattern_c_ephemeral_minimal(self):
+        plan = gdp.build_delegate_plan(
+            task_id="snap-c-ephemeral",
+            project_slug="totally-new",
+            description="quick survey",
+            verification_depth="minimal",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_c_ephemeral_minimal", plan.delegate_body)
+
+    def test_golden_pattern_c_gitignored_repo_root(self):
+        """Codex Round 1 Minor: gitignored sub-mode is the highest-risk
+        Pattern C variant; lock its DELEGATE rendering down with a golden."""
+        try:
+            import subprocess as _sp
+            _sp.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, _sp.CalledProcessError):
+            self.skipTest("git not available")
+        local_repo = Path(self._td.name) / "host-repo"
+        local_repo.mkdir()
+        _sp.run(["git", "-C", str(local_repo), "init", "-q"], check=True)
+        (local_repo / ".gitignore").write_text("tmp/\n", encoding="utf-8")
+        # Re-seed registry so the host-repo project is registered.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| ホスト | host-app | {local_repo} | Host repo | tmp 編集 |\n"
+            f"| claude-org-ja | claude-org-ja | {self.sb.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="snap-c-gitignored",
+            project_slug="host-app",
+            targets=["tmp/secret.txt"],
+            description="redact gitignored notes",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # Normalise the local_repo path so the golden stays portable.
+        body = plan.delegate_body.replace(str(local_repo.resolve()), "<HOSTREPO>")
+        self._check("pattern_c_gitignored_repo_root_full", body)
+        # Variant must be visible in the formatted body.
+        self.assertIn("gitignored サブモード", body)
+
+    def test_golden_pattern_a_doc_audit(self):
+        """Codex M-4 regression guard: --mode audit must surface as doc-audit
+        and the brief filename must stay CLAUDE.md (no spurious .local.md)."""
+        plan = gdp.build_delegate_plan(
+            task_id="snap-a-audit",
+            project_slug="claude-org-ja",
+            description="audit recent changes",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self._check("pattern_a_doc_audit_full", plan.delegate_body)
+        self.assertEqual(plan.layout.role, "doc-audit")
+
+
+# ---------------------------------------------------------------------------
+# --from-toml round-trip (Codex Round 1 Major: TOML survives bare CLI)
+# ---------------------------------------------------------------------------
+
+
+class TestFromTomlRoundTrip(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _write_toml(self, path: Path, *, role: str, depth: str) -> None:
+        path.write_text(
+            "[task]\n"
+            'id = "round-trip"\n'
+            'description = "round-trip via TOML"\n'
+            f'verification_depth = "{depth}"\n'
+            'branch = "round-trip"\n'
+            'commit_prefix = "feat(clock):"\n'
+            "\n[worker]\n"
+            f'dir = "X:/dummy"\n'
+            'pattern = "A"\n'
+            f'role = "{role}"\n'
+            f'self_edit = {"true" if role == "claude-org-self-edit" else "false"}\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            'description = "Web 時計"\n'
+            "\n[paths]\n"
+            'claude_org = "."\n',
+            encoding="utf-8",
+        )
+
+    def test_from_toml_preserves_doc_audit_mode_and_minimal_depth(self):
+        toml = Path(self._td.name) / "input.toml"
+        self._write_toml(toml, role="doc-audit", depth="minimal")
+        # Bare CLI: no --mode / --verification-depth flag → TOML wins.
+        kwargs = gdp._gather_plan_kwargs(
+            argparse.Namespace(
+                from_toml=toml,
+                task_id=None, project_slug=None, target=[], description=None,
+                mode=None, branch_override=None, commit_prefix=None,
+                verification_depth=None, issue_url=None, closes_issue=None,
+                refs_issues=None, project_name_override=None,
+                project_description_override=None, impl_target=[],
+                impl_guidance=None, knowledge=[], parallel_notes=None,
+                registry_path=None, state_db_path=None, claude_org_root=None,
+                workers_dir=None,
+            )
+        )
+        self.assertEqual(kwargs["mode"], "audit")
+        self.assertEqual(kwargs["verification_depth"], "minimal")
+        self.assertEqual(kwargs["project_slug"], "clock-app")
+
+    def test_from_toml_cli_override_wins(self):
+        toml = Path(self._td.name) / "input.toml"
+        self._write_toml(toml, role="doc-audit", depth="minimal")
+        kwargs = gdp._gather_plan_kwargs(
+            argparse.Namespace(
+                from_toml=toml,
+                task_id=None, project_slug=None, target=[], description=None,
+                mode="edit", branch_override=None, commit_prefix=None,
+                verification_depth="full", issue_url=None, closes_issue=None,
+                refs_issues=None, project_name_override=None,
+                project_description_override=None, impl_target=[],
+                impl_guidance=None, knowledge=[], parallel_notes=None,
+                registry_path=None, state_db_path=None, claude_org_root=None,
+                workers_dir=None,
+            )
+        )
+        self.assertEqual(kwargs["mode"], "edit")
+        self.assertEqual(kwargs["verification_depth"], "full")
+
+
+# ---------------------------------------------------------------------------
+# Issue #290 regression tests — TOML [worker] / [paths] honor + encoding
+# ---------------------------------------------------------------------------
+
+
+class TestIssue290Regressions(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _write_toml(self, path: Path, body: str) -> None:
+        path.write_text(body, encoding="utf-8")
+
+    def _run_preview_json(self, argv: list[str]) -> dict:
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *argv, "--json"])
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue())
+
+    def test_290_a_worker_block_overrides_resolver(self):
+        """TOML [worker] pattern/role/self_edit/dir survive into the layout
+        summary instead of being recomputed by the resolver."""
+        explicit_dir = self.sb.root / "explicit-worker-dir"
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290a"\n'
+            'description = "honor worker block"\n'
+            "\n[worker]\n"
+            f'dir = "{explicit_dir.as_posix()}"\n'
+            'pattern = "B"\n'
+            'role = "claude-org-self-edit"\n'
+            "self_edit = true\n"
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        s = data["summary"]
+        self.assertEqual(s["pattern"], "B")
+        self.assertEqual(s["role"], "claude-org-self-edit")
+        self.assertTrue(s["self_edit"])
+        self.assertEqual(
+            Path(s["worker_dir"]).resolve(), explicit_dir.resolve()
+        )
+        # settings_args picks up the overridden role + worker_dir.
+        self.assertEqual(s["settings_args"]["role"], "claude-org-self-edit")
+        self.assertEqual(
+            Path(s["settings_args"]["worker-dir"]).resolve(),
+            explicit_dir.resolve(),
+        )
+
+    def test_290_b_paths_claude_org_flows_into_settings_args(self):
+        """[paths] claude_org from TOML lands in settings_args.claude-org-path
+        when no CLI override is supplied (no more cwd-derived drift)."""
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290b"\n'
+            'description = "paths.claude_org honored"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+        # Intentionally no --claude-org-root.
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        self.assertEqual(
+            Path(data["summary"]["settings_args"]["claude-org-path"]).resolve(),
+            self.sb.claude_org_root.resolve(),
+        )
+
+    def test_290_c_cli_claude_org_root_overrides_toml_paths(self):
+        """CLI --claude-org-root wins over [paths] claude_org."""
+        bogus = self.sb.root / "bogus-elsewhere"
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290c"\n'
+            'description = "cli wins"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{bogus.as_posix()}"\n',
+        )
+        data = self._run_preview_json([
+            "--from-toml", str(toml),
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ])
+        resolved = Path(
+            data["summary"]["settings_args"]["claude-org-path"]
+        ).resolve()
+        self.assertEqual(resolved, self.sb.claude_org_root.resolve())
+        self.assertNotEqual(resolved, bogus.resolve())
+
+    def test_290_d_japanese_preview_does_not_mojibake_under_cp932(self):
+        """preview stdout decodes cleanly even when the underlying console
+        is cp932 — the encoding wrapper rewraps stdout to utf-8."""
+        import io as _io
+
+        toml = self.sb.root / "in.toml"
+        self._write_toml(
+            toml,
+            "[task]\n"
+            'id = "t-290d"\n'
+            'description = "日本語の説明文 — 派遣テスト"\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+        )
+
+        raw = _io.BytesIO()
+        wrapper = _io.TextIOWrapper(
+            raw, encoding="cp932", errors="strict", write_through=True
+        )
+        old_stdout = sys.stdout
+        sys.stdout = wrapper
+        try:
+            rc = gdp.main([
+                "preview",
+                "--from-toml", str(toml),
+                "--state-db-path", str(self.sb.db_path),
+            ])
+        finally:
+            try:
+                wrapper.flush()
+            except Exception:
+                pass
+            sys.stdout = old_stdout
+        self.assertEqual(rc, 0)
+        decoded = raw.getvalue().decode("utf-8")
+        # Japanese phrases from the DELEGATE template + description survive.
+        self.assertIn("以下のワーカーを派遣", decoded)
+        self.assertIn("日本語の説明文", decoded)
+
+
+# ---------------------------------------------------------------------------
+# Issue #309: Pattern B apply must create the git worktree
+# ---------------------------------------------------------------------------
+
+
+class TestPatternBWorktreeCreation(unittest.TestCase):
+    """apply for Pattern B (incl. live_repo_worktree variant) must run
+    `git worktree add` so the brief lands inside a real worktree."""
+
+    def setUp(self) -> None:
+        try:
+            import subprocess as _sp
+            _sp.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Initialize claude_org_root as a real git repo so live_repo_worktree
+        # can branch from it.
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        import subprocess as _sp
+        self._init_repo_with_origin_main(self.sb.claude_org_root)
+
+    def _init_repo_with_origin_main(self, base: Path) -> None:
+        """Init ``base`` as a git repo on `main` with one commit and
+        ``origin/HEAD`` pointing at ``origin/main`` (no real remote required)."""
+        import subprocess as _sp
+        _sp.run(["git", "-C", str(base), "init", "-q", "-b", "main"],
+                check=True)
+        _sp.run(["git", "-C", str(base), "commit", "--allow-empty",
+                 "-m", "init", "-q"],
+                check=True, env=self._git_env)
+        sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "main"],
+        ).decode().strip()
+        _sp.run(
+            ["git", "-C", str(base), "update-ref",
+             "refs/remotes/origin/main", sha],
+            check=True,
+        )
+        _sp.run(
+            ["git", "-C", str(base), "symbolic-ref",
+             "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _build_self_edit_b(self, *, task_id: str = "b-task"):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="self-edit pattern B",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def _list_worktrees(self) -> list[str]:
+        import subprocess as _sp
+        out = _sp.check_output(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        return [
+            line[len("worktree "):].strip()
+            for line in out.splitlines()
+            if line.startswith("worktree ")
+        ]
+
+    def test_apply_creates_live_repo_worktree(self):
+        plan = self._build_self_edit_b()
+        # Plan should know which repo to branch from.
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), self.sb.claude_org_root.resolve()
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir).resolve()
+        self.assertTrue(worker_dir.exists())
+        self.assertTrue((worker_dir / ".git").exists())
+        # Registered with git as a worktree
+        registered = {Path(p).resolve() for p in self._list_worktrees()}
+        self.assertIn(worker_dir, registered)
+        # Brief landed inside the worktree
+        brief = worker_dir / "CLAUDE.local.md"
+        self.assertTrue(brief.exists())
+
+    def test_apply_idempotent_when_worktree_already_registered(self):
+        plan = self._build_self_edit_b(task_id="idem-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        # Pre-create the worktree manually to simulate a partial / retry run.
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        import subprocess as _sp
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "-b", plan.layout.planned_branch,
+             str(worker_dir)],
+            check=True, capture_output=True,
+        )
+        # Apply must NOT raise and must not duplicate or replace it.
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        # Brief still lands in the worktree
+        self.assertTrue((worker_dir / "CLAUDE.local.md").exists())
+
+    def test_apply_aborts_when_worker_dir_has_unrelated_content(self):
+        plan = self._build_self_edit_b(task_id="dirty-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.mkdir(parents=True)
+        (worker_dir / "stale.txt").write_text("garbage", encoding="utf-8")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("not a registered git worktree", str(cm.exception))
+        # Brief was NOT written into the dirty dir.
+        self.assertFalse((worker_dir / "CLAUDE.local.md").exists())
+
+    def test_apply_aborts_do_not_leak_queued_db_row(self):
+        """Codex Major: a failed _ensure_worktree must not leave behind a
+        queued runs row, because resolve_worker_layout treats `queued` as an
+        active run and would steer subsequent delegations onto Pattern B."""
+        plan = self._build_self_edit_b(task_id="leak-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.mkdir(parents=True)
+        (worker_dir / "stale.txt").write_text("garbage", encoding="utf-8")
+        with self.assertRaises(gdp.WorktreeApplyError):
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        runs = self.sb.list_runs()
+        self.assertFalse(
+            any(r["task_id"] == "leak-task" for r in runs),
+            f"queued row leaked after worktree abort: {runs}",
+        )
+
+    def test_apply_branches_off_default_ref_not_current_head(self):
+        """Codex Blocker: the new worktree must branch off the default ref
+        (origin/HEAD or main), not the base repo's currently-checked-out
+        feature branch."""
+        import subprocess as _sp
+        # Make a commit on main so HEAD is non-empty, then check the base
+        # repo out onto a feature branch with its own commit. apply must
+        # still branch off main.
+        base = self.sb.claude_org_root
+        seed_file = base / "seed.txt"
+        seed_file.write_text("seed", encoding="utf-8")
+        _sp.run(["git", "-C", str(base), "add", "seed.txt"], check=True)
+        _sp.run(["git", "-C", str(base), "commit", "-m", "seed", "-q"],
+                check=True, env=self._git_env)
+        main_sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "main"],
+        ).decode().strip()
+        # Refresh the simulated origin/main to point at the latest main tip,
+        # since setUp captured an earlier commit before the seed file landed.
+        _sp.run(
+            ["git", "-C", str(base), "update-ref",
+             "refs/remotes/origin/main", main_sha],
+            check=True,
+        )
+        _sp.run(["git", "-C", str(base), "checkout", "-q", "-b", "feat/other"],
+                check=True)
+        feat_file = base / "feat.txt"
+        feat_file.write_text("feat-only", encoding="utf-8")
+        _sp.run(["git", "-C", str(base), "add", "feat.txt"], check=True)
+        _sp.run(["git", "-C", str(base), "commit", "-m", "feat-only", "-q"],
+                check=True, env=self._git_env)
+        feat_sha = _sp.check_output(
+            ["git", "-C", str(base), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertNotEqual(main_sha, feat_sha)
+
+        plan = self._build_self_edit_b(task_id="default-ref-task")
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        new_sha = _sp.check_output(
+            ["git", "-C", str(worker_dir), "rev-parse", "HEAD"],
+        ).decode().strip()
+        self.assertEqual(
+            new_sha, main_sha,
+            "new worktree must branch off main, not the base repo's "
+            "currently-checked-out feature branch",
+        )
+        # Sanity: the feat-only file must NOT appear in the new worktree.
+        self.assertFalse((worker_dir / "feat.txt").exists())
+
+    def test_apply_aborts_when_existing_worktree_on_wrong_branch(self):
+        """Codex Round 2 Major: idempotent reuse must verify the existing
+        worktree is on the planned branch — a stale partial-retry on a
+        different branch must abort, not silently dispatch."""
+        plan = self._build_self_edit_b(task_id="branch-mismatch")
+        worker_dir = Path(plan.layout.worker_dir)
+        import subprocess as _sp
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Pre-create on a different branch than planned_branch.
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "-b", "wrong-branch", str(worker_dir)],
+            check=True, capture_output=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("not the planned", str(cm.exception))
+
+    def test_apply_aborts_when_no_origin_head(self):
+        """Codex Round 2 + Round 3 Major: must abort when origin/HEAD is
+        absent — never guess from local main/master (could be stale after
+        a trunk-rename) and never fall back to HEAD (re-introduces the
+        original Pattern-B bug)."""
+        import subprocess as _sp
+        base = self.sb.claude_org_root
+        # Tear down the origin/HEAD setup from setUp so the resolver can't
+        # find any authoritative trunk.
+        _sp.run(["git", "-C", str(base), "symbolic-ref", "--delete",
+                 "refs/remotes/origin/HEAD"], check=True)
+        _sp.run(["git", "-C", str(base), "update-ref", "-d",
+                 "refs/remotes/origin/main"], check=True)
+        plan = self._build_self_edit_b(task_id="no-origin-head-task")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("origin/HEAD", str(cm.exception))
+        # Neither DB row nor brief should exist.
+        self.assertFalse(
+            any(r["task_id"] == "no-origin-head-task"
+                for r in self.sb.list_runs())
+        )
+
+    def test_apply_aborts_when_existing_worktree_in_detached_head(self):
+        """Codex Round 3 Major: idempotent reuse must reject detached HEAD
+        too, not just a different-named branch."""
+        import subprocess as _sp
+        plan = self._build_self_edit_b(task_id="detached-task")
+        worker_dir = Path(plan.layout.worker_dir)
+        worker_dir.parent.mkdir(parents=True, exist_ok=True)
+        # Create as a detached worktree (no -b, no branch name).
+        main_sha = _sp.check_output(
+            ["git", "-C", str(self.sb.claude_org_root), "rev-parse", "main"],
+        ).decode().strip()
+        _sp.run(
+            ["git", "-C", str(self.sb.claude_org_root),
+             "worktree", "add", "--detach", str(worker_dir), main_sha],
+            check=True, capture_output=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("detached-HEAD", str(cm.exception))
+
+    def test_apply_creates_plain_pattern_b_worktree_for_project_repo(self):
+        """Non-self-edit Pattern B branches from the project's registered repo."""
+        # Stand up a dedicated project repo on disk and re-seed the registry.
+        import subprocess as _sp
+        project_repo = Path(self._td.name) / "clock-app-repo"
+        project_repo.mkdir()
+        self._init_repo_with_origin_main(project_repo)
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| 時計アプリ | clock-app | {project_repo} | Web 時計 | デザイン |\n"
+            f"| claude-org-ja | claude-org-ja | {self.sb.claude_org_root} | Self | スキル改善 |\n",
+            encoding="utf-8",
+        )
+        # Force Pattern B by adding an active concurrent run on the project.
+        self.sb.add_active_run(
+            task_id="other-clock-task",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="plain-b-task",
+            project_slug="clock-app",
+            description="add a sparkline",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.layout.pattern_variant)
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), project_repo.resolve()
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir).resolve()
+        # Worktree registered against the project repo (not claude-org).
+        out = _sp.check_output(
+            ["git", "-C", str(project_repo),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        registered = {
+            Path(line[len("worktree "):].strip()).resolve()
+            for line in out.splitlines() if line.startswith("worktree ")
+        }
+        self.assertIn(worker_dir, registered)
+        self.assertTrue((worker_dir / "CLAUDE.md").exists())
+
+
+def _env_update_goldens() -> bool:
+    import os
+    return os.environ.get("UPDATE_GOLDENS") == "1"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -1,0 +1,985 @@
+"""Generate the Secretary's DELEGATE payload for a worker dispatch.
+
+Issue #283 Stage 3. Top-level CLI that takes the same task-shape inputs
+:mod:`tools.gen_worker_brief` ``from-task`` accepts, then assembles the
+full delegation packet:
+
+- ``preview`` (default): pure planning. Emits the DELEGATE message body
+  to stdout plus a list of artifacts that *would* be created. **Touches
+  no files, no DB, no MCP.** This lets Secretary inspect the plan before
+  committing to a reservation.
+
+- ``apply``: performs the T1 reservation per Set B contract:
+
+  1. Reserve the worker_dir + run row in state.db with
+     ``runs.status='queued'`` (Codex Design Blocker B-1; ``Active Work
+     Items`` remains the dispatcher's T2 responsibility — see
+     ``docs/contracts/delegation-lifecycle-contract.md``).
+  2. Write CLAUDE.md / CLAUDE.local.md via :mod:`tools.gen_worker_brief`.
+  3. Optionally call ``claude-org-runtime settings generate`` to write
+     ``.claude/settings.local.json`` (skip with ``--skip-settings``;
+     useful when the runtime CLI isn't on PATH yet, e.g. in tests).
+  4. Emit ``send_plan.json`` describing the renga-peers send_message
+     call Secretary should issue (``to_id="dispatcher"``, ``message=<body>``).
+     Codex M-3 reframed the original ``--send`` flag: this script never
+     calls MCP itself; Secretary copies the JSON into their own
+     ``mcp__renga-peers__send_message`` call.
+
+The internal split is :func:`build_delegate_plan` (pure planner returning
+a :class:`DelegatePlan`) and :func:`apply_delegate_plan` (side-effect
+executor). Tests exercise both paths.
+"""
+from __future__ import annotations
+
+# Direct-script bootstrap (see tools/resolve_worker_layout.py for context).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from tools import gen_worker_brief as gwb
+from tools import resolve_worker_layout as rwl
+
+
+_PERMISSION_MODE_RE = re.compile(
+    r"^\s*default_permission_mode\s*:\s*(\S+)\s*$", re.MULTILINE
+)
+
+_PATTERN_LABELS = {
+    "A": "A: プロジェクトディレクトリ",
+    "B": "B: worktree",
+    "C": "C: エフェメラル",
+}
+
+
+class WorktreeApplyError(RuntimeError):
+    """Raised by apply when Pattern B worktree creation cannot proceed safely
+    (e.g. ``worker_dir`` already contains unrelated content, or git fails).
+    Issue #309: apply must abort rather than silently leave a half-formed
+    worker dir for Secretary to discover after the worker has been spawned.
+    """
+
+
+@dataclass(frozen=True)
+class DelegatePlan:
+    task_id: str
+    project_slug: str
+    description: str
+    config: dict[str, Any]
+    layout: rwl.WorkerLayout
+    delegate_body: str
+    brief_out_path: Path
+    settings_args: dict[str, str]
+    permission_mode: str
+    verification_depth: str
+    closes_issue: Optional[int]
+    refs_issues: list[int]
+    artifacts_to_create: list[Path] = field(default_factory=list)
+    # Pattern B only: absolute path of the repo from which `git worktree add`
+    # is run. None for Pattern A / C, or when no usable base repo could be
+    # determined (apply will then raise WorktreeApplyError).
+    base_repo: Optional[Path] = None
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "project_slug": self.project_slug,
+            "pattern": self.layout.pattern,
+            "pattern_variant": self.layout.pattern_variant,
+            "role": self.layout.role,
+            "self_edit": self.layout.self_edit,
+            "worker_dir": self.layout.worker_dir,
+            "planned_branch": self.layout.planned_branch,
+            "permission_mode": self.permission_mode,
+            "verification_depth": self.verification_depth,
+            "brief_out_path": str(self.brief_out_path),
+            "settings_args": dict(self.settings_args),
+            "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
+            "base_repo": str(self.base_repo) if self.base_repo else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_permission_mode(claude_org_root: Path) -> str:
+    """Return the org-wide ``default_permission_mode`` (defaults to ``auto``)."""
+    cfg = claude_org_root / "registry" / "org-config.md"
+    if not cfg.exists():
+        return "auto"
+    text = cfg.read_text(encoding="utf-8")
+    m = _PERMISSION_MODE_RE.search(text)
+    return m.group(1) if m else "auto"
+
+
+def _pattern_label(layout: rwl.WorkerLayout) -> str:
+    base = _PATTERN_LABELS.get(layout.pattern, layout.pattern)
+    if layout.pattern_variant == "gitignored_repo_root":
+        return "C: gitignored サブモード (registered repo 直接編集)"
+    if layout.pattern_variant == "live_repo_worktree":
+        return "B: worktree (live_repo_worktree — Secretary live repo 配下)"
+    return base
+
+
+def _project_label(layout: rwl.WorkerLayout, project_path: Optional[str]) -> str:
+    if layout.pattern == "A":
+        return f"clone or reuse: {project_path or '-'}"
+    if layout.pattern == "B":
+        return f"worktree base: {project_path or '-'}"
+    if layout.pattern == "C":
+        if layout.pattern_variant == "gitignored_repo_root":
+            return f"既存 repo 直接編集: {layout.worker_dir}"
+        return "新規作成 (clone なし) — エフェメラル"
+    return project_path or "-"
+
+
+def _summarize_description(description: str, limit: int = 120) -> str:
+    one_line = " ".join(description.strip().split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: limit - 1].rstrip() + "…"
+
+
+def _brief_filename(self_edit: bool) -> str:
+    return "CLAUDE.local.md" if self_edit else "CLAUDE.md"
+
+
+def _format_delegate_body(
+    *,
+    layout: rwl.WorkerLayout,
+    task_id: str,
+    description: str,
+    project_path: Optional[str],
+    permission_mode: str,
+    verification_depth: str,
+    brief_filename: str,
+) -> str:
+    """Format the DELEGATE message body per org-delegate Step 2 template."""
+    instr_summary = _summarize_description(description)
+    branch_line = (
+        layout.planned_branch
+        if layout.planned_branch
+        else "(Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)"
+    )
+    # Use the platform-native joiner to avoid the mixed `\\…/CLAUDE.md`
+    # output the literal-`/` template produced on Windows (Codex Round 1 Nit).
+    brief_full_path = str(Path(layout.worker_dir) / brief_filename)
+    body = f"""DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- {task_id}: {instr_summary or task_id}
+  - ワーカーディレクトリ: {layout.worker_dir}（{brief_filename}・設定配置済み）
+  - ディレクトリパターン: {_pattern_label(layout)}
+  - プロジェクト: {_project_label(layout, project_path)}
+  - ブランチ (planned): {branch_line}
+  - Permission Mode: {permission_mode}
+  - 検証深度: {verification_depth}
+  - 指示内容: 詳細は `{brief_full_path}` を参照。要約: {instr_summary or '(none)'}
+
+窓口ペイン名: `secretary`（renga layout で登録済み）"""
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Planner — pure
+# ---------------------------------------------------------------------------
+
+
+def build_delegate_plan(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    commit_prefix: Optional[str] = None,
+    verification_depth: str = "full",
+    issue_url: Optional[str] = None,
+    closes_issue: Optional[int] = None,
+    refs_issues: Optional[list[int]] = None,
+    project_description_override: Optional[str] = None,
+    implementation_target_files: Optional[list[str]] = None,
+    implementation_guidance: Optional[str] = None,
+    references_knowledge: Optional[list[str]] = None,
+    parallel_notes: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
+) -> DelegatePlan:
+    """Resolve the layout, assemble the brief config, format the DELEGATE body.
+
+    Pure: no file writes, no DB writes, no subprocesses other than the
+    ``git check-ignore`` Step 0.7 probe (read-only) inside the resolver.
+    """
+    config, layout = gwb.build_config_from_task(
+        task_id=task_id,
+        project_slug=project_slug,
+        targets=targets,
+        description=description,
+        mode=mode,
+        branch_override=branch_override,
+        commit_prefix=commit_prefix,
+        verification_depth=verification_depth,
+        issue_url=issue_url,
+        closes_issue=closes_issue,
+        refs_issues=refs_issues,
+        project_description_override=project_description_override,
+        implementation_target_files=implementation_target_files,
+        implementation_guidance=implementation_guidance,
+        references_knowledge=references_knowledge,
+        parallel_notes=parallel_notes,
+        registry_path=registry_path,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        workers_dir=workers_dir,
+        layout_overrides=layout_overrides,
+    )
+
+    self_edit = bool(config["worker"]["self_edit"])
+    brief_filename = _brief_filename(self_edit)
+    brief_out_path = Path(layout.worker_dir) / brief_filename
+
+    permission_mode = parse_permission_mode(Path(claude_org_root))
+
+    # Look up project.path for the DELEGATE body label.
+    project_path: Optional[str] = None
+    registry_for_meta = registry_path or (
+        Path(claude_org_root) / "registry" / "projects.md"
+    )
+    if registry_for_meta.exists():
+        rows = rwl.parse_projects(registry_for_meta)
+        match = rwl.find_project(rows, project_slug)
+        if match is not None:
+            project_path = match.path
+
+    delegate_body = _format_delegate_body(
+        layout=layout,
+        task_id=task_id,
+        description=description,
+        project_path=project_path,
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        brief_filename=brief_filename,
+    )
+
+    artifacts = [
+        brief_out_path,
+        Path(layout.worker_dir) / ".claude" / "settings.local.json",
+    ]
+
+    # Pattern B: figure out which repo `git worktree add` should be run from.
+    # live_repo_worktree → Secretary's live claude-org repo;
+    # plain Pattern B    → the registered project's path.
+    base_repo: Optional[Path] = None
+    if layout.pattern == "B":
+        if layout.pattern_variant == "live_repo_worktree":
+            base_repo = Path(claude_org_root).resolve()
+        elif project_path and rwl.is_local_git_repo(project_path):
+            base_repo = Path(project_path).resolve()
+
+    return DelegatePlan(
+        task_id=task_id,
+        project_slug=project_slug,
+        description=description,
+        config=config,
+        layout=layout,
+        delegate_body=delegate_body,
+        brief_out_path=brief_out_path,
+        settings_args=dict(layout.settings_args),
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        closes_issue=closes_issue,
+        refs_issues=list(refs_issues or []),
+        artifacts_to_create=artifacts,
+        base_repo=base_repo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executor — side effects (DB write, file write, settings subprocess)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApplyResult:
+    plan: DelegatePlan
+    brief_path: Path
+    settings_path: Optional[Path]
+    settings_skipped_reason: Optional[str]
+    send_plan_path: Path
+    db_reservation: dict[str, Any]
+
+
+def _reserve_in_db(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path],
+) -> dict[str, Any]:
+    """Reserve the worker_dir + queue the run row.
+
+    Per Codex Design Blocker B-1 + Set B contract, this writes
+    ``runs.status='queued'`` only. Active Work Items remains the
+    dispatcher's T2 responsibility and is *not* touched here.
+    """
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    if not state_db_path.exists():
+        # Fresh DB — create empty file and apply schema. The importer
+        # would normally seed projects/workstreams; we only need a usable
+        # schema here, ensure_project below will create the project row.
+        state_db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = connect(state_db_path)
+        apply_schema(conn)
+        conn.close()
+
+    conn = connect(state_db_path)
+    try:
+        writer = StateWriter(conn, claude_org_root=claude_org_root)
+        with writer.transaction() as tx:
+            tx.register_worker_dir(
+                abs_path=plan.layout.worker_dir,
+                layout="flat",
+                is_git_repo=plan.layout.pattern != "C"
+                or plan.layout.pattern_variant == "gitignored_repo_root",
+                is_worktree=plan.layout.pattern == "B",
+            )
+            issue_refs_iter = None
+            if plan.closes_issue is not None:
+                issue_refs_iter = [str(plan.closes_issue)]
+            elif plan.refs_issues:
+                issue_refs_iter = [str(n) for n in plan.refs_issues]
+            tx.upsert_run(
+                task_id=plan.task_id,
+                project_slug=plan.project_slug,
+                pattern=plan.layout.pattern,
+                title=plan.task_id,
+                status="queued",
+                branch=plan.layout.planned_branch,
+                issue_refs=issue_refs_iter,
+                verification=(
+                    "minimal" if plan.verification_depth == "minimal" else "standard"
+                ),
+                worker_dir_abs_path=plan.layout.worker_dir,
+            )
+        return {
+            "task_id": plan.task_id,
+            "project_slug": plan.project_slug,
+            "worker_dir": plan.layout.worker_dir,
+            "status": "queued",
+        }
+    finally:
+        conn.close()
+
+
+def _resolve_base_ref(base_repo: Path) -> Optional[str]:
+    """Pick the starting ref for ``git worktree add -b <branch> <path> <ref>``.
+
+    Pattern B is triggered precisely when another active run is occupying
+    the base clone — so the base's current ``HEAD`` is typically that
+    other task's feature branch. Branching off it would mix unmerged
+    commits into the new worktree.
+
+    The only ref we treat as authoritative is ``origin/HEAD`` (the
+    project's default branch as the remote knows it). We deliberately do
+    NOT fall back to local ``main`` / ``master`` / ``HEAD`` because:
+
+    - a stale local ``main`` left over after a trunk-rename would silently
+      branch off the wrong commit (Codex Round 3 Major 2026-05-06);
+    - ``HEAD`` is the original bug (Codex Round 2);
+    - convention-based guessing of the trunk name is not safe in repos
+      using ``trunk`` / ``develop`` / etc.
+
+    Returns ``None`` when ``origin/HEAD`` is not set — apply then aborts
+    with a recovery hint pointing to ``git remote set-head origin --auto``.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "symbolic-ref", "--short",
+         "refs/remotes/origin/HEAD"],
+        capture_output=True,
+    )
+    if proc.returncode == 0:
+        ref = proc.stdout.decode("utf-8", errors="replace").strip()
+        if ref:
+            return ref
+    return None
+
+
+def _worktree_branch(worker_dir: Path) -> Optional[str]:
+    """Return the branch name currently checked out at ``worker_dir`` (or
+    None on detached HEAD / git error)."""
+    proc = subprocess.run(
+        ["git", "-C", str(worker_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return None
+    name = proc.stdout.decode("utf-8", errors="replace").strip()
+    if not name or name == "HEAD":
+        return None
+    return name
+
+
+def _is_registered_worktree(base_repo: Path, worker_dir: Path) -> bool:
+    """True iff ``worker_dir`` is already a registered worktree of ``base_repo``.
+
+    Compared by resolved absolute path so a re-run of apply against an
+    already-created worktree is idempotent (Issue #309).
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "worktree", "list", "--porcelain"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return False
+    try:
+        target = worker_dir.resolve()
+    except OSError:
+        return False
+    for line in proc.stdout.decode("utf-8", errors="replace").splitlines():
+        if line.startswith("worktree "):
+            try:
+                p = Path(line[len("worktree "):]).resolve()
+            except OSError:
+                continue
+            if p == target:
+                return True
+    return False
+
+
+def _ensure_worktree(plan: DelegatePlan) -> None:
+    """For Pattern B, run ``git worktree add`` if the dir is not already one.
+
+    Idempotent — no-op when ``worker_dir`` is already a registered worktree
+    of ``base_repo``. Aborts with :class:`WorktreeApplyError` when the dir
+    exists with unrelated content (Secretary judgment call to clean up,
+    per Issue #309).
+    """
+    if plan.layout.pattern != "B":
+        return
+    if plan.base_repo is None:
+        raise WorktreeApplyError(
+            f"Pattern B but no usable base repo could be determined for "
+            f"project {plan.project_slug!r} (variant="
+            f"{plan.layout.pattern_variant!r}); cannot run `git worktree add`."
+        )
+    worker_dir = Path(plan.layout.worker_dir)
+    if _is_registered_worktree(plan.base_repo, worker_dir):
+        # Idempotent reuse — but only when the existing worktree is on the
+        # branch the brief / DB will pin. A stale partial-retry worktree on
+        # a different branch (or in detached-HEAD state) would otherwise
+        # silently dispatch on the wrong ref (Codex Round 2 + Round 3
+        # Majors 2026-05-06).
+        expected = plan.layout.planned_branch
+        if expected:
+            actual = _worktree_branch(worker_dir)
+            if actual is None:
+                raise WorktreeApplyError(
+                    f"worker_dir {worker_dir} is registered as a git "
+                    f"worktree but is in detached-HEAD state, not on the "
+                    f"planned branch {expected!r}. Refusing to dispatch — "
+                    "Secretary must `git checkout` the intended branch (or "
+                    "remove the worktree and let apply recreate it) and retry."
+                )
+            if actual != expected:
+                raise WorktreeApplyError(
+                    f"worker_dir {worker_dir} is registered as a git "
+                    f"worktree but is on branch {actual!r}, not the planned "
+                    f"{expected!r}. Refusing to dispatch on a mismatched "
+                    "branch — Secretary must check out the intended branch "
+                    "(or remove the worktree and let apply recreate it) "
+                    "and retry."
+                )
+        return
+    if worker_dir.exists() and any(worker_dir.iterdir()):
+        raise WorktreeApplyError(
+            f"worker_dir {worker_dir} exists with content but is not a "
+            f"registered git worktree of {plan.base_repo}. Refusing to "
+            "auto-recover — Secretary must clean up the directory (or run "
+            "`git worktree add` manually) and retry apply."
+        )
+    branch = plan.layout.planned_branch
+    if not branch:
+        raise WorktreeApplyError(
+            f"Pattern B requires a planned_branch but layout produced None "
+            f"(task_id={plan.task_id!r})."
+        )
+    base_ref = _resolve_base_ref(plan.base_repo)
+    if base_ref is None:
+        raise WorktreeApplyError(
+            f"could not resolve `origin/HEAD` in {plan.base_repo}. Refusing "
+            "to guess the trunk from local refs because a stale local "
+            "`main` after a trunk-rename would silently branch the new "
+            "worktree off the wrong commit, and `HEAD` is the original "
+            "Pattern-B bug (it points to whatever feature branch the base "
+            "is currently on). Run `git remote set-head origin --auto` in "
+            f"{plan.base_repo} (or `git symbolic-ref refs/remotes/origin/"
+            "HEAD refs/remotes/origin/<trunk>` if you don't have remote "
+            "access) and retry."
+        )
+    worker_dir.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "git", "-C", str(plan.base_repo),
+        "worktree", "add", "-b", branch, str(worker_dir), base_ref,
+    ]
+    proc = subprocess.run(cmd, capture_output=True)
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise WorktreeApplyError(
+            f"`git worktree add` failed (rc={proc.returncode}) for "
+            f"{worker_dir} from {plan.base_repo}: {stderr}"
+        )
+
+
+def _write_brief(plan: DelegatePlan) -> Path:
+    text = gwb.render(plan.config)
+    out = plan.brief_out_path
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    return out
+
+
+def _run_settings_generate(
+    plan: DelegatePlan,
+    *,
+    runtime_cmd: str = "claude-org-runtime",
+) -> tuple[Optional[Path], Optional[str]]:
+    """Run ``claude-org-runtime settings generate``.
+
+    Returns ``(written_path, skipped_reason)``. When the CLI is missing
+    we return ``(None, reason)`` and let the caller record it in the
+    ApplyResult — apply does NOT crash, since several real-world dispatch
+    flows happen on machines without the runtime installed (e.g. fresh
+    test sandboxes).
+    """
+    if shutil.which(runtime_cmd) is None:
+        return None, f"{runtime_cmd!r} not on PATH"
+
+    settings_args = plan.settings_args
+    out = Path(settings_args["out"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        runtime_cmd,
+        "settings",
+        "generate",
+        "--role",
+        settings_args["role"],
+        "--worker-dir",
+        settings_args["worker-dir"],
+        "--claude-org-path",
+        settings_args["claude-org-path"],
+        "--out",
+        settings_args["out"],
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        return None, (
+            f"{runtime_cmd} settings generate failed (rc={e.returncode}): "
+            f"{(e.stderr or b'').decode('utf-8', errors='replace').strip()}"
+        )
+    return out, None
+
+
+def _write_send_plan(plan: DelegatePlan, *, out_path: Path) -> Path:
+    """Write the renga-peers MCP call manifest Secretary will copy from."""
+    payload = {
+        "to_id": "dispatcher",
+        "message": plan.delegate_body,
+        "summary": plan.to_summary_dict(),
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def apply_delegate_plan(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path] = None,
+    skip_settings: bool = False,
+    runtime_cmd: str = "claude-org-runtime",
+    send_plan_out: Optional[Path] = None,
+) -> ApplyResult:
+    """Execute the side effects: reserve in DB, write brief, settings, send_plan."""
+    # Issue #309: create the worktree FIRST. If this fails (dirty dir,
+    # git error, etc.) we must not leak a `runs.status='queued'` row,
+    # because resolve_worker_layout treats `queued` as an active run and
+    # would silently steer the next delegation onto another Pattern B
+    # branch (Codex Major 2026-05-06). No-op for Pattern A / C.
+    _ensure_worktree(plan)
+    db_reservation = _reserve_in_db(
+        plan, state_db_path=state_db_path, claude_org_root=claude_org_root
+    )
+    brief_path = _write_brief(plan)
+    settings_path: Optional[Path] = None
+    skipped_reason: Optional[str] = None
+    if skip_settings:
+        skipped_reason = "skip_settings flag set"
+    else:
+        settings_path, skipped_reason = _run_settings_generate(
+            plan, runtime_cmd=runtime_cmd
+        )
+    if send_plan_out is None:
+        send_plan_out = brief_path.with_name("send_plan.json")
+    send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
+    return ApplyResult(
+        plan=plan,
+        brief_path=brief_path,
+        settings_path=settings_path,
+        settings_skipped_reason=skipped_reason,
+        send_plan_path=send_plan_path,
+        db_reservation=db_reservation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_task_args(p: argparse.ArgumentParser) -> None:
+    """Args shared by preview and apply for the from-task input form.
+
+    Defaults for ``--mode`` and ``--verification-depth`` are intentionally
+    ``None``. The merge step in :func:`_gather_plan_kwargs` only treats a
+    CLI value as an override when it is not None, so a ``--from-toml``
+    config's ``mode`` / ``verification_depth`` survives unless the caller
+    explicitly re-passes the flag. Final defaults (``edit`` / ``full``)
+    are applied after merging — see Codex Round 1 Major.
+    """
+    p.add_argument("--task-id")
+    p.add_argument("--project-slug")
+    p.add_argument("--target", action="append", default=[])
+    p.add_argument("--description", default=None)
+    p.add_argument("--mode", choices=("edit", "audit"), default=None)
+    p.add_argument("--branch", dest="branch_override", default=None)
+    p.add_argument("--commit-prefix", default=None)
+    p.add_argument(
+        "--verification-depth", choices=("full", "minimal"), default=None
+    )
+    p.add_argument("--issue-url", default=None)
+    p.add_argument("--closes-issue", type=int, default=None)
+    p.add_argument("--refs-issues", type=int, nargs="*", default=None)
+    # Intentionally no --project-name: project.name is the slug (use
+    # --project-slug). Allowing an override created a round-trip drift
+    # where the next --from-toml read 通称 back as the slug (Codex Round 2).
+    p.add_argument(
+        "--project-description",
+        dest="project_description_override",
+        default=None,
+    )
+    p.add_argument("--impl-target", action="append", default=[])
+    p.add_argument("--impl-guidance", default=None)
+    p.add_argument("--knowledge", action="append", default=[])
+    p.add_argument("--parallel-notes", default=None)
+    p.add_argument("--registry-path", type=Path, default=None)
+    p.add_argument("--state-db-path", type=Path, default=None)
+    p.add_argument("--claude-org-root", type=Path, default=None)
+    p.add_argument("--workers-dir", type=Path, default=None)
+    p.add_argument(
+        "--from-toml",
+        type=Path,
+        default=None,
+        help="Load task arguments from a worker_brief-style TOML instead of CLI flags.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="gen_delegate_payload",
+        description="Generate the Secretary's DELEGATE payload (preview or apply).",
+    )
+    sub = p.add_subparsers(dest="cmd")
+    sub.required = True
+
+    preview = sub.add_parser(
+        "preview",
+        help="Print the planned DELEGATE body and artifact paths. No writes.",
+    )
+    _add_task_args(preview)
+    preview.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit a single JSON object instead of human-readable text.",
+    )
+
+    apply_p = sub.add_parser(
+        "apply",
+        help="Reserve in DB (runs.status='queued'), write brief, settings, send_plan.json.",
+    )
+    _add_task_args(apply_p)
+    apply_p.add_argument(
+        "--skip-settings", action="store_true",
+        help="Skip the claude-org-runtime settings generate subprocess.",
+    )
+    apply_p.add_argument("--runtime-cmd", default="claude-org-runtime")
+    apply_p.add_argument(
+        "--send-plan-out",
+        type=Path,
+        default=None,
+        help="Override send_plan.json output path (default: alongside the brief).",
+    )
+
+    return p
+
+
+def _resolve_claude_org_root(args: argparse.Namespace) -> Path:
+    """Resolve claude-org repo root. Priority (highest first):
+
+    1. ``--claude-org-root`` CLI flag (explicit).
+    2. ``[paths] claude_org`` from ``--from-toml`` (Issue #290 defect 2 —
+       previously ignored, leaving cwd-derived paths to drift).
+    3. cwd-walk fallback (:func:`gwb._detect_claude_org_root`).
+    """
+    if args.claude_org_root is not None:
+        return Path(args.claude_org_root).resolve()
+    toml_path = getattr(args, "from_toml", None)
+    if toml_path is not None:
+        try:
+            with Path(toml_path).open("rb") as fh:
+                cfg = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            cfg = {}
+        cfg_path = (cfg.get("paths") or {}).get("claude_org")
+        if cfg_path:
+            p = Path(cfg_path)
+            if not p.is_absolute():
+                p = (Path(toml_path).resolve().parent / p)
+            return p.resolve()
+    return gwb._detect_claude_org_root()
+
+
+def _resolve_state_db_path(args: argparse.Namespace, claude_org_root: Path) -> Path:
+    if args.state_db_path is not None:
+        return args.state_db_path
+    return claude_org_root / ".state" / "state.db"
+
+
+def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
+    """Pull task-shape kwargs out of a worker_brief.toml.
+
+    The TOML schema (see ``tools/templates/worker_brief.example.toml``)
+    uses ``project.name`` for the slug — that's what both the legacy
+    hand-written briefs and Stage 2's ``from-task`` output write — so we
+    treat it as ``project_slug`` directly. Codex Round 1+2 caught the
+    inversions (common_name vs slug; --project-name override drift).
+
+    ``mode`` is derived from ``worker.role``: ``doc-audit`` → ``audit``,
+    everything else → ``edit``. Returning the field at all (even when
+    falsey) lets the merge step recognise an explicit TOML setting.
+    """
+    with path.open("rb") as fh:
+        cfg = tomllib.load(fh)
+    task = cfg.get("task", {})
+    worker = cfg.get("worker", {})
+    project = cfg.get("project", {})
+    impl = cfg.get("implementation", {})
+    refs = cfg.get("references", {})
+    parallel = cfg.get("parallel", {})
+    role = (worker.get("role") or "").strip()
+    mode_from_toml = "audit" if role == "doc-audit" else "edit"
+
+    # Issue #290 defect 1: surface explicit [worker] fields so the resolver
+    # honors them instead of silently re-deriving pattern/role/dir/self_edit.
+    layout_overrides: dict[str, Any] = {}
+    if worker.get("pattern"):
+        layout_overrides["pattern"] = worker["pattern"]
+    if worker.get("pattern_variant"):
+        layout_overrides["pattern_variant"] = worker["pattern_variant"]
+    if worker.get("dir"):
+        # Resolve relative dirs against the TOML file's parent so
+        # [paths].claude_org and [worker].dir share the same base
+        # (Codex Round 1 Minor — previously cwd-relative).
+        wd = Path(worker["dir"])
+        if not wd.is_absolute():
+            wd = (path.resolve().parent / wd)
+        layout_overrides["worker_dir"] = str(wd)
+    if role:
+        layout_overrides["role"] = role
+    if "self_edit" in worker:
+        # Pass through unchanged so resolve()'s strict bool check fires
+        # on malformed input (e.g. self_edit = "false" parsed as a string).
+        # Codex Round 2 Minor.
+        layout_overrides["self_edit"] = worker["self_edit"]
+
+    return {
+        "task_id": task.get("id"),
+        "project_slug": project.get("name"),
+        "description": task.get("description"),
+        "branch_override": task.get("branch"),
+        "commit_prefix": task.get("commit_prefix"),
+        "verification_depth": task.get("verification_depth"),
+        "issue_url": task.get("issue_url"),
+        "closes_issue": task.get("closes_issue"),
+        "refs_issues": task.get("refs_issues"),
+        "project_description_override": project.get("description"),
+        "implementation_target_files": impl.get("target_files"),
+        "implementation_guidance": impl.get("guidance"),
+        "references_knowledge": refs.get("knowledge"),
+        "parallel_notes": parallel.get("notes"),
+        "mode": mode_from_toml,
+        "layout_overrides": layout_overrides or None,
+    }
+
+
+def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
+    """Merge --from-toml defaults with CLI flags (CLI wins).
+
+    Defaults for ``mode`` (``edit``) and ``verification_depth`` (``full``)
+    are applied **after** the merge so a TOML-supplied value survives a
+    bare CLI invocation. Otherwise argparse's defaults would always win
+    and TOML round-trip would silently flatten ``doc-audit`` / ``minimal``.
+    """
+    base: dict[str, Any] = {}
+    if args.from_toml is not None:
+        base.update(_load_task_args_from_toml(args.from_toml))
+    # CLI overrides — only when caller actually provided a value.
+    cli_overrides: dict[str, Any] = {
+        "task_id": args.task_id,
+        "project_slug": args.project_slug,
+        "targets": args.target or None,
+        "description": args.description,
+        "mode": args.mode,
+        "branch_override": args.branch_override,
+        "commit_prefix": args.commit_prefix,
+        "verification_depth": args.verification_depth,
+        "issue_url": args.issue_url,
+        "closes_issue": args.closes_issue,
+        "refs_issues": args.refs_issues,
+        "project_description_override": args.project_description_override,
+        "implementation_target_files": args.impl_target or None,
+        "implementation_guidance": args.impl_guidance,
+        "references_knowledge": args.knowledge or None,
+        "parallel_notes": args.parallel_notes,
+        "registry_path": args.registry_path,
+        "workers_dir": args.workers_dir,
+    }
+    for k, v in cli_overrides.items():
+        if v is not None:
+            base[k] = v
+    base.setdefault("mode", "edit")
+    base.setdefault("verification_depth", "full")
+    base.setdefault("description", "")
+    if not base.get("task_id"):
+        raise SystemExit("error: --task-id is required (or supply --from-toml)")
+    if not base.get("project_slug"):
+        raise SystemExit(
+            "error: --project-slug is required (or supply --from-toml)"
+        )
+    return base
+
+
+def _cmd_preview(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+
+    if args.json_out:
+        json.dump(
+            {
+                "delegate_body": plan.delegate_body,
+                "summary": plan.to_summary_dict(),
+            },
+            sys.stdout,
+            indent=2,
+            ensure_ascii=False,
+        )
+        sys.stdout.write("\n")
+        return 0
+
+    print("--- DELEGATE body (preview, no writes) ---")
+    print(plan.delegate_body)
+    print()
+    print("--- Artifacts that 'apply' would create ---")
+    for p in plan.artifacts_to_create:
+        print(f"  {p}")
+    print(f"  send_plan.json (alongside brief)")
+    print()
+    print("--- Layout summary ---")
+    print(json.dumps(plan.to_summary_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+    result = apply_delegate_plan(
+        plan,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        skip_settings=args.skip_settings,
+        runtime_cmd=args.runtime_cmd,
+        send_plan_out=args.send_plan_out,
+    )
+    print(f"reserved (queued) task_id={plan.task_id} pattern={plan.layout.pattern}")
+    print(f"brief: {result.brief_path}")
+    if result.settings_path is not None:
+        print(f"settings: {result.settings_path}")
+    elif result.settings_skipped_reason:
+        print(f"settings: SKIPPED ({result.settings_skipped_reason})")
+    print(f"send_plan: {result.send_plan_path}")
+    print(
+        "Next step: copy send_plan.json's `to_id`/`message` into a "
+        "renga-peers send_message call."
+    )
+    return 0
+
+
+def _reconfigure_stdout() -> None:
+    """Force stdout/stderr to UTF-8 on Windows so the DELEGATE body / Layout
+    summary (which contain Japanese) don't mojibake under cp932 consoles
+    (Issue #290 defect 3). No-op when reconfigure is unavailable."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    _reconfigure_stdout()
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "preview":
+        return _cmd_preview(args)
+    if args.cmd == "apply":
+        return _cmd_apply(args)
+    raise SystemExit(f"unknown subcommand: {args.cmd!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#311](https://github.com/suisya-systems/claude-org-ja/pull/311)

Merge SHA: `daaa8b729e6aa4e9c63eaa671ef46187b251cd0b`

Source: ja PR [#311](https://github.com/suisya-systems/claude-org-ja/pull/311)
Merge SHA: `daaa8b729e6aa4e9c63eaa671ef46187b251cd0b`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_gen_delegate_payload.py`
- `tools/gen_delegate_payload.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
