### PR TITLE
ci: point JA_REPO at the ja repo so auto-mirror can fetch PR files

### DIFF
--- a/.github/workflows/auto-mirror-runtime.yml
+++ b/.github/workflows/auto-mirror-runtime.yml
@@ -1,7 +1,7 @@
 name: Auto-mirror runtime (ja -> en)
 
 # Phase P2 (mirror PR, manual merge). Listens to repository_dispatch
-# ja_pr_merged from suisya-systems/claude-org, classifies the changed
+# ja_pr_merged from suisya-systems/claude-org-ja, classifies the changed
 # files via tools/sync_classifier.py, and:
 #
 #   - For runtime-class files: opens (or refreshes) a mirror PR on this
@@ -52,7 +52,7 @@ env:
   # P2 = open mirror PR for runtime-class files. Flip to "false" to
   # revert to P1 warn-only (tracking issue only, even for runtime files).
   OPEN_PR: 'true'
-  JA_REPO: suisya-systems/claude-org
+  JA_REPO: suisya-systems/claude-org-ja
 
 jobs:
   classify-and-mirror:

--- a/docs/runbook/auto-mirror-runtime.md
+++ b/docs/runbook/auto-mirror-runtime.md
@@ -1,11 +1,11 @@
 # Runbook: auto-mirror-runtime workflow
 
 `.github/workflows/auto-mirror-runtime.yml` mirrors runtime code from
-`suisya-systems/claude-org` into this repo when a ja PR merges. This page
+`suisya-systems/claude-org-ja` into this repo when a ja PR merges. This page
 covers operational tasks and the phased rollout plan.
 
-Design source: `suisya-systems/claude-org#189` (and Lead decision #171).
-P2 implementation tracked under `suisya-systems/claude-org#335`.
+Design source: `suisya-systems/claude-org-ja#189` (and Lead decision #171).
+P2 implementation tracked under `suisya-systems/claude-org-ja#335`.
 
 ## What it does today (Phase P2)
 
@@ -97,7 +97,7 @@ gh workflow run auto-mirror-runtime.yml \
   -R suisya-systems/claude-org \
   -f ja_pr_number=<NUMBER> \
   -f ja_pr_title="<TITLE>" \
-  -f ja_pr_url="https://github.com/suisya-systems/claude-org/pull/<NUMBER>"
+  -f ja_pr_url="https://github.com/suisya-systems/claude-org-ja/pull/<NUMBER>"
 ```
 
 `ja_merge_sha` is optional — the workflow resolves it from the PR via
@@ -162,4 +162,4 @@ flipped with doc-only edits if Lead changes course:
 - Tests: `tools/test_sync_classifier.py`
 - Workflow: `.github/workflows/auto-mirror-runtime.yml`
 - Canonical mapping: `docs/canonical-ownership.md`
-- Sibling policy (ja): `docs/sync-policy.md` in `suisya-systems/claude-org`
+- Sibling policy (ja): `docs/sync-policy.md` in `suisya-systems/claude-org-ja`


### PR DESCRIPTION
## Summary
- The `Auto-mirror runtime (ja -> en)` workflow had `JA_REPO=suisya-systems/claude-org` (the en repo itself), so `gh api repos/${JA_REPO}/pulls/${PR_NUM}/files` returned 404 for every dispatched PR. Five recent `ja_pr_merged` runs failed in a row (e.g. run 25506752632 with `gh: Not Found (HTTP 404)` on PR #362).
- Fix `JA_REPO` to `suisya-systems/claude-org-ja` and update the leading comment that references the dispatch source.
- Sync the runbook (`docs/runbook/auto-mirror-runtime.md`) so the ja source / design issue / manual rerun example / sibling sync-policy references all point at `claude-org-ja`. The `gh workflow run -R suisya-systems/claude-org` line is intentionally kept — the workflow runs in the en repo.

## Test plan
- [x] `python tools/check_role_configs.py --include-worker-settings .` → role_configs OK.
- [x] Existing unittests don't exercise this YAML env value.
- [ ] Post-merge: rerun a past failed run (or trigger via `workflow_dispatch`) to confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)