### PR TITLE
auto-mirror: ja#358 fix(claude): rewrite Windows-fragile resolver test without git clone

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -37,13 +38,28 @@ GOLDEN_DIR = REPO_ROOT / "tests" / "fixtures" / "delegate_payload"
 
 
 class _Sandbox:
-    def __init__(self, td: Path):
+    def __init__(self, td: Path, *, with_claude_org_origin: bool = True):
         self.root = td
         self.workers = td / "workers"
         self.workers.mkdir()
         self.claude_org_root = td / "claude-org"
         (self.claude_org_root / ".state").mkdir(parents=True)
         (self.claude_org_root / "registry").mkdir()
+        # Self-edit detection runs off git origin URL. Tests that drive
+        # their own git setup on claude_org_root (e.g. pre-seeding a
+        # ``main`` branch + initial commit for worktree-creation tests)
+        # opt out via ``with_claude_org_origin=False`` to avoid a
+        # ``git init`` race that would silently swallow ``--initial-branch``.
+        if with_claude_org_origin:
+            subprocess.run(
+                ["git", "init", "-q", str(self.claude_org_root)],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(self.claude_org_root), "remote", "add",
+                 "origin", "https://github.com/suisya-systems/claude-org-ja.git"],
+                check=True,
+            )
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Permission Mode\ndefault_permission_mode: auto\n"
             "## Workers Directory\nworkers_dir: ../workers\n",
@@ -684,7 +700,10 @@ class TestPatternBWorktreeCreation(unittest.TestCase):
         except (FileNotFoundError):
             self.skipTest("git not available")
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
+        # This class drives its own ``git init -b main`` + initial commit on
+        # claude_org_root, so we opt out of the sandbox-level git init that
+        # would otherwise re-init and silently swallow ``--initial-branch``.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
         # Initialize claude_org_root as a real git repo so live_repo_worktree
         # can branch from it.
         import os

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -784,6 +784,18 @@ class TestIsClaudeOrgProject(unittest.TestCase):
         )
         self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
 
+    def test_en_mirror_slug_and_origin_returns_true(self):
+        """The en mirror (``suisya-systems/claude-org``) is also a self-edit
+        target: slug ``claude-org`` + matching github origin → True. Without
+        this, Secretaries running from the en checkout never get the
+        claude-org-self-edit role auto-switch."""
+        repo = self.tmp / "en-live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org", repo))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -35,7 +35,7 @@ from tools.state_db.writer import StateWriter  # noqa: E402
 class _Sandbox:
     """One self-contained claude-org-like tree for a single test."""
 
-    def __init__(self, td: Path):
+    def __init__(self, td: Path, *, with_claude_org_origin: bool = False):
         self.root = td
         self.workers = td / "workers"
         self.workers.mkdir()
@@ -44,6 +44,11 @@ class _Sandbox:
         self.claude_org_root.mkdir()
         (self.claude_org_root / ".state").mkdir()
         (self.claude_org_root / "registry").mkdir()
+        if with_claude_org_origin:
+            self.init_git_with_origin(
+                self.claude_org_root,
+                "https://github.com/suisya-systems/claude-org-ja.git",
+            )
         # workers_dir relative to claude-org root → ../workers
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Workers Directory\nworkers_dir: ../workers\n",
@@ -54,6 +59,20 @@ class _Sandbox:
         conn = connect(self.db_path)
         apply_schema(conn)
         conn.close()
+
+    # ---- git helpers -------------------------------------------------------
+
+    @staticmethod
+    def init_git(repo: Path) -> None:
+        subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+
+    @classmethod
+    def init_git_with_origin(cls, repo: Path, origin_url: str) -> None:
+        cls.init_git(repo)
+        subprocess.run(
+            ["git", "-C", str(repo), "remote", "add", "origin", origin_url],
+            check=True,
+        )
 
     # ---- registry helpers --------------------------------------------------
 
@@ -301,18 +320,13 @@ class TestPatternCGitignored(unittest.TestCase):
 class TestRoleDetection(unittest.TestCase):
     def setUp(self) -> None:
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
-        # Register the sandbox claude-org root as a project so role detection
-        # has something to compare against.
+        # claude-org-ja self-edit detection runs off the sandbox's git origin
+        # URL, so the sandbox needs ``with_claude_org_origin=True`` and no
+        # registry row for the self-edit target.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
         self.sb.write_registry(
             [
                 ("時計", "clock-app", "-", "Demo clock"),
-                (
-                    "claude-org-ja",
-                    "claude-org-ja",
-                    str(self.sb.claude_org_root),
-                    "claude-org self",
-                ),
             ]
         )
 
