### PR TITLE
feat(claude): classify scripts/install.{sh,ps1} as runtime

### DIFF
--- a/tools/sync_classifier.py
+++ b/tools/sync_classifier.py
@@ -30,6 +30,11 @@ RUNTIME_GLOBS: tuple[str, ...] = (
     ".hooks/**/*",
     "tests/*",
     "tests/**/*",
+    # Runtime installer scripts (Issue #159). Narrow on purpose: only the two
+    # documented entry points are ja-canonical; other scripts/* paths fall
+    # through to unknown for manual triage.
+    "scripts/install.sh",
+    "scripts/install.ps1",
 )
 
 # Carve-outs from RUNTIME_GLOBS. A path that matches a runtime glob but also

--- a/tools/test_sync_classifier.py
+++ b/tools/test_sync_classifier.py
@@ -41,6 +41,9 @@ RUNTIME_PATHS = [
     ".hooks/lib/segment-split.sh",
     "tests/integration/test_flow.py",
     "tests/unit.py",
+    # Issue #159: documented installer entry points are runtime.
+    "scripts/install.sh",
+    "scripts/install.ps1",
 ]
 
 TRANSLATION_PATHS = [
@@ -69,6 +72,10 @@ DIVERGENCE_PATHS = [
 UNKNOWN_PATHS = [
     "Makefile",
     "scripts/build.sh",
+    # The install rule is narrow — sibling scripts under scripts/ stay unknown
+    # so they get manual triage rather than silently mirroring.
+    "scripts/install-hooks.sh",
+    "scripts/install.bat",
     "random/file.txt",
     "tools-not-tools/foo.py",
     "knowledge/raw/2026-05-01-note.md",


### PR DESCRIPTION
## Summary
- Add `scripts/install.sh` and `scripts/install.ps1` to `RUNTIME_GLOBS` in `tools/sync_classifier.py` so the documented installer entry points are classified as runtime and auto-mirror from ja main.
- Narrow on purpose: sibling `scripts/*` (e.g. `install-hooks.sh`, `build.sh`, `install.bat`) stay `unknown` so they receive manual triage rather than silently mirroring.
- Tests in `tools/test_sync_classifier.py` cover both directions: runtime hits for the two documented entry points, and unknown carve-outs for sibling scripts.

## Test plan
- [x] `python -m unittest test_sync_classifier` (7/7 OK)
- [x] `codex exec` self-review (no Blocker / Major / Minor / Nit findings)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)