### PR TITLE
auto-mirror: ja#302 feat(secretary): add pending-decisions register for relay-gap detection

### DIFF
--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -1,0 +1,286 @@
+"""Tests for tools/pending_decisions.py (Issue #297)."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools import pending_decisions as pd  # noqa: E402
+
+
+class PendingDecisionsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.store = Path(self._tmpdir.name) / "pending_decisions.json"
+
+    def _read_raw(self) -> list[dict]:
+        return json.loads(self.store.read_text(encoding="utf-8"))
+
+    # (a) ----------------------------------------------------------------
+    def test_append_to_empty_store_creates_file_with_pending_entry(self) -> None:
+        self.assertFalse(self.store.exists())
+        entry = pd.append("t1", "judgment please", store_path=self.store)
+        self.assertTrue(self.store.exists())
+        self.assertEqual(entry.task_id, "t1")
+        self.assertEqual(entry.status, "pending")
+        self.assertEqual(entry.raw_message, "judgment please")
+        self.assertIsNone(entry.resolved_at)
+        self.assertIsNone(entry.resolution_kind)
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+        self.assertEqual(raw[0]["task_id"], "t1")
+
+    # (b) ----------------------------------------------------------------
+    def test_append_same_task_id_is_idempotent(self) -> None:
+        first = pd.append("t1", "first", store_path=self.store)
+        second = pd.append("t1", "second body ignored", store_path=self.store)
+        self.assertEqual(first.received_at, second.received_at)
+        self.assertEqual(second.raw_message, "first")  # original kept
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 1)
+
+    # (c) ----------------------------------------------------------------
+    def test_resolve_to_user_marks_escalated(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        out = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, "escalated")
+        self.assertEqual(out.resolution_kind, "to_user")
+        self.assertIsNotNone(out.resolved_at)
+
+    # (d) ----------------------------------------------------------------
+    def test_resolve_to_worker_marks_resolved(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        out = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.status, "resolved")
+        self.assertEqual(out.resolution_kind, "to_worker")
+
+    # (e) ----------------------------------------------------------------
+    def test_resolve_unknown_task_id_returns_none(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        self.assertIsNone(pd.resolve("nonexistent", "to_user", store_path=self.store))
+        # Original pending entry untouched
+        pending = pd.list_pending(store_path=self.store)
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0].status, "pending")
+
+    # (f) ----------------------------------------------------------------
+    def test_list_pending_older_than_filters_by_received_at(self) -> None:
+        old_ts = "2026-05-05T00:00:00Z"
+        new_ts = "2026-05-05T05:50:00Z"
+        seed = [
+            {
+                "task_id": "old",
+                "received_at": old_ts,
+                "raw_message": "old",
+                "status": "pending",
+            },
+            {
+                "task_id": "new",
+                "received_at": new_ts,
+                "raw_message": "new",
+                "status": "pending",
+            },
+            {
+                "task_id": "done",
+                "received_at": old_ts,
+                "raw_message": "done",
+                "status": "resolved",
+                "resolved_at": old_ts,
+                "resolution_kind": "to_worker",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+
+        now = datetime(2026, 5, 5, 6, 0, 0, tzinfo=timezone.utc)
+        result = pd.list_pending_older_than(15, store_path=self.store, now=now)
+        self.assertEqual([e.task_id for e in result], ["old"])
+
+    # (g) ----------------------------------------------------------------
+    def test_atomic_write_leaves_no_tmp_file(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        siblings = list(self.store.parent.iterdir())
+        names = sorted(p.name for p in siblings)
+        self.assertEqual(names, [self.store.name])
+        # No leftover tmp file
+        self.assertFalse(any(p.name.endswith(".tmp") for p in siblings))
+
+    # (h) ----------------------------------------------------------------
+    def test_malformed_json_raises_value_error(self) -> None:
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text("{not json", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            pd.list_pending(store_path=self.store)
+
+    # extras -------------------------------------------------------------
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+        self.assertEqual(
+            pd.list_pending_older_than(15, store_path=self.store), []
+        )
+
+    def test_resolve_picks_oldest_pending_when_multiple(self) -> None:
+        # Direct-seed two pending entries for the same task_id (the
+        # public append() de-dups, so we bypass it to construct the
+        # rare "multiple pending" state described in the spec).
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T05:00:00Z",
+                "raw_message": "newer",
+                "status": "pending",
+            },
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T04:00:00Z",
+                "raw_message": "older",
+                "status": "pending",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+
+        out = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertEqual(out.raw_message, "older")
+        # The newer one stays pending.
+        remaining = pd.list_pending(store_path=self.store)
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].raw_message, "newer")
+
+    def test_resolve_unknown_kind_raises(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        with self.assertRaises(ValueError):
+            pd.resolve("t1", "to_nowhere", store_path=self.store)  # type: ignore[arg-type]
+
+    def test_append_after_resolve_creates_new_pending(self) -> None:
+        pd.append("t1", "first", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        # A new judgment-request for the same task should re-open.
+        new_entry = pd.append("t1", "second round", store_path=self.store)
+        self.assertEqual(new_entry.status, "pending")
+        self.assertEqual(new_entry.raw_message, "second round")
+        raw = self._read_raw()
+        self.assertEqual(len(raw), 2)
+
+    def test_canonical_lifecycle_pending_escalated_resolved(self) -> None:
+        # Mirrors the prose contract in CLAUDE.md / SKILL.md:
+        # append -> resolve(to_user) -> resolve(to_worker) must terminate
+        # the entry as resolved (not be a no-op on the third step).
+        pd.append("t1", "ask", store_path=self.store)
+        first = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNotNone(first)
+        assert first is not None
+        self.assertEqual(first.status, "escalated")
+        second = pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertIsNotNone(second)
+        assert second is not None
+        self.assertEqual(second.status, "resolved")
+        self.assertEqual(second.resolution_kind, "to_worker")
+        # No open entries remain — relay-gap should not fire.
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+        self.assertEqual(
+            pd.list_pending_older_than(0, store_path=self.store), []
+        )
+
+    def test_resolve_to_user_after_escalated_is_noop(self) -> None:
+        # to_user only matches pending — escalated entries are not
+        # re-eligible for it.
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        again = pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertIsNone(again)
+
+    def test_list_pending_excludes_escalated(self) -> None:
+        # Escalated entries are awaiting human reply, not Secretary
+        # action — surfacing them as relay-gap would false-positive on
+        # every slow human answer. (a)(2) detection is left to a
+        # follow-up Issue with a richer schema.
+        old_ts = "2026-05-05T05:30:00Z"
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": old_ts,
+                "raw_message": "ask",
+                "status": "escalated",
+                "resolved_at": old_ts,
+                "resolution_kind": "to_user",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        now = datetime(2026, 5, 5, 5, 50, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            pd.list_pending_older_than(15, store_path=self.store, now=now),
+            [],
+        )
+        self.assertEqual(pd.list_pending(store_path=self.store), [])
+
+    def test_unknown_status_in_register_raises(self) -> None:
+        # Status validation matches the loud-failure stance taken for
+        # unparseable received_at and malformed JSON; silently dropping
+        # an unknown-status entry would be a false-negative source for
+        # the relay-gap fallback contract.
+        seed = [
+            {
+                "task_id": "t1",
+                "received_at": "2026-05-05T05:00:00Z",
+                "raw_message": "ask",
+                "status": "weird",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        with self.assertRaises(ValueError):
+            pd.list_pending(store_path=self.store)
+
+    def test_unparseable_received_at_is_surfaced(self) -> None:
+        # Malformed timestamp must surface as a relay-gap candidate
+        # rather than be silently dropped (loud failure beats false
+        # negative against .dispatcher/CLAUDE.md Step 5.1 contract).
+        seed = [
+            {
+                "task_id": "broken",
+                "received_at": "not-a-timestamp",
+                "raw_message": "ask",
+                "status": "pending",
+            },
+        ]
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(seed), encoding="utf-8")
+        out = pd.list_pending_older_than(15, store_path=self.store)
+        self.assertEqual([e.task_id for e in out], ["broken"])
+
+    def test_cli_append_and_list(self) -> None:
+        rc = pd.main(
+            [
+                "--store",
+                str(self.store),
+                "append",
+                "--task-id",
+                "tcli",
+                "--message",
+                "hi",
+            ]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(len(pd.list_pending(store_path=self.store)), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Secretary-side pending-decisions register (Issue #297).
+
+Tracks judgment-requests received by the Secretary from workers so that
+the dispatcher's SECRETARY_RELAY_GAP_SUSPECTED detection (Step 5.1 in
+``.dispatcher/CLAUDE.md``) can use a deterministic register lookup
+instead of proxy heuristics (snapshot diff / send_message timing).
+
+Lifecycle:
+
+* When the Secretary receives a judgment-request from a worker, it
+  appends an entry with ``status="pending"``.
+* When the Secretary relays the question to the human user, it resolves
+  the entry with ``kind="to_user"`` (status becomes ``escalated``).
+* When the Secretary relays the human's answer back to the worker, it
+  resolves with ``kind="to_worker"`` (status becomes ``resolved``).
+
+The dispatcher periodically calls :func:`list_pending_older_than` to
+find entries whose ``received_at`` is older than the relay-gap window;
+non-empty result triggers a SECRETARY_RELAY_GAP_SUSPECTED notification
+to the user pane.
+
+Storage is a JSON file (default ``.state/pending_decisions.json``)
+written atomically via tmp-file + ``os.replace``. Missing file is
+treated as an empty register. Malformed JSON raises ``ValueError`` —
+callers that want to keep working through corruption should catch it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+# Repo root resolution mirrors tools/journal_append.py — keeps the
+# default store path stable regardless of the caller's cwd (the
+# dispatcher runs from ``.dispatcher/`` and uses relative paths).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PATH = _REPO_ROOT / ".state" / "pending_decisions.json"
+
+ResolutionKind = Literal["to_user", "to_worker"]
+Status = Literal["pending", "resolved", "escalated"]
+
+_KIND_TO_STATUS: dict[str, Status] = {
+    "to_user": "escalated",
+    "to_worker": "resolved",
+}
+
+# Statuses that ``resolve`` can transition *from*. ``to_user`` only accepts
+# fresh ``pending`` entries (Secretary just received the request from the
+# worker). ``to_worker`` accepts either ``pending`` (Secretary skipped the
+# explicit user-relay step) or ``escalated`` (canonical flow:
+# pending → escalated when user is informed → resolved when worker is told).
+_KIND_TO_ELIGIBLE_STATUSES: dict[str, tuple[Status, ...]] = {
+    "to_user": ("pending",),
+    "to_worker": ("pending", "escalated"),
+}
+
+# Statuses considered "open" — neither terminal nor in steady-state at
+# the user's hands. Only ``pending`` qualifies: ``escalated`` means the
+# Secretary has already done its half (relayed to user) and the entry
+# is now waiting on the human, which we cannot distinguish from
+# "Secretary forgot to relay back" without a separate user-replied
+# marker. So ``escalated`` is intentionally **not** an alarm trigger
+# for relay-gap detection (would produce false positives whenever a
+# human takes >15 min to reply).
+_OPEN_STATUSES: tuple[Status, ...] = ("pending",)
+
+_VALID_STATUSES: frozenset[str] = frozenset({"pending", "escalated", "resolved"})
+
+
+@dataclass
+class PendingDecision:
+    task_id: str
+    received_at: str
+    raw_message: str
+    status: Status = "pending"
+    resolved_at: Optional[str] = None
+    resolution_kind: Optional[ResolutionKind] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PendingDecision":
+        return cls(
+            task_id=data["task_id"],
+            received_at=data["received_at"],
+            raw_message=data["raw_message"],
+            status=data.get("status", "pending"),
+            resolved_at=data.get("resolved_at"),
+            resolution_kind=data.get("resolution_kind"),
+        )
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load(store_path: Path) -> list[PendingDecision]:
+    if not store_path.exists():
+        return []
+    try:
+        raw = store_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"failed to read {store_path}: {exc}") from exc
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"malformed JSON in {store_path}: {exc.msg} at line {exc.lineno}"
+        ) from exc
+    if not isinstance(data, list):
+        raise ValueError(
+            f"malformed register in {store_path}: top-level must be a list"
+        )
+    out: list[PendingDecision] = []
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] is not a dict"
+            )
+        try:
+            decoded = PendingDecision.from_dict(entry)
+        except KeyError as exc:
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] missing {exc}"
+            ) from exc
+        if decoded.status not in _VALID_STATUSES:
+            raise ValueError(
+                f"malformed register in {store_path}: entry[{i}] has "
+                f"unknown status {decoded.status!r}; expected one of "
+                f"{sorted(_VALID_STATUSES)}"
+            )
+        out.append(decoded)
+    return out
+
+
+def _atomic_write(store_path: Path, entries: list[PendingDecision]) -> None:
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = store_path.with_name(store_path.name + ".tmp")
+    payload = json.dumps(
+        [e.to_dict() for e in entries],
+        ensure_ascii=False,
+        indent=2,
+    )
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, store_path)
+
+
+def append(
+    task_id: str,
+    raw_message: str,
+    store_path: Path = DEFAULT_PATH,
+) -> PendingDecision:
+    """Add a new pending entry, or return the existing pending one.
+
+    Idempotent: if ``task_id`` already has a ``pending`` entry, returns
+    that entry without modifying the store. Existing ``resolved`` /
+    ``escalated`` entries for the same ``task_id`` are ignored (a fresh
+    judgment-request can re-open).
+    """
+    entries = _load(store_path)
+    for entry in entries:
+        if entry.task_id == task_id and entry.status == "pending":
+            return entry
+    new_entry = PendingDecision(
+        task_id=task_id,
+        received_at=_now_iso(),
+        raw_message=raw_message,
+        status="pending",
+    )
+    entries.append(new_entry)
+    _atomic_write(store_path, entries)
+    return new_entry
+
+
+def resolve(
+    task_id: str,
+    kind: ResolutionKind,
+    store_path: Path = DEFAULT_PATH,
+) -> Optional[PendingDecision]:
+    """Advance the oldest open entry for ``task_id`` along the lifecycle.
+
+    Lifecycle: ``pending`` → ``escalated`` (relayed to user) →
+    ``resolved`` (relayed user's answer back to worker).
+
+    * ``kind="to_user"`` advances ``pending`` → ``escalated``. Only
+      pending entries are eligible.
+    * ``kind="to_worker"`` advances ``pending`` or ``escalated`` →
+      ``resolved``. Either step is a valid terminal transition (the
+      Secretary may skip the explicit ``to_user`` step in trivial cases
+      where it inlines the relay-back).
+
+    Returns the updated entry, or ``None`` if no eligible entry exists
+    for ``task_id`` (no-op). When multiple eligible entries exist
+    (rare), the one with the oldest ``received_at`` is advanced.
+    """
+    if kind not in _KIND_TO_STATUS:
+        raise ValueError(f"unknown kind {kind!r}; expected to_user|to_worker")
+    eligible = _KIND_TO_ELIGIBLE_STATUSES[kind]
+    entries = _load(store_path)
+    target_index: Optional[int] = None
+    for i, entry in enumerate(entries):
+        if entry.task_id != task_id or entry.status not in eligible:
+            continue
+        if target_index is None:
+            target_index = i
+            continue
+        # Multiple eligible entries (rare): keep the oldest received_at.
+        if entry.received_at < entries[target_index].received_at:
+            target_index = i
+    if target_index is None:
+        return None
+    target = entries[target_index]
+    target.status = _KIND_TO_STATUS[kind]
+    target.resolved_at = _now_iso()
+    target.resolution_kind = kind
+    _atomic_write(store_path, entries)
+    return target
+
+
+def list_pending(store_path: Path = DEFAULT_PATH) -> list[PendingDecision]:
+    """Return entries with status ``pending``.
+
+    ``escalated`` entries are awaiting human reply and are deliberately
+    excluded — they're in the user's hands, not Secretary's, and surface
+    as an alarm would produce false positives whenever the human takes
+    a while to answer. ``resolved`` is terminal and also excluded.
+    """
+    return [e for e in _load(store_path) if e.status in _OPEN_STATUSES]
+
+
+def list_pending_older_than(
+    threshold_minutes: int,
+    store_path: Path = DEFAULT_PATH,
+    now: Optional[datetime] = None,
+) -> list[PendingDecision]:
+    """``pending`` entries whose ``received_at`` is older than ``threshold_minutes``.
+
+    Used by the dispatcher's Step 5.1 (a-0) for the (a)(1) direction
+    (Secretary forgot to relay worker's question to user). The (a)(2)
+    direction (Secretary forgot to relay user's answer back to worker)
+    is intentionally not caught here — the register has no signal for
+    "user has replied" so escalated-too-long would fire on every slow
+    human answer. (a)(2) coverage requires a richer schema (e.g. a
+    ``user_replied_at`` marker) and is left for a follow-up Issue.
+
+    ``now`` is injectable for tests; defaults to ``datetime.now(UTC)``.
+    Entries with an unparseable ``received_at`` are surfaced (treated as
+    arbitrarily old) rather than silently skipped — silent drop would
+    create a relay-gap false negative against the fallback contract in
+    ``.dispatcher/CLAUDE.md`` Step 5.1.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=threshold_minutes)
+    out: list[PendingDecision] = []
+    for entry in _load(store_path):
+        if entry.status not in _OPEN_STATUSES:
+            continue
+        try:
+            received = datetime.strptime(
+                entry.received_at, "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=timezone.utc)
+        except ValueError:
+            # Unparseable timestamp: surface the entry as a relay-gap
+            # candidate (loud failure beats silent suppression).
+            out.append(entry)
+            continue
+        if received <= cutoff:
+            out.append(entry)
+    return out
+
+
+# --------------------------------------------------------------------- CLI
+
+
+def _print_entry(entry: PendingDecision) -> None:
+    print(json.dumps(entry.to_dict(), ensure_ascii=False))
+
+
+def _cmd_append(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    entry = append(args.task_id, args.message, store_path=store_path)
+    _print_entry(entry)
+    return 0
+
+
+def _cmd_resolve(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    entry = resolve(args.task_id, args.kind, store_path=store_path)
+    if entry is None:
+        print(json.dumps({"status": "no_pending", "task_id": args.task_id}))
+        return 0
+    _print_entry(entry)
+    return 0
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    if args.older_than_min is not None:
+        entries: Iterable[PendingDecision] = list_pending_older_than(
+            args.older_than_min, store_path=store_path
+        )
+    else:
+        entries = list_pending(store_path=store_path)
+    for entry in entries:
+        _print_entry(entry)
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="tools/pending_decisions.py",
+        description="Secretary pending-decisions register (Issue #297).",
+    )
+    parser.add_argument(
+        "--store",
+        help=f"override store path (default: {DEFAULT_PATH})",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_append = sub.add_parser("append", help="add a new pending entry (idempotent)")
+    p_append.add_argument("--task-id", required=True)
+    p_append.add_argument("--message", required=True)
+    p_append.set_defaults(func=_cmd_append)
+
+    p_resolve = sub.add_parser("resolve", help="resolve a pending entry")
+    p_resolve.add_argument("--task-id", required=True)
+    p_resolve.add_argument(
+        "--kind", required=True, choices=["to_user", "to_worker"]
+    )
+    p_resolve.set_defaults(func=_cmd_resolve)
+
+    p_list = sub.add_parser("list", help="list pending entries")
+    p_list.add_argument(
+        "--older-than-min",
+        type=int,
+        default=None,
+        help="only entries whose received_at is older than N minutes",
+    )
+    p_list.set_defaults(func=_cmd_list)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#302](https://github.com/suisya-systems/claude-org-ja/pull/302)

Merge SHA: `262b39365bb4b9345510a5ffc22142486ba3b02b`

Source: ja PR [#302](https://github.com/suisya-systems/claude-org-ja/pull/302)
Merge SHA: `262b39365bb4b9345510a5ffc22142486ba3b02b`

| class | count |
|---|---|
| runtime | 2 |
| translation | 2 |
| divergence-allowed | 1 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_pending_decisions.py`
- `tools/pending_decisions.py`

</details>
<details><summary>translation (2)</summary>

- `.claude/skills/org-delegate/SKILL.md`
- `CLAUDE.md`

</details>
<details><summary>divergence-allowed (1)</summary>

- `.dispatcher/CLAUDE.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
