### PR TITLE
fix: reclassify worker_brief templates as translation, not runtime

### DIFF
--- a/tools/sync_classifier.py
+++ b/tools/sync_classifier.py
@@ -32,6 +32,16 @@ RUNTIME_GLOBS: tuple[str, ...] = (
     "tests/**/*",
 )
 
+# Carve-outs from RUNTIME_GLOBS. A path that matches a runtime glob but also
+# matches one of these is *not* classified as runtime; it falls through to the
+# next rule (typically translation). Used so the broad tools/** runtime rule
+# can still hand off prose templates like worker_brief_*.md to the translation
+# pipeline. tools/templates/**/*.py / *.json remain runtime-mirrored.
+RUNTIME_EXCLUDE_GLOBS: tuple[str, ...] = (
+    "tools/templates/**/*.md",
+    "tools/templates/**/*.toml",
+)
+
 TRANSLATION_GLOBS: tuple[str, ...] = (
     ".claude/skills/*",
     ".claude/skills/**/*",
@@ -39,6 +49,11 @@ TRANSLATION_GLOBS: tuple[str, ...] = (
     "docs/**/*",
     "README.md",
     "CLAUDE.md",
+    # Worker brief templates contain prose / placeholder text rendered into
+    # Worker prompts. en harness needs the English version, so the
+    # translation pipeline owns these.
+    "tools/templates/**/*.md",
+    "tools/templates/**/*.toml",
 )
 
 DIVERGENCE_GLOBS: tuple[str, ...] = (
@@ -104,7 +119,7 @@ def classify_path(path: str) -> str:
     allowed paths under .state/ etc. should never be queued for translation.
     """
     p = _normalize(path)
-    if _matches_any(p, RUNTIME_GLOBS):
+    if _matches_any(p, RUNTIME_GLOBS) and not _matches_any(p, RUNTIME_EXCLUDE_GLOBS):
         return CLASS_RUNTIME
     if _matches_any(p, DIVERGENCE_GLOBS):
         return CLASS_DIVERGENCE

--- a/tools/test_sync_classifier.py
+++ b/tools/test_sync_classifier.py
@@ -27,6 +27,10 @@ RUNTIME_PATHS = [
     "tools/test_check_renga_compat.py",
     "tools/migrations/2026-05-runtime.sh",
     "tools/data/fixtures/sample.yaml",
+    # Templates dir mechanics (loader scripts / JSON schemas) stay runtime;
+    # only the prose .md / .toml templates fall through to translation.
+    "tools/templates/loader.py",
+    "tools/templates/schema.json",
     "dashboard/app.js",
     "dashboard/server.py",
     "dashboard/index.html",
@@ -46,6 +50,11 @@ TRANSLATION_PATHS = [
     "docs/runbook/auto-mirror-runtime.md",
     "README.md",
     "CLAUDE.md",
+    # Worker brief templates: prose rendered into Worker prompts. Must reach
+    # en harness in English via the translation pipeline.
+    "tools/templates/worker_brief_self_edit.md",
+    "tools/templates/worker_brief_normal.md",
+    "tools/templates/worker_brief.example.toml",
 ]
 
 DIVERGENCE_PATHS = [


### PR DESCRIPTION
## Summary
- Move `tools/templates/**/*.md` and `tools/templates/**/*.toml` from runtime classification to translation in `tools/sync_classifier.py`, so the auto-mirror pipeline produces English versions of `worker_brief_self_edit.md`, `worker_brief_normal.md`, and `worker_brief.example.toml` in the en repo.
- Template mechanics files (`tools/templates/**/*.py` / `*.json`) stay runtime — only prose templates rendered into Worker prompts are reclassified.
- Implemented via a new `RUNTIME_EXCLUDE_GLOBS` so the runtime broad rule (`tools/**`) is preserved while carving out the prose templates.

## Why
The en harness targets English-speaking users, but worker_brief templates were mirrored verbatim from ja and reached en Workers as Japanese prose, degrading brief comprehension. Audit task `audit-templates-translation` confirmed this was a side-effect of the broad `tools/**` runtime glob, not a deliberate exclusion. See `docs/sync-policy.md` background.

## Test plan
- [x] `py -3 -m pytest tools/test_sync_classifier.py` (7 passed / 38 subtests)
- [x] `py -3 -m pytest tools/ tests/` (448 passed / 1 skipped, no regressions)
- [x] `py -3 -m unittest discover -s tools -p 'test_*.py'` (293 OK / 1 skipped — CI parity)
- [x] Live `classify()` calls return `translation` for the 3 prose templates and `runtime` for hypothetical `loader.py` / `schema.json` paths
- [x] `codex exec` self-review: no findings

## Follow-up
- `docs/sync-policy.md` scope description still says runtime covers `tools/**/*.py, *.json`; needs an addendum noting `tools/templates/*.md|*.toml` are translation. ja-canonical, so file as a separate Issue against claude-org-ja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)