@@ -351,6 +365,28 @@ class TestRoleDetection(unittest.TestCase):
         )
         self.assertEqual(layout.role, "doc-audit")
         self.assertFalse(layout.self_edit)
+
+    def test_audit_mode_for_claude_org_keeps_pattern_a_via_synthesized_project(self):
+        """Regression: the production registry no longer carries a
+        claude-org-ja row, but ``mode='audit'`` on this slug must still
+        land on Pattern A with worker_dir under workers_dir/claude-org-ja
+        (read-only audit clone) — not silently fall through to Pattern C
+        ephemeral. The resolver synthesizes a virtual project entry from
+        the slug + matching git origin so the legacy pattern logic keeps
+        working."""
+        layout = rwl.resolve(
+            task_id="audit-task",
+            project_slug="claude-org-ja",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-ja").resolve(),
+        )
 
     def test_audit_mode_for_non_claude_org_also_doc_audit(self):
         layout = rwl.resolve(
@@ -493,16 +529,13 @@ class TestPatternBLiveRepoWorktree(unittest.TestCase):
 
     def setUp(self) -> None:
         self._td = tempfile.TemporaryDirectory()
-        self.sb = _Sandbox(Path(self._td.name))
+        # Self-edit detection runs off git origin (claude-org-ja has no
+        # registry row); the active-run gate on Pattern B vs A still
+        # applies the same way it did when the row was present.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
         self.sb.write_registry(
             [
                 ("時計", "clock-app", "-", "Demo clock"),
-                (
-                    "claude-org-ja",
-                    "claude-org-ja",
-                    str(self.sb.claude_org_root),
-                    "claude-org self",
-                ),
             ]
         )
         # An active run on claude-org-ja forces Pattern B for the next task.
@@ -634,6 +667,122 @@ class TestPatternBLiveRepoWorktree(unittest.TestCase):
             Path(layout.worker_dir),
             (self.sb.claude_org_root / ".worktrees" / "explicit-self-edit").resolve(),
         )
