### PR TITLE
auto-mirror: ja#299 docs(secretary): document live_repo_worktree convention for self-edit Pattern B

### DIFF
--- a/tests/fixtures/delegate_payload/delegate_payload_pattern_b_self_edit_full.golden.md
+++ b/tests/fixtures/delegate_payload/delegate_payload_pattern_b_self_edit_full.golden.md
@@ -1,0 +1,13 @@
+DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- snap-b-self-edit: refactor a skill
+  - ワーカーディレクトリ: <SANDBOX>/claude-org/.worktrees/snap-b-self-edit（CLAUDE.local.md・設定配置済み）
+  - ディレクトリパターン: B: worktree (live_repo_worktree — Secretary live repo 配下)
+  - プロジェクト: worktree base: <SANDBOX>/claude-org
+  - ブランチ (planned): feat/snap-b-self-edit
+  - Permission Mode: auto
+  - 検証深度: full
+  - 指示内容: 詳細は `<SANDBOX>/claude-org/.worktrees/snap-b-self-edit/CLAUDE.local.md` を参照。要約: refactor a skill
+
+窓口ペイン名: `secretary`（renga layout で登録済み）

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -1,0 +1,640 @@
+"""Unit tests for tools/resolve_worker_layout.py.
+
+Covers Issue #283 Stage 1 acceptance:
+- All 3 patterns (A new / A reuse / B / C ephemeral / C gitignored)
+- All 3 roles (default / claude-org-self-edit / doc-audit)
+- planned_branch inference (feat / fix / explicit override / null for Pattern C)
+- registry-not-found → Pattern C ephemeral
+- runs.status='queued' counts as active reservation (B-1 contract)
+- ``runs JOIN worker_dirs`` driven decision (B-2)
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools import resolve_worker_layout as rwl  # noqa: E402
+from tools.state_db import apply_schema, connect  # noqa: E402
+from tools.state_db.writer import StateWriter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture builder
+# ---------------------------------------------------------------------------
+
+
+class _Sandbox:
+    """One self-contained claude-org-like tree for a single test."""
+
+    def __init__(self, td: Path):
+        self.root = td
+        self.workers = td / "workers"
+        self.workers.mkdir()
+        # claude-org repo skeleton lives in <td>/claude-org/
+        self.claude_org_root = td / "claude-org"
+        self.claude_org_root.mkdir()
+        (self.claude_org_root / ".state").mkdir()
+        (self.claude_org_root / "registry").mkdir()
+        # workers_dir relative to claude-org root → ../workers
+        (self.claude_org_root / "registry" / "org-config.md").write_text(
+            "## Workers Directory\nworkers_dir: ../workers\n",
+            encoding="utf-8",
+        )
+        self.db_path = self.claude_org_root / ".state" / "state.db"
+        self.db_path.touch()  # let connect() open it (apply_schema below)
+        conn = connect(self.db_path)
+        apply_schema(conn)
+        conn.close()
+
+    # ---- registry helpers --------------------------------------------------
+
+    def write_registry(self, rows: list[tuple[str, str, str, str]]) -> None:
+        """Each row: (通称, slug, path, description)."""
+        lines = [
+            "# Projects Registry",
+            "",
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |",
+            "|---|---|---|---|---|",
+        ]
+        for common, slug, path, desc in rows:
+            lines.append(f"| {common} | {slug} | {path} | {desc} | - |")
+        (self.claude_org_root / "registry" / "projects.md").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    # ---- state.db helpers --------------------------------------------------
+
+    def add_run(
+        self,
+        *,
+        task_id: str,
+        project_slug: str,
+        pattern: str,
+        status: str,
+        worker_dir_abs: str,
+        title: str = "",
+    ) -> None:
+        conn = connect(self.db_path)
+        # NOTE: pass claude_org_root=False-equivalent; we don't want post-commit
+        # snapshotter to fire during fixture setup.
+        w = StateWriter(conn)
+        with w.transaction() as tx:
+            tx.register_worker_dir(abs_path=worker_dir_abs, layout="flat",
+                                   is_git_repo=True, is_worktree=(pattern == "B"))
+            tx.upsert_run(
+                task_id=task_id,
+                project_slug=project_slug,
+                pattern=pattern,
+                title=title or task_id,
+                status=status,
+                worker_dir_abs_path=worker_dir_abs,
+            )
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestPatternDetection(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_pattern_a_new_when_no_runs(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="clock-task-1",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+        self.assertEqual(layout.planned_branch, "feat/clock-task-1")
+
+    def test_pattern_a_reuse_when_only_completed_runs(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-prev",
+            project_slug="clock-app",
+            pattern="A",
+            status="completed",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-2",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+
+    def test_pattern_b_when_in_use_run_exists(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-other",
+            project_slug="clock-app",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-3",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app" / ".worktrees" / "clock-task-3").resolve(),
+        )
+        self.assertEqual(layout.planned_branch, "feat/clock-task-3")
+
+    def test_pattern_b_when_queued_run_exists(self):
+        """B-1 contract: runs.status='queued' is an active reservation."""
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-pending",
+            project_slug="clock-app",
+            pattern="A",
+            status="queued",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-q",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+
+    def test_pattern_b_when_review_run_exists(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        self.sb.add_run(
+            task_id="clock-prev-rev",
+            project_slug="clock-app",
+            pattern="A",
+            status="review",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-task-r",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+
+    def test_pattern_c_ephemeral_when_slug_not_in_registry(self):
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="adhoc-survey",
+            project_slug="not-in-registry",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "adhoc-survey").resolve(),
+        )
+        self.assertIsNone(layout.planned_branch)
+
+
+# ---------------------------------------------------------------------------
+# Pattern C gitignored sub-mode (Step 0.7)
+# ---------------------------------------------------------------------------
+
+
+class TestPatternCGitignored(unittest.TestCase):
+    """Requires `git` on PATH. Skipped when unavailable."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available")
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Set up a real local repo that has tmp/secret.txt gitignored.
+        self.local_repo = Path(self._td.name) / "local-repo"
+        self.local_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.local_repo), "init", "-q"],
+            check=True,
+        )
+        (self.local_repo / ".gitignore").write_text("tmp/\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_gitignored_target_forces_pattern_c_repo_root(self):
+        self.sb.write_registry(
+            [("ローカルアプリ", "local-app", str(self.local_repo), "Local repo demo")]
+        )
+        layout = rwl.resolve(
+            task_id="cleanup-tmp",
+            project_slug="local-app",
+            targets=["tmp/secret.txt"],
+            description="cleanup gitignored notes",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "gitignored_repo_root")
+        self.assertEqual(
+            Path(layout.worker_dir).resolve(),
+            self.local_repo.resolve(),
+        )
+        self.assertIsNone(layout.planned_branch)
+
+    def test_tracked_target_falls_through_to_normal_pattern_judgment(self):
+        # tracked file is NOT in tmp/ so check-ignore returns 1.
+        self.sb.write_registry(
+            [("ローカルアプリ", "local-app", str(self.local_repo), "Local repo demo")]
+        )
+        layout = rwl.resolve(
+            task_id="edit-readme",
+            project_slug="local-app",
+            targets=["README.md"],
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+
+
+# ---------------------------------------------------------------------------
+# Role / mode detection
+# ---------------------------------------------------------------------------
+
+
+class TestRoleDetection(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Register the sandbox claude-org root as a project so role detection
+        # has something to compare against.
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-ja",
+                    "claude-org-ja",
+                    str(self.sb.claude_org_root),
+                    "claude-org self",
+                ),
+            ]
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_default_role_for_non_claude_org_edit(self):
+        layout = rwl.resolve(
+            task_id="t-1",
+            project_slug="clock-app",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+
+    def test_claude_org_self_edit_role_when_editing_claude_org(self):
+        layout = rwl.resolve(
+            task_id="t-2",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+
+    def test_audit_mode_forces_doc_audit_even_for_claude_org(self):
+        layout = rwl.resolve(
+            task_id="t-3",
+            project_slug="claude-org-ja",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+        self.assertFalse(layout.self_edit)
+
+    def test_audit_mode_for_non_claude_org_also_doc_audit(self):
+        layout = rwl.resolve(
+            task_id="t-4",
+            project_slug="clock-app",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+
+
+# ---------------------------------------------------------------------------
+# Branch inference
+# ---------------------------------------------------------------------------
+
+
+class TestBranchInference(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _resolve(self, **kw):
+        defaults = dict(
+            task_id="task-x",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        defaults.update(kw)
+        return rwl.resolve(**defaults)
+
+    def test_feat_prefix_when_description_has_no_fix_words(self):
+        layout = self._resolve(description="add a new sparkline component")
+        self.assertEqual(layout.planned_branch, "feat/task-x")
+
+    def test_fix_prefix_for_english_bug_word(self):
+        layout = self._resolve(description="bug in clock tick handler")
+        self.assertEqual(layout.planned_branch, "fix/task-x")
+
+    def test_fix_prefix_for_japanese_word(self):
+        layout = self._resolve(description="ロード時の修正")
+        self.assertEqual(layout.planned_branch, "fix/task-x")
+
+    def test_branch_override_wins(self):
+        layout = self._resolve(
+            description="bug bug bug",
+            branch_override="release/2026-05",
+        )
+        self.assertEqual(layout.planned_branch, "release/2026-05")
+
+    def test_pattern_c_branch_is_null(self):
+        # unregistered slug → Pattern C → no branch
+        layout = self._resolve(project_slug="totally-new")
+        self.assertEqual(layout.pattern, "C")
+        self.assertIsNone(layout.planned_branch)
+
+
+# ---------------------------------------------------------------------------
+# Settings args & CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsArgs(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_settings_args_carries_all_required_keys(self):
+        layout = rwl.resolve(
+            task_id="t-5",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        args = layout.settings_args
+        self.assertEqual(set(args), {"role", "worker-dir", "claude-org-path", "out"})
+        self.assertEqual(args["role"], layout.role)
+        self.assertEqual(args["worker-dir"], layout.worker_dir)
+        self.assertTrue(args["out"].endswith(os.path.join(".claude", "settings.local.json")))
+
+
+class TestCLI(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry([("時計", "clock-app", "-", "")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_cli_emits_valid_json(self):
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = rwl.main([
+                "--task-id", "cli-test",
+                "--project-slug", "clock-app",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+            ])
+        self.assertEqual(rc, 0)
+        data = json.loads(buf.getvalue())
+        self.assertEqual(data["pattern"], "A")
+        self.assertEqual(data["role"], "default")
+        self.assertEqual(data["planned_branch"], "feat/cli-test")
+        self.assertIn("settings_args", data)
+
+    def test_cli_invalid_mode_returns_2(self):
+        # argparse rejects choices and exits 2; we route through SystemExit.
+        with self.assertRaises(SystemExit) as cm:
+            rwl.main([
+                "--task-id", "x",
+                "--project-slug", "clock-app",
+                "--mode", "delete",
+                "--claude-org-root", str(self.sb.claude_org_root),
+            ])
+        self.assertEqual(cm.exception.code, 2)
+
+
+# ---------------------------------------------------------------------------
+# Issue #289: Pattern B live_repo_worktree variant for claude-org self-edit
+# ---------------------------------------------------------------------------
+
+
+class TestPatternBLiveRepoWorktree(unittest.TestCase):
+    """Issue #289: claude-org self-edit Pattern B places the worktree under
+    Secretary's live repo (claude_org_root/.worktrees/{task_id}/) rather than
+    {workers_dir}/{project_slug}/.worktrees/."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-ja",
+                    "claude-org-ja",
+                    str(self.sb.claude_org_root),
+                    "claude-org self",
+                ),
+            ]
+        )
+        # An active run on claude-org-ja forces Pattern B for the next task.
+        self.sb.add_run(
+            task_id="self-edit-prev",
+            project_slug="claude-org-ja",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.claude_org_root),
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_pattern_b_self_edit_auto_selects_live_repo_worktree(self):
+        """Pattern B + role=claude-org-self-edit + variant unset →
+        variant auto-selected to 'live_repo_worktree' and worker_dir under
+        claude_org_root/.worktrees/."""
+        layout = rwl.resolve(
+            task_id="self-edit-task",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+        self.assertEqual(layout.pattern_variant, "live_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.claude_org_root / ".worktrees" / "self-edit-task").resolve(),
+        )
+
+    def test_pattern_b_default_role_keeps_null_variant_and_workers_dir(self):
+        """Pattern B + role=default → variant stays None and worker_dir is
+        the conventional {workers_dir}/{project_slug}/.worktrees/ path."""
+        # Add an active run on clock-app so Pattern B fires for the new task.
+        self.sb.add_run(
+            task_id="clock-prev",
+            project_slug="clock-app",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="clock-next",
+            project_slug="clock-app",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.role, "default")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "clock-app" / ".worktrees" / "clock-next").resolve(),
+        )
+
+    def test_inconsistent_role_self_edit_combo_is_rejected(self):
+        """Codex Round 3 Major regression: role and self_edit must agree.
+        role='default' + self_edit=true would otherwise let the coherence
+        pass relocate the worktree under claude_org_root while the
+        settings generator still emits non-self-edit permissions."""
+        with self.assertRaises(rwl.ResolveError):
+            rwl.resolve(
+                task_id="bad-combo",
+                project_slug="clock-app",
+                mode="edit",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={"role": "default", "self_edit": True},
+            )
+
+    def test_role_only_override_to_self_edit_re_derives_variant_and_worker_dir(self):
+        """Codex Round 1 Major regression: passing ONLY
+        layout_overrides={'role': 'claude-org-self-edit'} on a Pattern B
+        layout must promote pattern_variant to 'live_repo_worktree' and
+        relocate worker_dir to {claude_org_root}/.worktrees/. Otherwise
+        the resolver would emit an incoherent layout (role=self_edit but
+        worker_dir under {workers_dir}/{project_slug}/.worktrees/)."""
+        # Active run on clock-app forces Pattern B for the new task; the
+        # auto-resolved role would be 'default' (clock-app != claude-org).
+        self.sb.add_run(
+            task_id="clock-prev",
+            project_slug="clock-app",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(self.sb.workers / "clock-app"),
+        )
+        layout = rwl.resolve(
+            task_id="role-promoted",
+            project_slug="clock-app",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"role": "claude-org-self-edit"},
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+        self.assertEqual(layout.pattern_variant, "live_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.claude_org_root / ".worktrees" / "role-promoted").resolve(),
+        )
+
+    def test_explicit_variant_via_layout_overrides_resets_worker_dir(self):
+        """layout_overrides supplying pattern=B + variant='live_repo_worktree'
+        without an explicit worker_dir → resolver re-derives worker_dir under
+        claude_org_root/.worktrees/."""
+        layout = rwl.resolve(
+            task_id="explicit-self-edit",
+            project_slug="clock-app",  # not claude-org, so auto-derive picks default role
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+            },
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "live_repo_worktree")
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.claude_org_root / ".worktrees" / "explicit-self-edit").resolve(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -1,0 +1,796 @@
+"""Generate the Secretary's DELEGATE payload for a worker dispatch.
+
+Issue #283 Stage 3. Top-level CLI that takes the same task-shape inputs
+:mod:`tools.gen_worker_brief` ``from-task`` accepts, then assembles the
+full delegation packet:
+
+- ``preview`` (default): pure planning. Emits the DELEGATE message body
+  to stdout plus a list of artifacts that *would* be created. **Touches
+  no files, no DB, no MCP.** This lets Secretary inspect the plan before
+  committing to a reservation.
+
+- ``apply``: performs the T1 reservation per Set B contract:
+
+  1. Reserve the worker_dir + run row in state.db with
+     ``runs.status='queued'`` (Codex Design Blocker B-1; ``Active Work
+     Items`` remains the dispatcher's T2 responsibility — see
+     ``docs/contracts/delegation-lifecycle-contract.md``).
+  2. Write CLAUDE.md / CLAUDE.local.md via :mod:`tools.gen_worker_brief`.
+  3. Optionally call ``claude-org-runtime settings generate`` to write
+     ``.claude/settings.local.json`` (skip with ``--skip-settings``;
+     useful when the runtime CLI isn't on PATH yet, e.g. in tests).
+  4. Emit ``send_plan.json`` describing the renga-peers send_message
+     call Secretary should issue (``to_id="dispatcher"``, ``message=<body>``).
+     Codex M-3 reframed the original ``--send`` flag: this script never
+     calls MCP itself; Secretary copies the JSON into their own
+     ``mcp__renga-peers__send_message`` call.
+
+The internal split is :func:`build_delegate_plan` (pure planner returning
+a :class:`DelegatePlan`) and :func:`apply_delegate_plan` (side-effect
+executor). Tests exercise both paths.
+"""
+from __future__ import annotations
+
+# Direct-script bootstrap (see tools/resolve_worker_layout.py for context).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback
+    import tomli as tomllib  # type: ignore[no-redef]
+
+from tools import gen_worker_brief as gwb
+from tools import resolve_worker_layout as rwl
+
+
+_PERMISSION_MODE_RE = re.compile(
+    r"^\s*default_permission_mode\s*:\s*(\S+)\s*$", re.MULTILINE
+)
+
+_PATTERN_LABELS = {
+    "A": "A: プロジェクトディレクトリ",
+    "B": "B: worktree",
+    "C": "C: エフェメラル",
+}
+
+
+@dataclass(frozen=True)
+class DelegatePlan:
+    task_id: str
+    project_slug: str
+    description: str
+    config: dict[str, Any]
+    layout: rwl.WorkerLayout
+    delegate_body: str
+    brief_out_path: Path
+    settings_args: dict[str, str]
+    permission_mode: str
+    verification_depth: str
+    closes_issue: Optional[int]
+    refs_issues: list[int]
+    artifacts_to_create: list[Path] = field(default_factory=list)
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "project_slug": self.project_slug,
+            "pattern": self.layout.pattern,
+            "pattern_variant": self.layout.pattern_variant,
+            "role": self.layout.role,
+            "self_edit": self.layout.self_edit,
+            "worker_dir": self.layout.worker_dir,
+            "planned_branch": self.layout.planned_branch,
+            "permission_mode": self.permission_mode,
+            "verification_depth": self.verification_depth,
+            "brief_out_path": str(self.brief_out_path),
+            "settings_args": dict(self.settings_args),
+            "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_permission_mode(claude_org_root: Path) -> str:
+    """Return the org-wide ``default_permission_mode`` (defaults to ``auto``)."""
+    cfg = claude_org_root / "registry" / "org-config.md"
+    if not cfg.exists():
+        return "auto"
+    text = cfg.read_text(encoding="utf-8")
+    m = _PERMISSION_MODE_RE.search(text)
+    return m.group(1) if m else "auto"
+
+
+def _pattern_label(layout: rwl.WorkerLayout) -> str:
+    base = _PATTERN_LABELS.get(layout.pattern, layout.pattern)
+    if layout.pattern_variant == "gitignored_repo_root":
+        return "C: gitignored サブモード (registered repo 直接編集)"
+    if layout.pattern_variant == "live_repo_worktree":
+        return "B: worktree (live_repo_worktree — Secretary live repo 配下)"
+    return base
+
+
+def _project_label(layout: rwl.WorkerLayout, project_path: Optional[str]) -> str:
+    if layout.pattern == "A":
+        return f"clone or reuse: {project_path or '-'}"
+    if layout.pattern == "B":
+        return f"worktree base: {project_path or '-'}"
+    if layout.pattern == "C":
+        if layout.pattern_variant == "gitignored_repo_root":
+            return f"既存 repo 直接編集: {layout.worker_dir}"
+        return "新規作成 (clone なし) — エフェメラル"
+    return project_path or "-"
+
+
+def _summarize_description(description: str, limit: int = 120) -> str:
+    one_line = " ".join(description.strip().split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: limit - 1].rstrip() + "…"
+
+
+def _brief_filename(self_edit: bool) -> str:
+    return "CLAUDE.local.md" if self_edit else "CLAUDE.md"
+
+
+def _format_delegate_body(
+    *,
+    layout: rwl.WorkerLayout,
+    task_id: str,
+    description: str,
+    project_path: Optional[str],
+    permission_mode: str,
+    verification_depth: str,
+    brief_filename: str,
+) -> str:
+    """Format the DELEGATE message body per org-delegate Step 2 template."""
+    instr_summary = _summarize_description(description)
+    branch_line = (
+        layout.planned_branch
+        if layout.planned_branch
+        else "(Pattern C: 既存 repo の現在ブランチで作業 / 新規 branch なし)"
+    )
+    # Use the platform-native joiner to avoid the mixed `\\…/CLAUDE.md`
+    # output the literal-`/` template produced on Windows (Codex Round 1 Nit).
+    brief_full_path = str(Path(layout.worker_dir) / brief_filename)
+    body = f"""DELEGATE: 以下のワーカーを派遣してください。
+
+タスク一覧:
+- {task_id}: {instr_summary or task_id}
+  - ワーカーディレクトリ: {layout.worker_dir}（{brief_filename}・設定配置済み）
+  - ディレクトリパターン: {_pattern_label(layout)}
+  - プロジェクト: {_project_label(layout, project_path)}
+  - ブランチ (planned): {branch_line}
+  - Permission Mode: {permission_mode}
+  - 検証深度: {verification_depth}
+  - 指示内容: 詳細は `{brief_full_path}` を参照。要約: {instr_summary or '(none)'}
+
+窓口ペイン名: `secretary`（renga layout で登録済み）"""
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Planner — pure
+# ---------------------------------------------------------------------------
+
+
+def build_delegate_plan(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    commit_prefix: Optional[str] = None,
+    verification_depth: str = "full",
+    issue_url: Optional[str] = None,
+    closes_issue: Optional[int] = None,
+    refs_issues: Optional[list[int]] = None,
+    project_description_override: Optional[str] = None,
+    implementation_target_files: Optional[list[str]] = None,
+    implementation_guidance: Optional[str] = None,
+    references_knowledge: Optional[list[str]] = None,
+    parallel_notes: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
+) -> DelegatePlan:
+    """Resolve the layout, assemble the brief config, format the DELEGATE body.
+
+    Pure: no file writes, no DB writes, no subprocesses other than the
+    ``git check-ignore`` Step 0.7 probe (read-only) inside the resolver.
+    """
+    config, layout = gwb.build_config_from_task(
+        task_id=task_id,
+        project_slug=project_slug,
+        targets=targets,
+        description=description,
+        mode=mode,
+        branch_override=branch_override,
+        commit_prefix=commit_prefix,
+        verification_depth=verification_depth,
+        issue_url=issue_url,
+        closes_issue=closes_issue,
+        refs_issues=refs_issues,
+        project_description_override=project_description_override,
+        implementation_target_files=implementation_target_files,
+        implementation_guidance=implementation_guidance,
+        references_knowledge=references_knowledge,
+        parallel_notes=parallel_notes,
+        registry_path=registry_path,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        workers_dir=workers_dir,
+        layout_overrides=layout_overrides,
+    )
+
+    self_edit = bool(config["worker"]["self_edit"])
+    brief_filename = _brief_filename(self_edit)
+    brief_out_path = Path(layout.worker_dir) / brief_filename
+
+    permission_mode = parse_permission_mode(Path(claude_org_root))
+
+    # Look up project.path for the DELEGATE body label.
+    project_path: Optional[str] = None
+    registry_for_meta = registry_path or (
+        Path(claude_org_root) / "registry" / "projects.md"
+    )
+    if registry_for_meta.exists():
+        rows = rwl.parse_projects(registry_for_meta)
+        match = rwl.find_project(rows, project_slug)
+        if match is not None:
+            project_path = match.path
+
+    delegate_body = _format_delegate_body(
+        layout=layout,
+        task_id=task_id,
+        description=description,
+        project_path=project_path,
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        brief_filename=brief_filename,
+    )
+
+    artifacts = [
+        brief_out_path,
+        Path(layout.worker_dir) / ".claude" / "settings.local.json",
+    ]
+
+    return DelegatePlan(
+        task_id=task_id,
+        project_slug=project_slug,
+        description=description,
+        config=config,
+        layout=layout,
+        delegate_body=delegate_body,
+        brief_out_path=brief_out_path,
+        settings_args=dict(layout.settings_args),
+        permission_mode=permission_mode,
+        verification_depth=verification_depth,
+        closes_issue=closes_issue,
+        refs_issues=list(refs_issues or []),
+        artifacts_to_create=artifacts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executor — side effects (DB write, file write, settings subprocess)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApplyResult:
+    plan: DelegatePlan
+    brief_path: Path
+    settings_path: Optional[Path]
+    settings_skipped_reason: Optional[str]
+    send_plan_path: Path
+    db_reservation: dict[str, Any]
+
+
+def _reserve_in_db(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path],
+) -> dict[str, Any]:
+    """Reserve the worker_dir + queue the run row.
+
+    Per Codex Design Blocker B-1 + Set B contract, this writes
+    ``runs.status='queued'`` only. Active Work Items remains the
+    dispatcher's T2 responsibility and is *not* touched here.
+    """
+    from tools.state_db import apply_schema, connect
+    from tools.state_db.writer import StateWriter
+
+    if not state_db_path.exists():
+        # Fresh DB — create empty file and apply schema. The importer
+        # would normally seed projects/workstreams; we only need a usable
+        # schema here, ensure_project below will create the project row.
+        state_db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = connect(state_db_path)
+        apply_schema(conn)
+        conn.close()
+
+    conn = connect(state_db_path)
+    try:
+        writer = StateWriter(conn, claude_org_root=claude_org_root)
+        with writer.transaction() as tx:
+            tx.register_worker_dir(
+                abs_path=plan.layout.worker_dir,
+                layout="flat",
+                is_git_repo=plan.layout.pattern != "C"
+                or plan.layout.pattern_variant == "gitignored_repo_root",
+                is_worktree=plan.layout.pattern == "B",
+            )
+            issue_refs_iter = None
+            if plan.closes_issue is not None:
+                issue_refs_iter = [str(plan.closes_issue)]
+            elif plan.refs_issues:
+                issue_refs_iter = [str(n) for n in plan.refs_issues]
+            tx.upsert_run(
+                task_id=plan.task_id,
+                project_slug=plan.project_slug,
+                pattern=plan.layout.pattern,
+                title=plan.task_id,
+                status="queued",
+                branch=plan.layout.planned_branch,
+                issue_refs=issue_refs_iter,
+                verification=(
+                    "minimal" if plan.verification_depth == "minimal" else "standard"
+                ),
+                worker_dir_abs_path=plan.layout.worker_dir,
+            )
+        return {
+            "task_id": plan.task_id,
+            "project_slug": plan.project_slug,
+            "worker_dir": plan.layout.worker_dir,
+            "status": "queued",
+        }
+    finally:
+        conn.close()
+
+
+def _write_brief(plan: DelegatePlan) -> Path:
+    text = gwb.render(plan.config)
+    out = plan.brief_out_path
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    return out
+
+
+def _run_settings_generate(
+    plan: DelegatePlan,
+    *,
+    runtime_cmd: str = "claude-org-runtime",
+) -> tuple[Optional[Path], Optional[str]]:
+    """Run ``claude-org-runtime settings generate``.
+
+    Returns ``(written_path, skipped_reason)``. When the CLI is missing
+    we return ``(None, reason)`` and let the caller record it in the
+    ApplyResult — apply does NOT crash, since several real-world dispatch
+    flows happen on machines without the runtime installed (e.g. fresh
+    test sandboxes).
+    """
+    if shutil.which(runtime_cmd) is None:
+        return None, f"{runtime_cmd!r} not on PATH"
+
+    settings_args = plan.settings_args
+    out = Path(settings_args["out"])
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        runtime_cmd,
+        "settings",
+        "generate",
+        "--role",
+        settings_args["role"],
+        "--worker-dir",
+        settings_args["worker-dir"],
+        "--claude-org-path",
+        settings_args["claude-org-path"],
+        "--out",
+        settings_args["out"],
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except subprocess.CalledProcessError as e:
+        return None, (
+            f"{runtime_cmd} settings generate failed (rc={e.returncode}): "
+            f"{(e.stderr or b'').decode('utf-8', errors='replace').strip()}"
+        )
+    return out, None
+
+
+def _write_send_plan(plan: DelegatePlan, *, out_path: Path) -> Path:
+    """Write the renga-peers MCP call manifest Secretary will copy from."""
+    payload = {
+        "to_id": "dispatcher",
+        "message": plan.delegate_body,
+        "summary": plan.to_summary_dict(),
+    }
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def apply_delegate_plan(
+    plan: DelegatePlan,
+    *,
+    state_db_path: Path,
+    claude_org_root: Optional[Path] = None,
+    skip_settings: bool = False,
+    runtime_cmd: str = "claude-org-runtime",
+    send_plan_out: Optional[Path] = None,
+) -> ApplyResult:
+    """Execute the side effects: reserve in DB, write brief, settings, send_plan."""
+    db_reservation = _reserve_in_db(
+        plan, state_db_path=state_db_path, claude_org_root=claude_org_root
+    )
+    brief_path = _write_brief(plan)
+    settings_path: Optional[Path] = None
+    skipped_reason: Optional[str] = None
+    if skip_settings:
+        skipped_reason = "skip_settings flag set"
+    else:
+        settings_path, skipped_reason = _run_settings_generate(
+            plan, runtime_cmd=runtime_cmd
+        )
+    if send_plan_out is None:
+        send_plan_out = brief_path.with_name("send_plan.json")
+    send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
+    return ApplyResult(
+        plan=plan,
+        brief_path=brief_path,
+        settings_path=settings_path,
+        settings_skipped_reason=skipped_reason,
+        send_plan_path=send_plan_path,
+        db_reservation=db_reservation,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _add_task_args(p: argparse.ArgumentParser) -> None:
+    """Args shared by preview and apply for the from-task input form.
+
+    Defaults for ``--mode`` and ``--verification-depth`` are intentionally
+    ``None``. The merge step in :func:`_gather_plan_kwargs` only treats a
+    CLI value as an override when it is not None, so a ``--from-toml``
+    config's ``mode`` / ``verification_depth`` survives unless the caller
+    explicitly re-passes the flag. Final defaults (``edit`` / ``full``)
+    are applied after merging — see Codex Round 1 Major.
+    """
+    p.add_argument("--task-id")
+    p.add_argument("--project-slug")
+    p.add_argument("--target", action="append", default=[])
+    p.add_argument("--description", default=None)
+    p.add_argument("--mode", choices=("edit", "audit"), default=None)
+    p.add_argument("--branch", dest="branch_override", default=None)
+    p.add_argument("--commit-prefix", default=None)
+    p.add_argument(
+        "--verification-depth", choices=("full", "minimal"), default=None
+    )
+    p.add_argument("--issue-url", default=None)
+    p.add_argument("--closes-issue", type=int, default=None)
+    p.add_argument("--refs-issues", type=int, nargs="*", default=None)
+    # Intentionally no --project-name: project.name is the slug (use
+    # --project-slug). Allowing an override created a round-trip drift
+    # where the next --from-toml read 通称 back as the slug (Codex Round 2).
+    p.add_argument(
+        "--project-description",
+        dest="project_description_override",
+        default=None,
+    )
+    p.add_argument("--impl-target", action="append", default=[])
+    p.add_argument("--impl-guidance", default=None)
+    p.add_argument("--knowledge", action="append", default=[])
+    p.add_argument("--parallel-notes", default=None)
+    p.add_argument("--registry-path", type=Path, default=None)
+    p.add_argument("--state-db-path", type=Path, default=None)
+    p.add_argument("--claude-org-root", type=Path, default=None)
+    p.add_argument("--workers-dir", type=Path, default=None)
+    p.add_argument(
+        "--from-toml",
+        type=Path,
+        default=None,
+        help="Load task arguments from a worker_brief-style TOML instead of CLI flags.",
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="gen_delegate_payload",
+        description="Generate the Secretary's DELEGATE payload (preview or apply).",
+    )
+    sub = p.add_subparsers(dest="cmd")
+    sub.required = True
+
+    preview = sub.add_parser(
+        "preview",
+        help="Print the planned DELEGATE body and artifact paths. No writes.",
+    )
+    _add_task_args(preview)
+    preview.add_argument(
+        "--json", dest="json_out", action="store_true",
+        help="Emit a single JSON object instead of human-readable text.",
+    )
+
+    apply_p = sub.add_parser(
+        "apply",
+        help="Reserve in DB (runs.status='queued'), write brief, settings, send_plan.json.",
+    )
+    _add_task_args(apply_p)
+    apply_p.add_argument(
+        "--skip-settings", action="store_true",
+        help="Skip the claude-org-runtime settings generate subprocess.",
+    )
+    apply_p.add_argument("--runtime-cmd", default="claude-org-runtime")
+    apply_p.add_argument(
+        "--send-plan-out",
+        type=Path,
+        default=None,
+        help="Override send_plan.json output path (default: alongside the brief).",
+    )
+
+    return p
+
+
+def _resolve_claude_org_root(args: argparse.Namespace) -> Path:
+    """Resolve claude-org repo root. Priority (highest first):
+
+    1. ``--claude-org-root`` CLI flag (explicit).
+    2. ``[paths] claude_org`` from ``--from-toml`` (Issue #290 defect 2 —
+       previously ignored, leaving cwd-derived paths to drift).
+    3. cwd-walk fallback (:func:`gwb._detect_claude_org_root`).
+    """
+    if args.claude_org_root is not None:
+        return Path(args.claude_org_root).resolve()
+    toml_path = getattr(args, "from_toml", None)
+    if toml_path is not None:
+        try:
+            with Path(toml_path).open("rb") as fh:
+                cfg = tomllib.load(fh)
+        except (OSError, tomllib.TOMLDecodeError):
+            cfg = {}
+        cfg_path = (cfg.get("paths") or {}).get("claude_org")
+        if cfg_path:
+            p = Path(cfg_path)
+            if not p.is_absolute():
+                p = (Path(toml_path).resolve().parent / p)
+            return p.resolve()
+    return gwb._detect_claude_org_root()
+
+
+def _resolve_state_db_path(args: argparse.Namespace, claude_org_root: Path) -> Path:
+    if args.state_db_path is not None:
+        return args.state_db_path
+    return claude_org_root / ".state" / "state.db"
+
+
+def _load_task_args_from_toml(path: Path) -> dict[str, Any]:
+    """Pull task-shape kwargs out of a worker_brief.toml.
+
+    The TOML schema (see ``tools/templates/worker_brief.example.toml``)
+    uses ``project.name`` for the slug — that's what both the legacy
+    hand-written briefs and Stage 2's ``from-task`` output write — so we
+    treat it as ``project_slug`` directly. Codex Round 1+2 caught the
+    inversions (common_name vs slug; --project-name override drift).
+
+    ``mode`` is derived from ``worker.role``: ``doc-audit`` → ``audit``,
+    everything else → ``edit``. Returning the field at all (even when
+    falsey) lets the merge step recognise an explicit TOML setting.
+    """
+    with path.open("rb") as fh:
+        cfg = tomllib.load(fh)
+    task = cfg.get("task", {})
+    worker = cfg.get("worker", {})
+    project = cfg.get("project", {})
+    impl = cfg.get("implementation", {})
+    refs = cfg.get("references", {})
+    parallel = cfg.get("parallel", {})
+    role = (worker.get("role") or "").strip()
+    mode_from_toml = "audit" if role == "doc-audit" else "edit"
+
+    # Issue #290 defect 1: surface explicit [worker] fields so the resolver
+    # honors them instead of silently re-deriving pattern/role/dir/self_edit.
+    layout_overrides: dict[str, Any] = {}
+    if worker.get("pattern"):
+        layout_overrides["pattern"] = worker["pattern"]
+    if worker.get("pattern_variant"):
+        layout_overrides["pattern_variant"] = worker["pattern_variant"]
+    if worker.get("dir"):
+        # Resolve relative dirs against the TOML file's parent so
+        # [paths].claude_org and [worker].dir share the same base
+        # (Codex Round 1 Minor — previously cwd-relative).
+        wd = Path(worker["dir"])
+        if not wd.is_absolute():
+            wd = (path.resolve().parent / wd)
+        layout_overrides["worker_dir"] = str(wd)
+    if role:
+        layout_overrides["role"] = role
+    if "self_edit" in worker:
+        # Pass through unchanged so resolve()'s strict bool check fires
+        # on malformed input (e.g. self_edit = "false" parsed as a string).
+        # Codex Round 2 Minor.
+        layout_overrides["self_edit"] = worker["self_edit"]
+
+    return {
+        "task_id": task.get("id"),
+        "project_slug": project.get("name"),
+        "description": task.get("description"),
+        "branch_override": task.get("branch"),
+        "commit_prefix": task.get("commit_prefix"),
+        "verification_depth": task.get("verification_depth"),
+        "issue_url": task.get("issue_url"),
+        "closes_issue": task.get("closes_issue"),
+        "refs_issues": task.get("refs_issues"),
+        "project_description_override": project.get("description"),
+        "implementation_target_files": impl.get("target_files"),
+        "implementation_guidance": impl.get("guidance"),
+        "references_knowledge": refs.get("knowledge"),
+        "parallel_notes": parallel.get("notes"),
+        "mode": mode_from_toml,
+        "layout_overrides": layout_overrides or None,
+    }
+
+
+def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
+    """Merge --from-toml defaults with CLI flags (CLI wins).
+
+    Defaults for ``mode`` (``edit``) and ``verification_depth`` (``full``)
+    are applied **after** the merge so a TOML-supplied value survives a
+    bare CLI invocation. Otherwise argparse's defaults would always win
+    and TOML round-trip would silently flatten ``doc-audit`` / ``minimal``.
+    """
+    base: dict[str, Any] = {}
+    if args.from_toml is not None:
+        base.update(_load_task_args_from_toml(args.from_toml))
+    # CLI overrides — only when caller actually provided a value.
+    cli_overrides: dict[str, Any] = {
+        "task_id": args.task_id,
+        "project_slug": args.project_slug,
+        "targets": args.target or None,
+        "description": args.description,
+        "mode": args.mode,
+        "branch_override": args.branch_override,
+        "commit_prefix": args.commit_prefix,
+        "verification_depth": args.verification_depth,
+        "issue_url": args.issue_url,
+        "closes_issue": args.closes_issue,
+        "refs_issues": args.refs_issues,
+        "project_description_override": args.project_description_override,
+        "implementation_target_files": args.impl_target or None,
+        "implementation_guidance": args.impl_guidance,
+        "references_knowledge": args.knowledge or None,
+        "parallel_notes": args.parallel_notes,
+        "registry_path": args.registry_path,
+        "workers_dir": args.workers_dir,
+    }
+    for k, v in cli_overrides.items():
+        if v is not None:
+            base[k] = v
+    base.setdefault("mode", "edit")
+    base.setdefault("verification_depth", "full")
+    base.setdefault("description", "")
+    if not base.get("task_id"):
+        raise SystemExit("error: --task-id is required (or supply --from-toml)")
+    if not base.get("project_slug"):
+        raise SystemExit(
+            "error: --project-slug is required (or supply --from-toml)"
+        )
+    return base
+
+
+def _cmd_preview(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+
+    if args.json_out:
+        json.dump(
+            {
+                "delegate_body": plan.delegate_body,
+                "summary": plan.to_summary_dict(),
+            },
+            sys.stdout,
+            indent=2,
+            ensure_ascii=False,
+        )
+        sys.stdout.write("\n")
+        return 0
+
+    print("--- DELEGATE body (preview, no writes) ---")
+    print(plan.delegate_body)
+    print()
+    print("--- Artifacts that 'apply' would create ---")
+    for p in plan.artifacts_to_create:
+        print(f"  {p}")
+    print(f"  send_plan.json (alongside brief)")
+    print()
+    print("--- Layout summary ---")
+    print(json.dumps(plan.to_summary_dict(), indent=2, ensure_ascii=False))
+    return 0
+
+
+def _cmd_apply(args: argparse.Namespace) -> int:
+    claude_org_root = _resolve_claude_org_root(args)
+    state_db_path = _resolve_state_db_path(args, claude_org_root)
+    kwargs = _gather_plan_kwargs(args)
+    plan = build_delegate_plan(
+        claude_org_root=claude_org_root,
+        state_db_path=state_db_path if state_db_path.exists() else None,
+        **kwargs,
+    )
+    result = apply_delegate_plan(
+        plan,
+        state_db_path=state_db_path,
+        claude_org_root=claude_org_root,
+        skip_settings=args.skip_settings,
+        runtime_cmd=args.runtime_cmd,
+        send_plan_out=args.send_plan_out,
+    )
+    print(f"reserved (queued) task_id={plan.task_id} pattern={plan.layout.pattern}")
+    print(f"brief: {result.brief_path}")
+    if result.settings_path is not None:
+        print(f"settings: {result.settings_path}")
+    elif result.settings_skipped_reason:
+        print(f"settings: SKIPPED ({result.settings_skipped_reason})")
+    print(f"send_plan: {result.send_plan_path}")
+    print(
+        "Next step: copy send_plan.json's `to_id`/`message` into a "
+        "renga-peers send_message call."
+    )
+    return 0
+
+
+def _reconfigure_stdout() -> None:
+    """Force stdout/stderr to UTF-8 on Windows so the DELEGATE body / Layout
+    summary (which contain Japanese) don't mojibake under cp932 consoles
+    (Issue #290 defect 3). No-op when reconfigure is unavailable."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    _reconfigure_stdout()
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "preview":
+        return _cmd_preview(args)
+    if args.cmd == "apply":
+        return _cmd_apply(args)
+    raise SystemExit(f"unknown subcommand: {args.cmd!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -1,0 +1,560 @@
+"""Resolve worker layout (pattern / dir / role / branch) for a task.
+
+Codifies the org-delegate Step 0.7 + Step 1 + Step 1.5 ("Role の選び方")
+hand-decision flow as a deterministic library + thin CLI wrapper.
+
+Library-first: callers in the same Python process should import
+:func:`resolve` and consume the :class:`WorkerLayout` dataclass directly.
+The CLI (``python -m tools.resolve_worker_layout`` or
+``python tools/resolve_worker_layout.py``) is a thin JSON-stdout wrapper
+for shell consumers and for ad-hoc Secretary inspection.
+
+Inputs:
+- task_id, project_slug
+- targets (list of file paths for Step 0.7 gitignore check; 0 = skip)
+- description (free text; used only for branch-prefix inference)
+- mode ('edit' | 'audit') — explicit, so claude-org read-only audit is
+  not misclassified as a self-edit. Codex Design Major M-4.
+- branch_override (optional; bypasses inference)
+- registry_path / state_db_path / claude_org_root / workers_dir
+  (defaults derived from claude_org_root when None)
+
+Output (JSON shape):
+
+    {
+      "pattern": "A" | "B" | "C",
+      "pattern_variant": "ephemeral" | "gitignored_repo_root" | "live_repo_worktree" | None,
+      "worker_dir": "<absolute path>",
+      "role": "default" | "claude-org-self-edit" | "doc-audit",
+      "self_edit": <bool>,
+      "planned_branch": "<inferred or null>",
+      "settings_args": {
+        "role": "...",
+        "worker-dir": "...",
+        "claude-org-path": "...",
+        "out": "<worker_dir>/.claude/settings.local.json"
+      }
+    }
+
+Key contract notes (from Codex review of Issue #283):
+- ``pattern_variant`` carries sub-mode labels: the two Pattern C sub-modes
+  (``ephemeral`` / ``gitignored_repo_root``, M-1) and the Pattern B
+  ``live_repo_worktree`` sub-mode used by claude-org self-edit (Issue #289).
+- ``planned_branch`` is the resolver's *suggestion*; the actual branch
+  may diverge after worktree creation, so callers MUST re-read git
+  before pinning it into the brief / payload (M-2).
+- Active-work detection uses ``runs.status in ('queued','in_use','review')``
+  via a ``runs JOIN worker_dirs`` query — not a direct read of the
+  ``worker_dirs`` table (Codex Design Blocker B-2).
+"""
+from __future__ import annotations
+
+# When invoked as ``python tools/resolve_worker_layout.py`` (the form the
+# org-delegate skill documents), sys.path[0] is the ``tools/`` directory and
+# ``from tools import ...`` would fail with ModuleNotFoundError. Insert the
+# repo root so the package import works regardless of launch form. Harmless
+# when this module is imported (the path may already be there).
+import sys as _sys
+from pathlib import Path as _Path
+_sys.path.insert(0, str(_Path(__file__).resolve().parent.parent))
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from tools.registry_parser import Project as RegistryProject, parse_projects
+from tools.state_db import connect as db_connect
+from tools.state_db.queries import list_runs_with_dirs
+
+
+VALID_MODES = ("edit", "audit")
+VALID_PATTERNS = ("A", "B", "C")
+# 'live_repo_worktree' is the Pattern B sub-mode used by claude-org self-edit
+# tasks: the worktree base is Secretary's live repo (claude_org_root) instead
+# of the conventional {workers_dir}/{project_slug}/. See Issue #289 and
+# references/claude-org-self-edit.md for the rationale.
+VALID_VARIANTS = ("ephemeral", "gitignored_repo_root", "live_repo_worktree")
+VALID_ROLES = ("default", "claude-org-self-edit", "doc-audit")
+
+# Active reservation states — these mean someone else is occupying the base
+# clone, so a new task on the same project must use a worktree (Pattern B).
+# 'queued' is included because Issue #283 introduces T1 reservations that
+# write runs.status='queued' before the worker pane is spawned (T2 flips to
+# 'in_use'); a back-to-back delegation must see the queued reservation as
+# "in use".
+_ACTIVE_RUN_STATUSES = ("queued", "in_use", "review")
+
+# Trigger words that flip the planned-branch prefix from feat/ to fix/.
+_FIX_TRIGGERS = ("fix", "bug", "修正", "hotfix", "patch")
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+#
+# ``RegistryProject`` is re-exported from :mod:`tools.registry_parser` so
+# downstream callers keep working without churn; the shared dataclass uses
+# ``name`` (slug) / ``nickname`` (通称) instead of the legacy ``slug`` /
+# ``common_name`` field names.
+
+
+@dataclass(frozen=True)
+class WorkerLayout:
+    pattern: str                       # "A" | "B" | "C"
+    pattern_variant: Optional[str]     # "ephemeral" | "gitignored_repo_root" | "live_repo_worktree" | None
+    worker_dir: str                    # absolute path
+    role: str                          # default | claude-org-self-edit | doc-audit
+    self_edit: bool
+    planned_branch: Optional[str]
+    settings_args: dict[str, str] = field(default_factory=dict)
+
+    def to_json_dict(self) -> dict[str, Any]:
+        return {
+            "pattern": self.pattern,
+            "pattern_variant": self.pattern_variant,
+            "worker_dir": self.worker_dir,
+            "role": self.role,
+            "self_edit": self.self_edit,
+            "planned_branch": self.planned_branch,
+            "settings_args": dict(self.settings_args),
+        }
+
+
+class ResolveError(ValueError):
+    """Raised when inputs are malformed or contradictory."""
+
+
+# ---------------------------------------------------------------------------
+# registry/projects.md lookup
+# ---------------------------------------------------------------------------
+
+
+def find_project(rows: Iterable[RegistryProject], slug: str) -> Optional[RegistryProject]:
+    for r in rows:
+        if r.name == slug:
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# org-config.md (workers_dir)
+# ---------------------------------------------------------------------------
+
+
+_WORKERS_DIR_RE = re.compile(r"^\s*workers_dir\s*:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def parse_workers_dir(org_config_text: str) -> Optional[str]:
+    m = _WORKERS_DIR_RE.search(org_config_text)
+    return m.group(1) if m else None
+
+
+def resolve_workers_dir(claude_org_root: Path) -> Path:
+    cfg_path = claude_org_root / "registry" / "org-config.md"
+    raw = ""
+    if cfg_path.exists():
+        raw = cfg_path.read_text(encoding="utf-8")
+    rel = parse_workers_dir(raw) or "../workers"
+    return (claude_org_root / rel).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Step 0.7: gitignore check
+# ---------------------------------------------------------------------------
+
+
+def is_local_git_repo(path: str) -> bool:
+    """Local-path heuristic: not a URL, exists, has .git, isn't '-'."""
+    if not path or path == "-":
+        return False
+    if "://" in path:
+        return False
+    p = Path(path)
+    if not p.exists() or not p.is_dir():
+        return False
+    return (p / ".git").exists()
+
+
+def any_target_is_gitignored(project_path: str, targets: list[str]) -> bool:
+    """Return True iff at least one target matches ``git check-ignore``.
+
+    Only call this after :func:`is_local_git_repo` confirms the project
+    path is a usable local repo. Targets are passed through to git as-is
+    (git accepts both repo-relative and absolute paths under -C).
+    """
+    if not targets:
+        return False
+    for tgt in targets:
+        try:
+            rc = subprocess.run(
+                ["git", "-C", project_path, "check-ignore", "-q", "--", tgt],
+                capture_output=True,
+            ).returncode
+        except (FileNotFoundError, OSError):
+            # git missing or permission denied — be conservative: treat
+            # as "not ignored" so we fall through to normal Pattern judgment.
+            return False
+        if rc == 0:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# state.db — pattern detection via runs JOIN worker_dirs
+# ---------------------------------------------------------------------------
+
+
+def project_has_active_run(conn: sqlite3.Connection, project_slug: str) -> bool:
+    """True iff this project has at least one run with worker_dir attached
+    whose status is queued / in_use / review.
+
+    Routes through ``list_runs_with_dirs`` (the same query the snapshotter
+    uses) so resolver state-of-the-world matches what the dashboard and
+    org-state.md regenerate from. See Codex Design Blocker B-2.
+    """
+    for row in list_runs_with_dirs(conn):
+        if row.get("project_slug") != project_slug:
+            continue
+        if row.get("status") in _ACTIVE_RUN_STATUSES:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Branch inference
+# ---------------------------------------------------------------------------
+
+
+def infer_branch(task_id: str, description: str) -> str:
+    """Return ``feat/<task-id>`` or ``fix/<task-id>`` based on description.
+
+    If the task_id already carries a feat/ or fix/ prefix, return as-is.
+    """
+    if task_id.startswith(("feat/", "fix/", "chore/", "docs/")):
+        return task_id
+    desc_lower = description.lower()
+    is_fix = any(t in desc_lower for t in _FIX_TRIGGERS)
+    return f"{'fix' if is_fix else 'feat'}/{task_id}"
+
+
+# ---------------------------------------------------------------------------
+# Role detection
+# ---------------------------------------------------------------------------
+
+
+def is_claude_org_project(project: Optional[RegistryProject], claude_org_root: Path) -> bool:
+    """True iff the registered project resolves to the same dir as claude-org root."""
+    if project is None:
+        return False
+    if not project.path or project.path == "-" or "://" in project.path:
+        return False
+    try:
+        return Path(project.path).resolve() == claude_org_root.resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
+def decide_role(
+    *,
+    mode: str,
+    project: Optional[RegistryProject],
+    claude_org_root: Path,
+) -> str:
+    if mode == "audit":
+        return "doc-audit"
+    if mode == "edit":
+        if is_claude_org_project(project, claude_org_root):
+            return "claude-org-self-edit"
+        return "default"
+    raise ResolveError(f"unknown mode: {mode!r} (expected one of {VALID_MODES})")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def resolve(
+    *,
+    task_id: str,
+    project_slug: str,
+    targets: Optional[list[str]] = None,
+    description: str = "",
+    mode: str = "edit",
+    branch_override: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    state_db_path: Optional[Path] = None,
+    claude_org_root: Path,
+    workers_dir: Optional[Path] = None,
+    layout_overrides: Optional[dict[str, Any]] = None,
+) -> WorkerLayout:
+    """Resolve worker layout for one delegation. See module docstring."""
+    if not task_id:
+        raise ResolveError("task_id is required")
+    if not project_slug:
+        raise ResolveError("project_slug is required")
+    if mode not in VALID_MODES:
+        raise ResolveError(f"mode must be one of {VALID_MODES}, got {mode!r}")
+
+    targets = list(targets or [])
+    claude_org_root = Path(claude_org_root).resolve()
+    if registry_path is None:
+        registry_path = claude_org_root / "registry" / "projects.md"
+    if workers_dir is None:
+        workers_dir = resolve_workers_dir(claude_org_root)
+
+    # --- Project lookup ----------------------------------------------------
+    if registry_path.exists():
+        projects = parse_projects(registry_path)
+    else:
+        projects = []
+    project = find_project(projects, project_slug)
+
+    # --- Role decision (computed first so Pattern B can branch on it) -----
+    role = decide_role(mode=mode, project=project, claude_org_root=claude_org_root)
+    self_edit = role == "claude-org-self-edit"
+
+    # --- Pattern decision --------------------------------------------------
+    pattern: str
+    variant: Optional[str]
+    worker_dir: Path
+
+    if project is None:
+        # Unknown project → Pattern C ephemeral.
+        pattern, variant = "C", "ephemeral"
+        worker_dir = workers_dir / task_id
+    elif is_local_git_repo(project.path) and any_target_is_gitignored(
+        project.path, targets
+    ):
+        # Step 0.7 gitignored sub-mode → Pattern C / variant=gitignored_repo_root.
+        pattern, variant = "C", "gitignored_repo_root"
+        worker_dir = Path(project.path).resolve()
+    else:
+        # state.db driven A vs B decision. If DB read fails (missing file,
+        # corrupt schema, etc.) we fall back to Pattern A — the safer default
+        # for "no concurrent work known". The dispatcher / Stage 3 apply step
+        # will re-validate before actually creating any worktree.
+        active = False
+        if state_db_path is not None and Path(state_db_path).exists():
+            try:
+                conn = db_connect(state_db_path)
+                try:
+                    active = project_has_active_run(conn, project_slug)
+                finally:
+                    conn.close()
+            except sqlite3.Error:
+                active = False
+        if active:
+            pattern = "B"
+            # claude-org self-edit Pattern B places the worktree under
+            # Secretary's live repo (single .git, no two-clone sync). See
+            # Issue #289 / references/claude-org-self-edit.md.
+            if self_edit:
+                variant = "live_repo_worktree"
+                worker_dir = claude_org_root / ".worktrees" / task_id
+            else:
+                variant = None
+                worker_dir = workers_dir / project_slug / ".worktrees" / task_id
+        else:
+            pattern, variant = "A", None
+            worker_dir = workers_dir / project_slug
+
+    worker_dir = worker_dir.resolve() if worker_dir.is_absolute() else worker_dir.resolve()
+
+    # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
+    # Honor explicit values from the caller (typically a worker_brief.toml
+    # passed via gen_delegate_payload --from-toml) instead of letting the
+    # auto-derive above override them. Priority order, highest first:
+    #   TOML [worker] field > CLI flag > resolver auto-derive.
+    # Applied BEFORE the branch decision so a TOML-supplied pattern flips
+    # planned_branch consistently (e.g. pattern=C must imply planned_branch=None;
+    # pattern=B/A must compute a feat-/fix- branch even if auto-derive
+    # produced Pattern C without one). Codex Round 1 Major.
+    if layout_overrides:
+        explicit_worker_dir = bool(layout_overrides.get("worker_dir"))
+        if "pattern" in layout_overrides and layout_overrides["pattern"]:
+            pat = layout_overrides["pattern"]
+            if pat not in VALID_PATTERNS:
+                raise ResolveError(
+                    f"layout_overrides['pattern'] must be one of {VALID_PATTERNS}, got {pat!r}"
+                )
+            pattern = pat
+            # Pattern explicitly set; reset variant unless TOML also supplied one.
+            variant = layout_overrides.get("pattern_variant")
+            if variant is not None and variant not in VALID_VARIANTS:
+                raise ResolveError(
+                    f"layout_overrides['pattern_variant'] must be one of {VALID_VARIANTS} or None, got {variant!r}"
+                )
+            # Pattern B + variant=live_repo_worktree without explicit worker_dir
+            # → re-derive to claude_org_root/.worktrees/{task_id}/ (Issue #289).
+            if pattern == "B" and variant == "live_repo_worktree" and not explicit_worker_dir:
+                worker_dir = (claude_org_root / ".worktrees" / task_id).resolve()
+        if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
+            worker_dir = Path(layout_overrides["worker_dir"]).resolve()
+        if "role" in layout_overrides and layout_overrides["role"]:
+            r = layout_overrides["role"]
+            # Validate before any side effect (e.g. before apply reserves
+            # the DB row): a malformed role used to leak through to
+            # gen_worker_brief.validate() and only fail after the DB
+            # reservation was already persisted (Codex Round 2 Major).
+            if r not in VALID_ROLES:
+                raise ResolveError(
+                    f"layout_overrides['role'] must be one of {VALID_ROLES}, got {r!r}"
+                )
+            role = r
+            self_edit = role == "claude-org-self-edit"
+        if "self_edit" in layout_overrides:
+            se = layout_overrides["self_edit"]
+            # Strictly boolean — silently coercing a truthy string like
+            # "false" would let a malformed TOML bypass downstream validate()
+            # contracts (Codex Round 1 Minor).
+            if not isinstance(se, bool):
+                raise ResolveError(
+                    f"layout_overrides['self_edit'] must be bool, got {type(se).__name__}"
+                )
+            self_edit = se
+
+        # role / self_edit must agree. Otherwise a caller could pass
+        # role='default' + self_edit=true and the coherence pass below would
+        # relocate the worktree under claude_org_root while
+        # `settings generate --role default` still emits non-self-edit
+        # permissions (Codex Round 3 Major).
+        if self_edit != (role == "claude-org-self-edit"):
+            raise ResolveError(
+                "layout_overrides yielded inconsistent role / self_edit: "
+                f"role={role!r}, self_edit={self_edit!r}. "
+                "self_edit must be True iff role == 'claude-org-self-edit'."
+            )
+
+        # Final coherence pass for Issue #289: if overrides upgraded the role
+        # to claude-org-self-edit on a Pattern B layout but did not also
+        # specify pattern_variant / worker_dir, re-derive them so the live
+        # repo convention holds. Skipped when the caller explicitly supplied
+        # either (their value wins). Keyed off ``role`` (not ``self_edit``)
+        # because role is the field the downstream settings generator reads
+        # — keeping them in sync prevents a mismatched permission profile
+        # from being applied to a self-edit worktree (Codex Round 3 Major).
+        explicit_variant = "pattern_variant" in layout_overrides and layout_overrides.get("pattern_variant") is not None
+        if (
+            role == "claude-org-self-edit"
+            and pattern == "B"
+            and not explicit_variant
+            and not explicit_worker_dir
+        ):
+            variant = "live_repo_worktree"
+            worker_dir = (claude_org_root / ".worktrees" / task_id).resolve()
+
+    # --- Branch decision ---------------------------------------------------
+    # Re-derived from the *final* pattern so a TOML-supplied pattern override
+    # flips planned_branch consistently.
+    if pattern == "C":
+        # Pattern C ephemeral has no branch (no git); gitignored sub-mode
+        # runs against the repo root's existing branch and must not invent
+        # a new one (Codex M-2: planned_branch is a *suggestion*, not a
+        # commitment, and for Pattern C the suggestion is "don't").
+        planned_branch: Optional[str] = None
+    else:
+        planned_branch = branch_override or infer_branch(task_id, description)
+    if layout_overrides and "planned_branch" in layout_overrides:
+        planned_branch = layout_overrides["planned_branch"]
+
+    # --- settings_args -----------------------------------------------------
+    settings_args = {
+        "role": role,
+        "worker-dir": str(worker_dir),
+        "claude-org-path": str(claude_org_root),
+        "out": str(worker_dir / ".claude" / "settings.local.json"),
+    }
+
+    return WorkerLayout(
+        pattern=pattern,
+        pattern_variant=variant,
+        worker_dir=str(worker_dir),
+        role=role,
+        self_edit=self_edit,
+        planned_branch=planned_branch,
+        settings_args=settings_args,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Resolve worker layout for a delegation (org-delegate Step 0.7/1/1.5 codified).",
+    )
+    p.add_argument("--task-id", required=True)
+    p.add_argument("--project-slug", required=True)
+    p.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        help="Target file path for Step 0.7 gitignore check (repeatable).",
+    )
+    p.add_argument("--description", default="")
+    p.add_argument(
+        "--mode",
+        choices=VALID_MODES,
+        default="edit",
+        help="'edit' selects claude-org-self-edit or default; 'audit' forces doc-audit.",
+    )
+    p.add_argument("--branch", dest="branch_override", default=None,
+                   help="Override the inferred planned_branch.")
+    p.add_argument("--registry-path", default=None, type=Path)
+    p.add_argument("--state-db-path", default=None, type=Path)
+    p.add_argument("--claude-org-root", default=None, type=Path,
+                   help="Path to claude-org repo root (default: auto-detected).")
+    p.add_argument("--workers-dir", default=None, type=Path,
+                   help="Override workers_dir (default: read from registry/org-config.md).")
+    return p
+
+
+def _detect_claude_org_root() -> Path:
+    """Walk up from CWD until a registry/projects.md is found."""
+    here = Path.cwd().resolve()
+    for cand in (here, *here.parents):
+        if (cand / "registry" / "projects.md").exists() and (cand / ".state").exists():
+            return cand
+    # Fallback: just use CWD; resolve() will surface an error later.
+    return here
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    claude_org_root = args.claude_org_root or _detect_claude_org_root()
+    state_db_path = args.state_db_path
+    if state_db_path is None:
+        candidate = claude_org_root / ".state" / "state.db"
+        state_db_path = candidate if candidate.exists() else None
+    try:
+        layout = resolve(
+            task_id=args.task_id,
+            project_slug=args.project_slug,
+            targets=args.target,
+            description=args.description,
+            mode=args.mode,
+            branch_override=args.branch_override,
+            registry_path=args.registry_path,
+            state_db_path=state_db_path,
+            claude_org_root=claude_org_root,
+            workers_dir=args.workers_dir,
+        )
+    except ResolveError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    json.dump(layout.to_json_dict(), sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#299](https://github.com/suisya-systems/claude-org-ja/pull/299)

Merge SHA: `1efe91a0eb900c99b961ef40dbd24cc7970b9ae1`

Source: ja PR [#299](https://github.com/suisya-systems/claude-org-ja/pull/299)
Merge SHA: `1efe91a0eb900c99b961ef40dbd24cc7970b9ae1`

| class | count |
|---|---|
| runtime | 4 |
| translation | 3 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tests/fixtures/delegate_payload/delegate_payload_pattern_b_self_edit_full.golden.md`
- `tests/test_resolve_worker_layout.py`
- `tools/gen_delegate_payload.py`
- `tools/resolve_worker_layout.py`

</details>
<details><summary>translation (3)</summary>

- `.claude/skills/org-delegate/SKILL.md`
- `.claude/skills/org-delegate/references/claude-org-self-edit.md`
- `.claude/skills/org-delegate/references/delegate-flow-details.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
