### PR TITLE
auto-mirror: ja#366 test(claude): convert test_real_registry_fixture to fixture-based parse (#339)

### DIFF
--- a/tests/fixtures/registry/projects.md
+++ b/tests/fixtures/registry/projects.md
@@ -1,0 +1,15 @@
+# Projects Registry (Fixture)
+
+`tests/test_registry_parser.test_real_registry_fixture` 用の固定 fixture。
+本物の `registry/projects.md` は ja / en / fork で divergence-allowed なので
+（[`docs/sync-policy.md`](../../../docs/sync-policy.md) 参照）、
+parser のスナップショットテストはこの固定ファイルに対して行う。
+
+claude-org-ja 自身（self-edit）は live registry 同様このフィクスチャにも載せない。
+`tools/resolve_worker_layout.py:is_claude_org_project()` が live repo の git origin
+URL を見て判定する責務を負う。
+
+| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |
+|---|---|---|---|---|
+| 時計アプリ | clock-app | - | Webブラウザで動くデジタル時計 | デザイン変更、機能追加 |
+| renga | renga | https://github.com/suisya-systems/renga | Rust 製の Claude Code 用ターミナルマルチプレクサ（TUI） | 機能追加、バグ修正、Issue 対応 |

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -31,21 +31,57 @@ def _build(*body_lines: str, intro: str = "# Projects Registry\n\n") -> str:
 class TestParseProjects(unittest.TestCase):
 
     def test_real_registry_fixture(self):
-        path = PROJECT_ROOT / "registry" / "projects.md"
+        # Parses a checked-in fixture (not the live registry/projects.md), since
+        # the live registry is divergence-allowed across ja / en / forks per
+        # docs/sync-policy.md. The fixture pins a known project list so this
+        # test stays deterministic regardless of the host repo's roster.
+        path = PROJECT_ROOT / "tests" / "fixtures" / "registry" / "projects.md"
         projects = parse_projects(path)
         names = [p.name for p in projects]
-        # registry/projects.md is divergence-allowed per docs/sync-policy.md;
-        # both ja (claude-org-ja registry) and en (claude-org registry)
-        # checkouts should produce a non-empty, well-formed parse. The
-        # specific project name set is repo-local. A follow-up issue will
-        # convert this assertion to a fixture-based test that does not
-        # depend on the live registry contents.
-        self.assertGreater(len(projects), 0)
+        self.assertIn("clock-app", names)
+        self.assertIn("renga", names)
+        self.assertNotIn("claude-org-ja", names)
         # All rows are fully populated Project instances.
         for p in projects:
             self.assertIsInstance(p, Project)
             self.assertTrue(p.nickname)
             self.assertTrue(p.name)
+
+    def test_live_registry_smoke(self):
+        # Smoke check: the live registry/projects.md (which may diverge per
+        # repo/fork) must remain parseable and yield at least one well-formed
+        # row. We do NOT assert specific project names here — that is the
+        # fixture-based test's job.
+        path = PROJECT_ROOT / "registry" / "projects.md"
+        if not path.exists():  # pragma: no cover - safety for fork checkouts
+            self.skipTest("live registry/projects.md not present")
+        # parse_projects must not raise and must not emit malformed-row
+        # warnings against the live file. An empty registry is valid (fresh
+        # checkout / fork) — but if the file *contains* table data rows, at
+        # least one must parse cleanly, otherwise the registry is silently
+        # corrupt (e.g. separator dropped → every row classified as
+        # non_table and parser returns []).
+        text = path.read_text(encoding="utf-8")
+        with self.assertNoLogs("tools.registry_parser", level="WARNING"):
+            projects = parse_projects(path)
+        for p in projects:
+            self.assertIsInstance(p, Project)
+            self.assertTrue(p.nickname)
+            self.assertTrue(p.name)
+        # Detect "looks like a markdown table" by counting pipe-prefixed
+        # lines, not by iter_rows() kinds: when the separator row is missing
+        # iter_rows classifies every `| ... |` line (header AND would-be
+        # data rows) as "header", so a kind-based check would silently miss
+        # exactly the corruption mode we want to catch.
+        pipe_lines = sum(
+            1 for ln in text.splitlines() if ln.lstrip().startswith("|")
+        )
+        if pipe_lines >= 2:
+            self.assertGreater(
+                len(projects), 0,
+                "live registry has pipe-table lines but none parsed — "
+                "likely separator/header corruption",
+            )
 
     def test_happy_path(self):
         text = _build(


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#366](https://github.com/suisya-systems/claude-org-ja/pull/366)

Merge SHA: `362bfea283c07bfb5cab751ddbaa90b7ef0c4a6b`

Source: ja PR [#366](https://github.com/suisya-systems/claude-org-ja/pull/366)
Merge SHA: `362bfea283c07bfb5cab751ddbaa90b7ef0c4a6b`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/fixtures/registry/projects.md`
- `tests/test_registry_parser.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
