### PR TITLE
fix(claude): align dispatcher monitoring cadence to /loop 3m

### DIFF
--- a/.dispatcher/CLAUDE.md
+++ b/.dispatcher/CLAUDE.md
@@ -99,7 +99,7 @@ mcp__renga-peers__send_message(to_id="secretary", message="...")
 
 ## Watching Worker panes
 
-While any Worker pane is live, you watch it. Implementation: after the first dispatch completes, start a `/loop 1m` monitoring loop. Stop the loop once all Worker panes have closed.
+While any Worker pane is live, you watch it. Implementation: after the first dispatch completes, start a `/loop 3m` monitoring loop. Stop the loop once all Worker panes have closed.
 
 > **Channel separation** (renga 0.14.0+ exposes everything over MCP):
 > - **Pane lifecycle (start / exit)** — `mcp__renga-peers__poll_events`, cursor-based long-poll.
@@ -108,7 +108,7 @@ While any Worker pane is live, you watch it. Implementation: after the first dis
 > - **Pane enumeration / closing** — `mcp__renga-peers__list_panes` / `close_pane`.
 > - **Raw key input** — `mcp__renga-peers__send_keys` (Shift+Tab, Enter, Esc, ...).
 
-### One pass of the monitoring loop (every 1 min)
+### One pass of the monitoring loop (every 3 min)
 
 Run these in order each cycle:
 
@@ -265,7 +265,7 @@ The pane name to monitor is the Pane Name (`worker-{task_id}`) recorded in `.sta
 
 ### Design notes
 
-- **Why `poll_events` with `timeout_ms=5000`**: shorten the 1-minute polling interval. Each cycle long-polls for 5s; the remaining 55s is covered by `check_messages` + `list_panes` + `inspect_pane`. Reduces average pane-exit detection latency from ~30s to ~2.5s.
+- **Why `poll_events` with `timeout_ms=5000`**: shorten the 3-minute polling interval. Each cycle long-polls for 5s; the remaining 175s is covered by `check_messages` + `list_panes` + `inspect_pane`. Reduces average pane-exit detection latency from ~90s to ~2.5s.
 - **Cursor management**: `.state/dispatcher-event-cursor.txt` stores the previous `next_since`. First run (no cursor): omit `since` for "from now on" semantics. On crash recovery, missing cursor means losing up to 5 seconds of events — recoverable via the `list_panes` reconciliation.
 - **Why two layers (events + `list_panes`)**: events are best-effort (`EventsDropped` happens), so `mcp__renga-peers__list_panes` reconciliation is the safety net.
 - **Why inspect is an independent observation channel**: when a Worker stalls on an approval prompt, relying only on Worker self-report (renga-peers) means the Worker may stall before sending the notification. Inspect actively observes from the Dispatcher side, backstopping any missed / delayed self-report. Self-report and inspect together give "two-channel observation of the same event" — redundancy by design.


### PR DESCRIPTION
## Summary
- `docs/contracts/role-contract.md` (L87, L141) already specifies `/loop 3m` as the canonical Dispatcher monitoring cadence, but `.dispatcher/CLAUDE.md` (L95 and the section header at L104) was still on the legacy `/loop 1m`. The live Dispatcher reads `.dispatcher/CLAUDE.md`, so the doc drift translated into actual behavior 3× more frequent than the contract.
- Update `.dispatcher/CLAUDE.md` so the cadence text and all derived numbers match the contract.

## Diff (1 commit, `953b5b8`)
- `loop 1m` → `loop 3m`
- "every 1 min" → "every 3 min"
- Internal interval references aligned: `1-minute polling / 55s / ~30s` → `3-minute polling / 175s / ~90s`

## Test plan
- [ ] `tools/audit_link_paths.py` shows no new violations attributable to this diff.
- [ ] Next Dispatcher startup runs `/loop 3m` (verifiable from the next live session log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)