+
+
+# ---------------------------------------------------------------------------
+# is_claude_org_project() — git origin URL based self-edit detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsClaudeOrgProject(unittest.TestCase):
+    """Self-edit detection runs off ``git -C <claude_org_root> remote
+    get-url origin`` so the claude-org-ja target has no registry row to
+    leak a user-specific local path. Two signals must both hold: the
+    canonical slug AND a matching origin URL."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_live_claude_org_checkout_returns_true(self):
+        """(a) Inside the live claude-org-ja checkout (origin =
+        ``https://github.com/suisya-systems/claude-org-ja.git``) returns
+        True for the canonical slug."""
+        repo = self.tmp / "live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_worker_dir_clone_returns_false(self):
+        """(b) A worker-dir clone has origin pointing at a local filesystem
+        path (no ``github.com`` segment), so detection returns False even
+        for the canonical slug.
+
+        Implementation note: we do NOT invoke ``git clone`` here. The
+        contract under test is purely about the recorded ``origin`` URL —
+        ``is_claude_org_project`` only reads ``git remote get-url origin``
+        and rejects any value lacking a ``github.com`` segment. Driving an
+        actual clone (via ``file://`` URI or plain path) is fragile on
+        Windows because Git for Windows / MSYS path translation rules
+        differ across installations. Instead, we initialize a repo and
+        register a local-path origin directly, modeling each origin shape
+        a worker-dir clone would plausibly record. Trade-off: this no
+        longer asserts the exact string Git itself would write — only
+        that the github-URL gate rejects each modeled local form. The
+        gate's regex (no ``github.com`` segment → reject) is what guards
+        the contract, so this coverage is sufficient and stable."""
+        upstream = self.tmp / "upstream"
+        # ``git clone`` of a local source records origin in one of these
+        # shapes depending on how the source was specified. We assert that
+        # ALL of them fail the github-URL gate.
+        local_origin_forms = [
+            upstream.as_uri(),                  # file:///... URI form
+            str(upstream),                      # raw absolute path form
+            upstream.as_posix(),                # forward-slash path form
+        ]
+        for i, origin_url in enumerate(local_origin_forms):
+            with self.subTest(origin_url=origin_url):
+                worker_clone = self.tmp / f"worker-{i}"
+                worker_clone.mkdir()
+                _Sandbox.init_git_with_origin(worker_clone, origin_url)
+                self.assertFalse(
+                    rwl.is_claude_org_project("claude-org-ja", worker_clone)
+                )
+
+    def test_repo_without_remote_returns_false(self):
+        """(c) A fresh git repo with no ``origin`` remote returns False."""
+        repo = self.tmp / "noremote"
+        repo.mkdir()
+        _Sandbox.init_git(repo)
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_non_self_edit_slug_returns_false_even_with_matching_origin(self):
+        """Slug gate: even with a matching origin URL, a non-canonical slug
+        (clock-app, renga, ...) must not be flagged as self-edit. Without
+        this gate every edit task run from inside the live claude-org
+        checkout would misfire as self-edit, since Secretary always
+        operates from there."""
+        repo = self.tmp / "live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org-ja.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("clock-app", repo))
+
+    def test_ssh_origin_form_normalizes(self):
+        """``git@github.com:suisya-systems/claude-org-ja.git`` → match."""
+        repo = self.tmp / "ssh"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "git@github.com:suisya-systems/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_fork_origin_still_matches(self):
+        """CONTRIBUTING.md documents fork-based contribution: a fork's
+        ``origin`` points at the contributor's fork, not at suisya-systems.
+        Self-edit detection must still fire so fork-based maintainers
+        keep getting Pattern B + CLAUDE.local.md."""
+        repo = self.tmp / "fork-origin"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "git@github.com:some-contributor/claude-org-ja.git"
+        )
+        self.assertTrue(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_unrelated_github_repo_returns_false(self):
+        """A different github repo (e.g. an unrelated fork) must not match."""
+        repo = self.tmp / "fork"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/someone-else/some-other-repo.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -808,6 +808,22 @@ class TestIsClaudeOrgProject(unittest.TestCase):
         )
         self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
 
+    def test_origin_with_github_com_in_path_returns_false(self):
+        """Anchor guard: a non-github host whose URL merely *contains* the
+        literal ``github.com`` somewhere (mirror server path, file:// URI
+        with a coincidentally named directory) must NOT pass the host
+        gate, even when the slug matches."""
+        bad_origins = [
+            "https://mirror.example/github.com/suisya-systems/claude-org-ja.git",
+            "file:///tmp/github.com/suisya-systems/claude-org-ja.git",
+        ]
+        for i, origin in enumerate(bad_origins):
+            with self.subTest(origin=origin):
+                repo = self.tmp / f"masquerade-{i}"
+                repo.mkdir()
+                _Sandbox.init_git_with_origin(repo, origin)
+                self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
+
     def test_en_slug_in_ja_checkout_returns_false(self):
         """Symmetric cross-match guard: slug=claude-org from inside the ja
         checkout (origin=.../claude-org-ja.git) must also be False."""

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -796,6 +796,28 @@ class TestIsClaudeOrgProject(unittest.TestCase):
         )
         self.assertTrue(rwl.is_claude_org_project("claude-org", repo))
 
+    def test_ja_slug_in_en_checkout_returns_false(self):
+        """Cross-match guard: a ja-targeted delegation (slug=claude-org-ja)
+        run from inside the en checkout (origin=.../claude-org.git) must
+        NOT be flagged self-edit. Otherwise the resolver would plant a ja
+        worktree under the en claude_org_root."""
+        repo = self.tmp / "en-live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("claude-org-ja", repo))
+
+    def test_en_slug_in_ja_checkout_returns_false(self):
+        """Symmetric cross-match guard: slug=claude-org from inside the ja
+        checkout (origin=.../claude-org-ja.git) must also be False."""
+        repo = self.tmp / "ja-live"
+        repo.mkdir()
+        _Sandbox.init_git_with_origin(
+            repo, "https://github.com/suisya-systems/claude-org-ja.git"
+        )
+        self.assertFalse(rwl.is_claude_org_project("claude-org", repo))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -265,14 +265,22 @@ _CLAUDE_ORG_SELF_EDIT_SLUGS: tuple[str, ...] = ("claude-org-ja", "claude-org")
 # Tuple constant so adding additional mirrors is a one-line change.
 _CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja", "claude-org")
 
-# Capture <owner>/<repo> from common github URL forms:
-#   https://github.com/owner/repo(.git)
-#   git@github.com:owner/repo(.git)
-#   ssh://git@github.com/owner/repo(.git)
+# Capture <owner>/<repo> from common github URL forms, with ``github.com``
+# anchored at the host position so URLs that merely *contain* the literal
+# ``github.com`` somewhere (e.g. ``file:///tmp/github.com/foo/claude-org.git``
+# or ``https://mirror.example/github.com/foo/claude-org.git``) do NOT match.
+# Accepted forms:
+#   https://[user[:pw]@]github.com/owner/repo(.git)
+#   http://[user[:pw]@]github.com/owner/repo(.git)
+#   ssh://[user@]github.com/owner/repo(.git)
+#   git://[user@]github.com/owner/repo(.git)
+#   git@github.com:owner/repo(.git)         (scp-like SSH form)
 # A local-path origin (worker-dir clones use these) has no ``github.com``
-# segment, so the regex naturally rejects it — even when the upstream dir
-# happens to be named ``claude-org-ja``.
-_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$")
+# host, so the anchored regex naturally rejects it.
+_GITHUB_OWNER_REPO_RE = re.compile(
+    r"^(?:(?:https?|ssh|git)://(?:[^@/\s]+@)?|git@)"
+    r"github\.com[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$"
+)
 
 
 def _extract_github_repo_name(url: str) -> Optional[str]:

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -325,7 +325,14 @@ def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
     if url is None:
         return False
     repo_name = _extract_github_repo_name(url)
-    return repo_name in _CLAUDE_ORG_REPO_NAMES
+    if repo_name not in _CLAUDE_ORG_REPO_NAMES:
+        return False
+    # Require slug ↔ origin repo-name agreement so a delegation targeting
+    # the ja repo from inside the en checkout (or vice-versa) is NOT
+    # misclassified as self-edit. Without this 1:1 gate the resolver would
+    # plant a ja worktree under the en claude_org_root and corrupt the
+    # wrong repo on commit. See Codex review of this PR.
+    return repo_name == project_slug
 
 
 def decide_role(

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -248,28 +248,96 @@ def infer_branch(task_id: str, description: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def is_claude_org_project(project: Optional[RegistryProject], claude_org_root: Path) -> bool:
-    """True iff the registered project resolves to the same dir as claude-org root."""
-    if project is None:
-        return False
-    if not project.path or project.path == "-" or "://" in project.path:
-        return False
+# Canonical claude-org self-edit slugs. The resolver short-circuits Pattern B +
+# live_repo_worktree for these slugs when claude_org_root's git origin matches
+# one of the canonical repos below. Detection runs off the origin URL so the
+# registry need not carry a user-specific local path for the self-edit target.
+# Both the ja source repo (``claude-org-ja``) and the en mirror (``claude-org``)
+# are treated as self-edit targets so Secretaries running from either repo get
+# the same role auto-switch.
+_CLAUDE_ORG_SELF_EDIT_SLUGS: tuple[str, ...] = ("claude-org-ja", "claude-org")
+
+# Repo names (lowercased, no owner, no trailing ``.git``) that count as
+# claude-org self-edit targets. Owner is intentionally NOT pinned: the
+# project documents fork-based contribution (see CONTRIBUTING.md), and a
+# fork's ``origin`` points at the contributor's fork (e.g.
+# ``git@github.com:<user>/claude-org-ja.git``), not at suisya-systems'.
+# Tuple constant so adding additional mirrors is a one-line change.
+_CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja", "claude-org")
+
+# Capture <owner>/<repo> from common github URL forms:
+#   https://github.com/owner/repo(.git)
+#   git@github.com:owner/repo(.git)
+#   ssh://git@github.com/owner/repo(.git)
+# A local-path origin (worker-dir clones use these) has no ``github.com``
+# segment, so the regex naturally rejects it — even when the upstream dir
+# happens to be named ``claude-org-ja``.
+_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$")
+
+
+def _extract_github_repo_name(url: str) -> Optional[str]:
+    """Return the lowercased repo name (no ``.git``) if ``url`` is a github
+    remote, else None."""
+    s = url.strip().lower()
+    if not s:
+        return None
+    m = _GITHUB_OWNER_REPO_RE.search(s)
+    return m.group(2) if m else None
+
+
+def _git_origin_url(repo_path: Path) -> Optional[str]:
+    """Return ``git -C repo_path remote get-url origin`` stdout, or None."""
     try:
-        return Path(project.path).resolve() == claude_org_root.resolve()
-    except (OSError, RuntimeError):
+        result = subprocess.run(
+            ["git", "-C", str(repo_path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
+def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
+    """True iff this delegation targets claude-org self-edit.
+
+    Two signals must both hold:
+    1. ``project_slug`` is one of the canonical self-edit slugs
+       (``claude-org-ja`` or its en mirror ``claude-org``). Without this
+       gate any edit task — clock-app, renga, etc. — would be flagged
+       self-edit because Secretary always runs the resolver from inside
+       the live claude-org checkout.
+    2. ``claude_org_root``'s ``origin`` remote URL points at a github
+       repo whose name matches a known claude-org target. Owner is not
+       pinned — fork-based contribution is the documented workflow and a
+       fork's origin is ``<contributor>/claude-org-ja``, not
+       ``suisya-systems/claude-org-ja``. A worker-dir clone has origin
+       set to a local filesystem path (no github.com segment), so it
+       does not match; a fresh repo without any remote also does not
+       match.
+    """
+    if project_slug not in _CLAUDE_ORG_SELF_EDIT_SLUGS:
         return False
+    url = _git_origin_url(claude_org_root)
+    if url is None:
+        return False
+    repo_name = _extract_github_repo_name(url)
+    return repo_name in _CLAUDE_ORG_REPO_NAMES
 
 
 def decide_role(
     *,
     mode: str,
-    project: Optional[RegistryProject],
+    project_slug: str,
     claude_org_root: Path,
 ) -> str:
     if mode == "audit":
         return "doc-audit"
     if mode == "edit":
-        if is_claude_org_project(project, claude_org_root):
+        if is_claude_org_project(project_slug, claude_org_root):
             return "claude-org-self-edit"
         return "default"
     raise ResolveError(f"unknown mode: {mode!r} (expected one of {VALID_MODES})")
@@ -316,8 +384,23 @@ def resolve(
         projects = []
     project = find_project(projects, project_slug)
 
+    # claude-org self-edit slugs (claude-org-ja / claude-org) are intentionally
+    # absent from the checked-in registry (the row used to leak a user-specific
+    # local path). When the slug + claude_org_root's git origin both signal
+    # self-edit, synthesize a virtual project pointing at the live checkout so
+    # audit mode and the active-run/state.db driven Pattern A↔B logic below
+    # keep treating it the same as a registered project.
+    if project is None and is_claude_org_project(project_slug, claude_org_root):
+        project = RegistryProject(
+            name=project_slug,
+            nickname=project_slug,
+            path=str(claude_org_root),
+            description="",
+            common_tasks="",
+        )
+
     # --- Role decision (computed first so Pattern B can branch on it) -----
-    role = decide_role(mode=mode, project=project, claude_org_root=claude_org_root)
+    role = decide_role(mode=mode, project_slug=project_slug, claude_org_root=claude_org_root)
     self_edit = role == "claude-org-self-edit"
 
     # --- Pattern decision --------------------------------------------------

--- a/tools/test_gen_worker_brief.py
+++ b/tools/test_gen_worker_brief.py
@@ -309,6 +309,17 @@ class FromTaskSubcommand(unittest.TestCase):
         self.claude_org_root = td / "claude-org"
         (self.claude_org_root / ".state").mkdir(parents=True)
         (self.claude_org_root / "registry").mkdir()
+        # Self-edit detection runs off the live repo's git origin URL, so
+        # the sandbox needs an initialised git repo with the canonical
+        # origin set for the claude-org-ja → CLAUDE.local.md auto-switch
+        # to fire.
+        import subprocess as _sp
+        _sp.run(["git", "init", "-q", str(self.claude_org_root)], check=True)
+        _sp.run(
+            ["git", "-C", str(self.claude_org_root), "remote", "add",
+             "origin", "https://github.com/suisya-systems/claude-org-ja.git"],
+            check=True,
+        )
         (self.claude_org_root / "registry" / "org-config.md").write_text(
             "## Workers Directory\nworkers_dir: ../workers\n",
             encoding="utf-8",


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#358](https://github.com/suisya-systems/claude-org-ja/pull/358)

Merge SHA: `78f1688074e8aa596e90168708aa34e8c08af660`

Source: ja PR [#358](https://github.com/suisya-systems/claude-org-ja/pull/358)
Merge SHA: `78f1688074e8aa596e90168708aa34e8c08af660`

| class | count |
|---|---|
| runtime | 1 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (1)</summary>

- `tests/test_resolve_worker_layout.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
