### PR TITLE
auto-mirror: ja#296 feat(dispatcher): extract retro completion-report polling into dispatcher_retro_gate.py

### DIFF
--- a/tests/test_dispatcher_retro_gate.py
+++ b/tests/test_dispatcher_retro_gate.py
@@ -1,0 +1,218 @@
+"""Tests for tools/dispatcher_retro_gate.py (Issue #285).
+
+The CLI is a one-shot per-attempt ack judge: it reads
+``{"messages": [...], "state": {...}}`` from stdin, applies the ack
+regex, and prints either a terminal verdict (acked / replied_no_ack /
+timeout / error) or a ``polling`` verdict carrying state for the next
+invocation. Tests drive it via ``subprocess.run`` so the CLI contract
+is exercised end-to-end.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "dispatcher_retro_gate.py"
+
+
+def _run(stdin_payload: dict | None, *, attempt: int = 1, max_attempts: int = 10,
+         extra_args: list[str] | None = None,
+         task_id: str = "issue-285-test") -> subprocess.CompletedProcess:
+    args = [
+        sys.executable, str(SCRIPT),
+        "--task-id", task_id,
+        "--attempt", str(attempt),
+        "--max-attempts", str(max_attempts),
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    stdin_text = ""
+    if stdin_payload is not None:
+        stdin_text = json.dumps(stdin_payload, ensure_ascii=False) + "\n"
+    return subprocess.run(
+        args, input=stdin_text, capture_output=True, text=True,
+        timeout=15, encoding="utf-8",
+    )
+
+
+def _final(proc: subprocess.CompletedProcess) -> dict:
+    lines = [line for line in proc.stdout.splitlines() if line.strip()]
+    assert lines, f"no stdout from CLI; stderr={proc.stderr!r}"
+    return json.loads(lines[-1])
+
+
+class DispatcherRetroGateTests(unittest.TestCase):
+
+    # --- Stage 2 baseline cases mandated by the issue brief ------------
+
+    def test_ack_on_first_poll(self) -> None:
+        proc = _run(
+            {"messages": [
+                {"from_id": "secretary", "message": "完了報告は届いています"},
+            ]},
+            attempt=1,
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertEqual(final["attempts"], 1)
+        self.assertIn("届い", final["raw"])
+
+    def test_ack_on_third_poll(self) -> None:
+        # Driver loops three invocations, threading state through.
+        state = None
+
+        # Attempt 1: empty.
+        proc = _run({"messages": [], "state": state}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        f1 = _final(proc)
+        self.assertEqual(f1["status"], "polling")
+        state = f1["state"]
+
+        # Attempt 2: noise from non-secretary.
+        proc = _run({"messages": [{"from_id": "other", "message": "noise"}],
+                      "state": state}, attempt=2)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+
+        # Attempt 3: real ack.
+        proc = _run({"messages": [{"from_id": "secretary",
+                                   "message": "ack received"}],
+                     "state": state}, attempt=3)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "acked")
+        self.assertEqual(final["attempts"], 3)
+        self.assertEqual(final["raw"], "ack received")
+
+    def test_timeout_after_max_attempts(self) -> None:
+        # All 10 attempts return empty messages and no secretary reply.
+        state = None
+        for n in range(1, 10):
+            proc = _run({"messages": [], "state": state}, attempt=n)
+            self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+            state = _final(proc)["state"]
+        proc = _run({"messages": [], "state": state}, attempt=10)
+        self.assertEqual(proc.returncode, 1, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "timeout")
+        self.assertEqual(final["attempts"], 10)
+        self.assertIsNone(final["received_at"])
+        self.assertIsNone(final["raw"])
+
+    # --- Hardening cases from Codex review rounds ----------------------
+
+    def test_anonymous_message_does_not_ack(self) -> None:
+        # Body matches the regex but no sender attribution → not ack.
+        proc = _run({"messages": [{"message": "届いてます"}]}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "polling")
+
+    def test_non_secretary_messages_do_not_ack(self) -> None:
+        proc = _run({"messages": [{"from_id": "worker-x",
+                                    "message": "届いてます"}]}, attempt=1)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+
+    def test_invalid_ack_pattern_returns_error(self) -> None:
+        proc = _run(None, extra_args=["--ack-pattern", "("])
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "error")
+        self.assertIn("invalid_ack_pattern", final["reason"])
+
+    def test_malformed_messages_payload_returns_error(self) -> None:
+        proc = _run({"messages": "oops"}, attempt=1)
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "error")
+        self.assertIn("invalid_schema", final["reason"])
+
+    def test_payload_must_be_object(self) -> None:
+        # JSON list at top level instead of object.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--task-id", "x",
+             "--attempt", "1", "--max-attempts", "10"],
+            input="[1,2,3]\n", capture_output=True, text=True,
+            timeout=15, encoding="utf-8",
+        )
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        self.assertIn("invalid_schema", _final(proc)["reason"])
+
+    def test_non_dict_message_entries_are_skipped(self) -> None:
+        # Mixed list: stray int, then real secretary ack.
+        proc = _run({"messages": [42, {"from_id": "secretary",
+                                        "message": "届きました"}]},
+                    attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["status"], "acked")
+
+    def test_non_string_body_does_not_crash(self) -> None:
+        proc = _run({"messages": [
+            {"from_id": "secretary", "message": 42},
+            {"from_id": "secretary", "message": "ack"},
+        ]}, attempt=1)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["raw"], "ack")
+
+    def test_secretary_replies_without_ack_regex(self) -> None:
+        # Secretary replies but bodies never match — at the final
+        # attempt the verdict must be replied_no_ack (exit 3), not
+        # timeout, so the dispatcher does not jump to the
+        # secretary_unreachable fallback.
+        state = None
+        # Attempt 1: secretary says "確認します"
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "確認します"}],
+                     "state": state}, attempt=1, max_attempts=3)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+        self.assertEqual(state["last_secretary_body"], "確認します")
+        self.assertEqual(state["last_secretary_attempt"], 1)
+
+        # Attempt 2: empty.
+        proc = _run({"messages": [], "state": state},
+                    attempt=2, max_attempts=3)
+        self.assertEqual(proc.returncode, 4, msg=proc.stderr)
+        state = _final(proc)["state"]
+
+        # Attempt 3 (final): secretary says "見当たりません"
+        proc = _run({"messages": [{"from_id": "secretary",
+                                    "message": "見当たりません"}],
+                     "state": state}, attempt=3, max_attempts=3)
+        self.assertEqual(proc.returncode, 3, msg=proc.stderr)
+        final = _final(proc)
+        self.assertEqual(final["status"], "replied_no_ack")
+        self.assertEqual(final["raw"], "見当たりません")
+        self.assertEqual(final["attempts"], 3)
+
+    def test_custom_ack_pattern(self) -> None:
+        proc = _run({"messages": [
+            {"from_id": "secretary", "message": "CONFIRMED-285"},
+        ]}, attempt=1, extra_args=["--ack-pattern", r"CONFIRMED-\d+"])
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertEqual(_final(proc)["raw"], "CONFIRMED-285")
+
+    def test_attempt_out_of_range_returns_error(self) -> None:
+        proc = _run({"messages": []}, attempt=11, max_attempts=10)
+        self.assertEqual(proc.returncode, 2, msg=proc.stderr)
+        self.assertIn("out of range", _final(proc)["reason"])
+
+    # --- --print-initial-prompt mode -----------------------------------
+
+    def test_print_initial_prompt(self) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--task-id", "issue-285-test",
+             "--print-initial-prompt"],
+            capture_output=True, text=True, timeout=15, encoding="utf-8",
+        )
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        self.assertIn("issue-285-test", proc.stdout)
+        self.assertIn("完了報告", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/dispatcher_retro_gate.py
+++ b/tools/dispatcher_retro_gate.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Per-attempt ack judge for the dispatcher's retro completion-report gate.
+
+Issue #285. Replaces the natural-language polling prose in
+``.dispatcher/CLAUDE.md`` (around the "完了報告ゲート" section) with a
+deterministic CLI so the dispatcher Claude no longer has to re-derive
+ack-judgement on every retro.
+
+Design: this CLI never calls renga-peers itself, and it does not run a
+long-lived polling loop — Claude Code's Bash tool is one-shot, so a
+co-routine that demands interactive stdin/stdout would not be runnable
+in practice. Instead, the dispatcher Claude runs this script ONCE per
+poll attempt, piping the latest ``check_messages`` result into stdin
+along with the gate state from the previous attempt. The script returns
+either a terminal verdict (``acked`` / ``replied_no_ack`` / ``timeout``
+/ ``error``) or a ``polling`` verdict that carries the updated state
+back so the dispatcher can sleep, fetch again, and re-invoke.
+
+Invocation per attempt::
+
+    python tools/dispatcher_retro_gate.py \
+        --task-id <id> --secretary secretary \
+        --attempt <n> --max-attempts 10 [--ack-pattern <regex>]
+
+stdin (single JSON object on one or more lines)::
+
+    {
+      "messages": [<renga-peers message dict>, ...],
+      "state":    {"last_secretary_attempt": <int>,
+                   "last_secretary_body":    <str|null>}   // optional
+    }
+
+stdout (single JSON object — terminal or progress)::
+
+    {"status": "acked",          "received_at": ..., "raw": ..., "attempts": <n>}
+    {"status": "replied_no_ack", "received_at": ..., "raw": ..., "attempts": <n>}
+    {"status": "timeout",        "received_at": null, "raw": null, "attempts": <max>}
+    {"status": "polling",        "attempts": <n>,  "state": {...}}
+    {"status": "error",          "reason":   ..., "attempts": <n>, ...}
+
+Exit codes::
+
+    0 = acked
+    1 = timeout
+    2 = error
+    3 = replied_no_ack
+    4 = polling (caller should sleep and re-invoke)
+
+The ``--print-initial-prompt`` mode prints the task-templated initial
+question (no stdin needed, no exit code semantics) so the dispatcher
+can pipe it into ``mcp__renga-peers__send_message`` once before the
+first attempt.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+# Ensure UTF-8 stdio on Windows (default cp932 mangles JP prompts/ack
+# bodies). Reconfigure is best-effort — on streams that don't support
+# it we leave the default in place.
+for _stream_name in ("stdout", "stderr", "stdin"):
+    _stream = getattr(sys, _stream_name, None)
+    if _stream is None:
+        continue
+    if getattr(_stream, "encoding", "").lower() == "utf-8":
+        continue
+    try:
+        _stream.reconfigure(encoding="utf-8")  # py>=3.7
+    except (AttributeError, io.UnsupportedOperation):
+        pass
+
+DEFAULT_ACK_PATTERN = r"(届[いきけくこ]|受領|受け取|ack|received|got it)"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _emit(obj: dict, stream) -> None:
+    stream.write(json.dumps(obj, ensure_ascii=False) + "\n")
+    stream.flush()
+
+
+def _is_secretary_message(msg: dict, secretary: str) -> bool:
+    """Return True only if the message explicitly identifies the secretary
+    as sender. Messages with no sender attribution are NOT treated as
+    secretary-origin — accepting them would let an unrelated message
+    whose body happens to contain "届い" trigger a false ack."""
+    return msg.get("from_id") == secretary or msg.get("from_name") == secretary
+
+
+def _extract_body(msg: dict) -> str:
+    """Pull the body text out of a renga-peers message dict. Non-string
+    values in any of the candidate fields are coerced to empty so the
+    caller's regex never sees a non-str (which would TypeError)."""
+    for key in ("message", "text", "body"):
+        value = msg.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _read_stdin_payload(stdin) -> dict[str, Any]:
+    raw = stdin.read()
+    if not raw or not raw.strip():
+        return {}
+    return json.loads(raw)
+
+
+def run_gate(args: argparse.Namespace, *, stdin=None, stdout=None) -> int:
+    stdin = stdin or sys.stdin
+    stdout = stdout or sys.stdout
+
+    if args.print_initial_prompt:
+        # Plain text on stdout — the dispatcher pipes this into
+        # mcp__renga-peers__send_message before the first attempt.
+        stdout.write(f"{args.task_id} の完了報告は届いていますか？\n")
+        stdout.flush()
+        return 0
+
+    if args.attempt < 1 or args.attempt > args.max_attempts:
+        _emit({
+            "status": "error",
+            "reason": (f"attempt {args.attempt} out of range "
+                       f"[1, {args.max_attempts}]"),
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    try:
+        pattern = re.compile(args.ack_pattern)
+    except re.error as exc:
+        _emit({
+            "status": "error",
+            "reason": f"invalid_ack_pattern: {exc}",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    try:
+        payload = _read_stdin_payload(stdin)
+    except json.JSONDecodeError as exc:
+        _emit({
+            "status": "error",
+            "reason": f"invalid_json: {exc}",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    if not isinstance(payload, dict):
+        _emit({
+            "status": "error",
+            "reason": "invalid_schema: payload must be a JSON object",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    messages = payload.get("messages", [])
+    if not isinstance(messages, list):
+        _emit({
+            "status": "error",
+            "reason": "invalid_schema: 'messages' must be a list",
+            "attempts": args.attempt,
+            "received_at": None,
+            "raw": None,
+        }, stdout)
+        return 2
+
+    state = payload.get("state") or {}
+    if not isinstance(state, dict):
+        state = {}
+    last_secretary_body = state.get("last_secretary_body")
+    last_secretary_attempt = state.get("last_secretary_attempt") or 0
+    if not isinstance(last_secretary_attempt, int):
+        last_secretary_attempt = 0
+    if last_secretary_body is not None and not isinstance(last_secretary_body, str):
+        last_secretary_body = None
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        if not _is_secretary_message(msg, args.secretary):
+            continue
+        body = _extract_body(msg)
+        last_secretary_body = body
+        last_secretary_attempt = args.attempt
+        if pattern.search(body):
+            _emit({
+                "status": "acked",
+                "received_at": _now_iso(),
+                "raw": body,
+                "attempts": args.attempt,
+            }, stdout)
+            return 0
+
+    if args.attempt >= args.max_attempts:
+        if last_secretary_body is not None:
+            _emit({
+                "status": "replied_no_ack",
+                "received_at": _now_iso(),
+                "raw": last_secretary_body,
+                "attempts": last_secretary_attempt,
+            }, stdout)
+            return 3
+        _emit({
+            "status": "timeout",
+            "received_at": None,
+            "raw": None,
+            "attempts": args.max_attempts,
+        }, stdout)
+        return 1
+
+    # More attempts to go — return updated state for the next invocation.
+    _emit({
+        "status": "polling",
+        "attempts": args.attempt,
+        "state": {
+            "last_secretary_attempt": last_secretary_attempt,
+            "last_secretary_body": last_secretary_body,
+        },
+    }, stdout)
+    return 4
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Per-attempt ack judge for the dispatcher's retro "
+                    "completion-report gate (Issue #285).",
+    )
+    p.add_argument("--task-id", required=True,
+                   help="Task id used in the prompt sent to the secretary.")
+    p.add_argument("--secretary", default="secretary",
+                   help="Secretary pane name / id (default: secretary).")
+    p.add_argument("--attempt", type=int, default=1,
+                   help="Current poll attempt number, 1-indexed.")
+    p.add_argument("--max-attempts", type=int, default=10,
+                   help="Total number of poll attempts (default: 10).")
+    p.add_argument("--ack-pattern", default=DEFAULT_ACK_PATTERN,
+                   help="Regex applied to incoming message bodies to decide ack.")
+    p.add_argument("--print-initial-prompt", action="store_true",
+                   help="Print the templated initial prompt and exit. "
+                        "Use this once before --attempt 1 to feed the "
+                        "secretary message via mcp__renga-peers__send_message.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return run_gate(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#296](https://github.com/suisya-systems/claude-org-ja/pull/296)

Merge SHA: `e164d4b9ac5126101b78281083ac24b252488e11`

Source: ja PR [#296](https://github.com/suisya-systems/claude-org-ja/pull/296)
Merge SHA: `e164d4b9ac5126101b78281083ac24b252488e11`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 1 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_dispatcher_retro_gate.py`
- `tools/dispatcher_retro_gate.py`

</details>
<details><summary>divergence-allowed (1)</summary>

- `.dispatcher/CLAUDE.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
