### PR TITLE
auto-mirror: ja#375 fix(claude): resolver supports mirror repos, self-edit first run, and --pattern override (#374)

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1275,5 +1275,144 @@ def _env_update_goldens() -> bool:
     return os.environ.get("UPDATE_GOLDENS") == "1"
 
 
+# ---------------------------------------------------------------------------
+# Issue #374: ``--pattern {A|B|C}`` override propagates into brief / send_plan
+# ---------------------------------------------------------------------------
+
+
+class TestPatternOverrideCLI(unittest.TestCase):
+    """Issue #374: Secretary may force a specific pattern via ``--pattern``.
+    The override must reach (a) the resolved layout, (b) the DELEGATE body
+    rendering, and (c) the ``summary`` block in send_plan.json. Invalid
+    combinations must surface as preview-time errors rather than after a DB
+    reservation.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _common_args(self, *, slug: str = "clock-app") -> list[str]:
+        return [
+            "--task-id", "override-task",
+            "--project-slug", slug,
+            "--description", "force the pattern",
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ]
+
+    def _run_preview_json(self, argv: list[str]) -> dict:
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *argv, "--json"])
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue())
+
+    def test_force_pattern_c_overrides_auto_a(self):
+        """Without override, clock-app + no active run = Pattern A. With
+        ``--pattern C`` the layout flips to ephemeral and planned_branch
+        becomes None (Pattern C has no branch by contract)."""
+        data = self._run_preview_json([*self._common_args(), "--pattern", "C"])
+        s = data["summary"]
+        self.assertEqual(s["pattern"], "C")
+        self.assertIsNone(s["planned_branch"])
+        # The DELEGATE body label reflects the override.
+        self.assertIn("ディレクトリパターン: C", data["delegate_body"])
+
+    def test_apply_writes_override_into_send_plan_summary(self):
+        """End-to-end: apply with ``--pattern C`` produces a send_plan.json
+        whose summary carries the overridden pattern (= what dispatcher
+        will see when it copies the manifest into renga-peers)."""
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "apply", *self._common_args(),
+                "--pattern", "C",
+                "--skip-settings",
+            ])
+        self.assertEqual(rc, 0)
+        # send_plan.json lives alongside the brief (Pattern C ephemeral
+        # writes to workers_dir/<task_id>/CLAUDE.md).
+        worker_dir = self.sb.workers / "override-task"
+        send_plan_path = worker_dir / "send_plan.json"
+        self.assertTrue(send_plan_path.exists())
+        send_plan = json.loads(send_plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(send_plan["summary"]["pattern"], "C")
+
+    def test_cli_pattern_drops_toml_worker_dir_and_variant(self):
+        """Codex Round 2 Major: ``--pattern X`` together with ``--from-toml``
+        used to keep the TOML's ``[worker].dir`` and ``[worker].pattern_variant``
+        in the override dict, so the resolver treated worker_dir as
+        explicitly set and skipped its pattern-driven re-derivation. Result
+        was an inconsistent layout (e.g. ``pattern=C`` but worker_dir on
+        the registered clone). The CLI flag must override fully."""
+        # TOML pre-pins Pattern A worker_dir to a deterministic path.
+        toml_path = self.sb.root / "in.toml"
+        explicit_dir = self.sb.workers / "clock-app"
+        toml_path.write_text(
+            "[task]\n"
+            'id = "toml-pattern"\n'
+            'description = "drop dir on cli pattern"\n'
+            "\n[worker]\n"
+            f'dir = "{explicit_dir.as_posix()}"\n'
+            'pattern = "A"\n'
+            'role = "default"\n'
+            'self_edit = false\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+            encoding="utf-8",
+        )
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "preview",
+                "--from-toml", str(toml_path),
+                "--state-db-path", str(self.sb.db_path),
+                "--pattern", "C",
+                "--json",
+            ])
+        self.assertEqual(rc, 0)
+        s = json.loads(buf.getvalue())["summary"]
+        # CLI pattern wins over TOML's pattern.
+        self.assertEqual(s["pattern"], "C")
+        # And worker_dir gets re-derived for the new pattern (workers_dir/<task_id>),
+        # not left at the TOML-supplied registered clone path.
+        self.assertEqual(
+            Path(s["worker_dir"]).resolve(),
+            (self.sb.workers / "toml-pattern").resolve(),
+        )
+        # Variant from TOML (or derived for old pattern) is dropped — Pattern
+        # C ephemeral default.
+        self.assertEqual(s["pattern_variant"], "ephemeral")
+
+    def test_force_pattern_a_on_self_edit_slug_errors_in_preview(self):
+        """Resolver rejects pattern=A on a self-edit slug — the error must
+        propagate out of ``preview`` rather than letting the bad layout
+        slip through."""
+        # ResolveError is raised inside build_delegate_plan, which runs
+        # under preview without reaching apply.
+        from tools.resolve_worker_layout import ResolveError as _RE
+
+        with self.assertRaises(_RE):
+            gdp.main([
+                "preview",
+                *self._common_args(slug="claude-org-ja"),
+                "--pattern", "A",
+            ])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -158,6 +158,53 @@ class TestParseProjects(unittest.TestCase):
         self.assertIn("blog-site", names)
 
 
+class TestMirrorOfColumn(unittest.TestCase):
+    """Issue #374: optional 6th column ``mirror_of`` carries a project slug
+    reference for back-port style mirrors. Backwards compatibility must
+    hold for fork registries that haven't adopted the column yet."""
+
+    def test_six_column_table_populates_mirror_of(self):
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of |\n"
+            "|---|---|---|---|---|---|\n"
+            "| EN ミラー | my-mirror | "
+            "https://github.com/example/mirror | mirror | - | upstream-slug |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "my-mirror")
+        self.assertEqual(projects[0].mirror_of, "upstream-slug")
+
+    def test_legacy_five_column_table_leaves_mirror_of_empty(self):
+        text = _build("| n | slug | / | d | t |")
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].mirror_of, "")
+
+    def test_extra_trailing_columns_are_ignored_not_rejected(self):
+        # Future column additions or fork-side experiments must not silently
+        # drop every row. iter_rows accepts trailing cells beyond the schema.
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of | future_col |\n"
+            "|---|---|---|---|---|---|---|\n"
+            "| n | slug | / | d | t | upstream | extra-value |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(len(projects), 1)
+        self.assertEqual(projects[0].name, "slug")
+        # The mirror_of column is still populated from cell index 5.
+        self.assertEqual(projects[0].mirror_of, "upstream")
+
+    def test_six_column_empty_mirror_of_cell_normalizes_to_empty(self):
+        text = (
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of |\n"
+            "|---|---|---|---|---|---|\n"
+            "| n | slug | / | d | t |  |\n"
+        )
+        projects = parse_projects_text(text)
+        self.assertEqual(projects[0].mirror_of, "")
+
+
 class TestIterRows(unittest.TestCase):
 
     def test_classifies_lines(self):

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -895,6 +895,43 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
             (self.clone / ".worktrees" / "en-task-b-alias").resolve(),
         )
 
+    def test_mirror_of_preserved_when_synthesizing_from_url_path_row(self):
+        """Codex Round 3 Major: when the registry row carries
+        ``path=https://...`` AND ``mirror_of=<slug>``, the resolver
+        re-pins onto the local clone but used to drop ``mirror_of``,
+        silently turning the row into a non-mirror project. The
+        first-run Pattern B short-circuit then never fired. Re-create
+        the production registry shape (URL path + mirror_of) and
+        verify Pattern B kicks in on the very first dispatch."""
+        # Live deployment shape: URL path AND mirror_of populated.
+        path = self.sb.claude_org_root / "registry" / "projects.md"
+        path.write_text(
+            "# Projects Registry\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of |\n"
+            "|---|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Demo clock | - |  |\n"
+            "| claude-org-en | claude-org | "
+            "https://github.com/suisya-systems/claude-org | mirror | - | "
+            "claude-org-ja |\n",
+            encoding="utf-8",
+        )
+        layout = rwl.resolve(
+            task_id="first-run-mirror",
+            project_slug="claude-org",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # No active run → without mirror_of preservation this would have
+        # been Pattern A. With it preserved, the mirror_of short-circuit
+        # fires and lifts the layout to Pattern B (claude_org_repo_worktree
+        # variant added by the post-derive claude_org_clone re-pin).
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.clone / ".worktrees" / "first-run-mirror").resolve(),
+        )
+
     def test_no_clone_falls_through_to_pattern_c_ephemeral(self):
         """Without a clone at workers_dir/claude-org, the slug is still
         unknown → Pattern C ephemeral (regression guard for the no-en-clone
@@ -1045,6 +1082,429 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
         self.assertEqual(
             Path(layout.worker_dir),
             (self.sb.workers / "clock-app").resolve(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #374: self-edit first-run short-circuit + mirror_of + --pattern override
+# ---------------------------------------------------------------------------
+
+
+class TestSelfEditFirstRunShortCircuit(unittest.TestCase):
+    """Issue #374: ``role=claude-org-self-edit`` is a *repo policy* (single
+    ``.git``, no two-clone sync), not a concurrency policy. Even on the
+    very first dispatch (no active runs) the layout must be Pattern B +
+    ``live_repo_worktree`` — not the legacy Pattern A that landed the
+    brief in the live repo root.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
+        # No registry row for claude-org-ja (matches the production layout
+        # — origin URL detection replaces the row).
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_first_run_self_edit_picks_pattern_b_live_repo_worktree(self):
+        """No active run exists. Before #374 this returned Pattern A and
+        wrote into ``workers_dir/claude-org-ja/`` (a separate clone),
+        breaking the single-.git invariant from Issue #289."""
+        layout = rwl.resolve(
+            task_id="self-edit-first",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "claude-org-self-edit")
+        self.assertTrue(layout.self_edit)
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "live_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.claude_org_root / ".worktrees" / "self-edit-first").resolve(),
+        )
+
+    def test_first_run_audit_mode_keeps_pattern_a(self):
+        """``mode='audit'`` is doc-audit, not self-edit, so the
+        short-circuit must not fire — audit clones go under
+        ``workers_dir/claude-org-ja/`` and behave like Pattern A."""
+        layout = rwl.resolve(
+            task_id="audit-first",
+            project_slug="claude-org-ja",
+            mode="audit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.role, "doc-audit")
+        self.assertEqual(layout.pattern, "A")
+
+
+class TestMirrorOfRegistryMetadata(unittest.TestCase):
+    """Issue #374: a registered project with non-empty ``mirror_of`` is a
+    back-port style mirror — each task is independent rather than
+    accumulating on a shared branch — so worktree-per-task (Pattern B) is
+    the natural default even on the very first dispatch."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available")
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # A real local clone for the mirror, so Pattern B has a usable base.
+        self.mirror_repo = Path(self._td.name) / "mirror-repo"
+        self.mirror_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.mirror_repo), "init", "-q"], check=True
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _write_registry_with_mirror(self, mirror_of: str = "upstream-slug") -> None:
+        # Hand-write the table so we can include the new 6th column without
+        # adding a Sandbox helper for every column variant.
+        path = self.sb.claude_org_root / "registry" / "projects.md"
+        path.write_text(
+            "# Projects Registry\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of |\n"
+            "|---|---|---|---|---|---|\n"
+            f"| 時計 | clock-app | - | Demo clock | - |  |\n"
+            f"| ミラー | my-mirror | {self.mirror_repo} | mirror | - | {mirror_of} |\n",
+            encoding="utf-8",
+        )
+
+    def test_first_run_mirror_picks_pattern_b_with_clone_base(self):
+        """No active run, mirror_of populated → Pattern B with worker_dir
+        under the mirror project's worktrees subtree. The base for
+        ``git worktree add`` is the registered local clone (gen_delegate_payload
+        derives base_repo from project.path)."""
+        self._write_registry_with_mirror()
+        layout = rwl.resolve(
+            task_id="mirror-task-1",
+            project_slug="my-mirror",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "B")
+        # Generic mirror — no special variant; base is the registered
+        # project path, not the live claude-org repo.
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "my-mirror" / ".worktrees" / "mirror-task-1").resolve(),
+        )
+        self.assertEqual(layout.planned_branch, "feat/mirror-task-1")
+
+    def test_mirror_of_with_url_path_raises_resolve_error(self):
+        """Codex Round 1 Blocker: ``mirror_of`` set on a row whose path is
+        a URL (or ``-``) used to force Pattern B even though
+        gen_delegate_payload could not derive a base for ``git worktree
+        add``. The mismatch surfaced as ``no usable base repo`` at apply
+        time, after a DB reservation. Surface the misconfiguration at
+        resolve() instead, before any side effect."""
+        path = self.sb.claude_org_root / "registry" / "projects.md"
+        path.write_text(
+            "# Projects Registry\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 | mirror_of |\n"
+            "|---|---|---|---|---|---|\n"
+            "| ミラー | url-mirror | "
+            "https://github.com/example/mirror | mirror | - | upstream |\n",
+            encoding="utf-8",
+        )
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-mirror",
+                project_slug="url-mirror",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+            )
+        self.assertIn("mirror_of", str(cm.exception))
+
+    def test_empty_mirror_of_keeps_legacy_pattern_a(self):
+        """A project whose 6th column is empty must keep the legacy A/B/C
+        decision tree — the mirror short-circuit triggers only on
+        non-empty values, otherwise the column rollout would silently
+        change the pattern of every existing project."""
+        self._write_registry_with_mirror(mirror_of="")
+        layout = rwl.resolve(
+            task_id="ordinary-task",
+            project_slug="my-mirror",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+
+
+class TestPatternOverrideContract(unittest.TestCase):
+    """Issue #374: ``layout_overrides['pattern']`` is a Secretary judgment
+    override. The contract is enforced at resolve() time so invalid combos
+    surface in preview rather than after a DB reservation:
+      - C is always allowed
+      - B requires a worktree base (registered local clone, claude-org
+        mirror clone, or self-edit)
+      - A is forbidden when the role is claude-org-self-edit (would dispatch
+        into a separate clone, breaking Issue #289 single-.git invariant)
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=True)
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_force_pattern_c_always_allowed(self):
+        layout = rwl.resolve(
+            task_id="force-c",
+            project_slug="clock-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "C"},
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertIsNone(layout.planned_branch)
+
+    def test_force_pattern_a_on_self_edit_is_rejected(self):
+        """Pattern A on a self-edit slug would dispatch into
+        ``workers_dir/claude-org-ja/``, voiding the live-repo single-.git
+        invariant."""
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-a",
+                project_slug="claude-org-ja",
+                mode="edit",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={"pattern": "A"},
+            )
+        self.assertIn("claude-org-self-edit", str(cm.exception))
+
+    def test_force_pattern_a_on_self_edit_role_override_is_rejected(self):
+        """When the override also flips role to self-edit (e.g.
+        ``--pattern A`` plus ``[worker].role = 'claude-org-self-edit'``),
+        the contract still rejects — we consult the *post-override* role
+        so the bad combo can't slip in via the role channel."""
+        with self.assertRaises(rwl.ResolveError):
+            rwl.resolve(
+                task_id="bad-a-via-role",
+                project_slug="clock-app",
+                mode="edit",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "A",
+                    "role": "claude-org-self-edit",
+                    "self_edit": True,
+                },
+            )
+
+    def test_force_pattern_b_without_local_clone_is_rejected(self):
+        """Slug whose registry path is ``-`` (no clone) and not a self-edit
+        target / mirror clone → Pattern B has no base, must error."""
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-b",
+                project_slug="clock-app",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={"pattern": "B"},
+            )
+        self.assertIn("Pattern B", str(cm.exception))
+
+    def test_force_pattern_b_on_self_edit_succeeds(self):
+        """Self-edit always has a base (the live repo), so ``--pattern B``
+        is permitted and re-derives variant + worker_dir like the
+        auto-resolved case."""
+        layout = rwl.resolve(
+            task_id="ok-b-self",
+            project_slug="claude-org-ja",
+            mode="edit",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "B"},
+        )
+        self.assertEqual(layout.pattern, "B")
+        # Coherence pass kicks in because role auto-resolves to self-edit
+        # and worker_dir wasn't supplied.
+        self.assertEqual(layout.pattern_variant, "live_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.claude_org_root / ".worktrees" / "ok-b-self").resolve(),
+        )
+
+    def test_force_pattern_b_with_role_default_on_self_edit_slug_rejects(self):
+        """Codex Round 1 Major: ``--pattern B`` together with a role
+        override flipping the slug out of self-edit dropped through the
+        contract — the resolver let the layout through because the
+        synthesized self-edit project record satisfied ``has_base``, but
+        gen_delegate_payload (which re-reads the registry and finds no
+        claude-org-ja row) ended up with ``base_repo=None``. The check
+        must drop the synthesized record when the override removes the
+        self-edit role."""
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-b-via-role",
+                project_slug="claude-org-ja",
+                mode="edit",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "role": "default",
+                    "self_edit": False,
+                },
+            )
+        self.assertIn("Pattern B", str(cm.exception))
+
+    def test_force_pattern_b_with_claude_org_mirror_re_derives_variant(self):
+        """Codex Round 2 Blocker: ``--pattern B`` on slug=claude-org used
+        to lose its variant (override resets it to None) and leave
+        worker_dir at the clone root, so gen_delegate_payload could not
+        derive a base. Re-default the variant to claude_org_repo_worktree
+        when the clone is detected, then re-derive worker_dir."""
+        # Build a fresh sandbox with a real claude-org mirror clone.
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        sb = _Sandbox(Path(td.name))
+        sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        clone = sb.workers / "claude-org"
+        clone.mkdir()
+        _Sandbox.init_git_with_origin(
+            clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+        layout = rwl.resolve(
+            task_id="force-b-mirror",
+            project_slug="claude-org",
+            claude_org_root=sb.claude_org_root,
+            state_db_path=sb.db_path,
+            layout_overrides={"pattern": "B"},
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(layout.pattern_variant, "claude_org_repo_worktree")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (clone / ".worktrees" / "force-b-mirror").resolve(),
+        )
+
+    def test_force_pattern_a_on_claude_org_mirror_re_derives_worker_dir(self):
+        """Codex Round 2 Major: ``--pattern A`` on slug=claude-org used to
+        leave worker_dir at the auto-derived ``.worktrees/<task>/`` path
+        because the A re-derivation was gated on
+        ``claude_org_clone is None``. Mirror branch must re-pin to the
+        clone root."""
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        td = tempfile.TemporaryDirectory()
+        self.addCleanup(td.cleanup)
+        sb = _Sandbox(Path(td.name))
+        sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        clone = sb.workers / "claude-org"
+        clone.mkdir()
+        _Sandbox.init_git_with_origin(
+            clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+        # Auto-derive will be Pattern A here (no active run); add one so
+        # auto-derive picks B + claude_org_repo_worktree (the case where
+        # the override stale-path bug used to bite).
+        sb.add_run(
+            task_id="other-en-task",
+            project_slug="claude-org",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(clone),
+        )
+        layout = rwl.resolve(
+            task_id="force-a-mirror",
+            project_slug="claude-org",
+            claude_org_root=sb.claude_org_root,
+            state_db_path=sb.db_path,
+            layout_overrides={"pattern": "A"},
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(Path(layout.worker_dir), clone.resolve())
+
+    def test_variant_live_repo_worktree_requires_self_edit_role(self):
+        """Codex Round 3 Blocker: ``pattern_variant=live_repo_worktree``
+        pins worker_dir + base_repo to Secretary's live claude-org repo.
+        Allowing it on a non-self-edit task (e.g. ``role=default``,
+        ``project_slug=clock-app``) would dispatch a clock-app worker into
+        the live claude-org repo — a different project entirely. The
+        override must reject this combination."""
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-variant",
+                project_slug="clock-app",
+                mode="edit",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "live_repo_worktree",
+                    # role/self_edit explicitly NOT self-edit
+                    "role": "default",
+                    "self_edit": False,
+                },
+            )
+        self.assertIn("live_repo_worktree", str(cm.exception))
+
+    def test_variant_claude_org_repo_worktree_requires_canonical_slug(self):
+        """Same blocker class for the other variant: it must only be
+        permitted on the canonical claude-org slug *and* with a clone
+        actually detected at workers_dir/claude-org. clock-app must not
+        be allowed to slip into the mirror's worktree pool."""
+        with self.assertRaises(rwl.ResolveError) as cm:
+            rwl.resolve(
+                task_id="bad-mirror-variant",
+                project_slug="clock-app",
+                claude_org_root=self.sb.claude_org_root,
+                state_db_path=self.sb.db_path,
+                layout_overrides={
+                    "pattern": "B",
+                    "pattern_variant": "claude_org_repo_worktree",
+                },
+            )
+        self.assertIn("claude_org_repo_worktree", str(cm.exception))
+
+    def test_force_pattern_b_with_local_repo_path_succeeds(self):
+        """Registered project with a local git repo path → ``--pattern B``
+        is allowed and the conventional ``workers_dir/<slug>/.worktrees/``
+        location is used."""
+        local_repo = Path(self._td.name) / "local-repo"
+        local_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(local_repo), "init", "-q"], check=True
+        )
+        self.sb.write_registry(
+            [("ローカル", "local-app", str(local_repo), "Demo")]
+        )
+        layout = rwl.resolve(
+            task_id="ok-b-local",
+            project_slug="local-app",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "B"},
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "local-app" / ".worktrees" / "ok-b-local").resolve(),
         )
 
 

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -749,6 +749,21 @@ def _add_task_args(p: argparse.ArgumentParser) -> None:
         default=None,
         help="Load task arguments from a worker_brief-style TOML instead of CLI flags.",
     )
+    # Issue #374: Secretary-side pattern override. The resolver enforces a
+    # strict contract (B requires a usable base, A forbidden on self-edit,
+    # C always permitted); see ``ResolveError`` raised from
+    # ``resolve_worker_layout.resolve``. Default None means "let the
+    # resolver auto-derive" — preserves the pre-#374 behaviour.
+    p.add_argument(
+        "--pattern",
+        choices=("A", "B", "C"),
+        default=None,
+        help=(
+            "Force a specific dispatch pattern (A/B/C). Validated by the "
+            "resolver: B requires a worktree base; A forbidden on "
+            "claude-org-self-edit; C always permitted."
+        ),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -899,6 +914,27 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
     base: dict[str, Any] = {}
     if args.from_toml is not None:
         base.update(_load_task_args_from_toml(args.from_toml))
+    # Issue #374: ``--pattern`` is a layout override, not a task field, so
+    # merge it into ``layout_overrides`` rather than into the top-level
+    # kwargs. CLI wins over a TOML [worker].pattern of the same key, matching
+    # the rest of the merge order documented above. ``None`` means "no CLI
+    # override", which preserves any TOML value already merged into base.
+    #
+    # When the CLI flag is supplied, also drop the TOML's [worker].dir and
+    # [worker].pattern_variant from the override dict — otherwise the
+    # resolver treats them as explicit values and skips its pattern-driven
+    # re-derivation, leaving worker_dir / variant on the previous pattern's
+    # convention. Codex Round 2 Major: ``--pattern C`` on a TOML that
+    # carries [worker].dir = workers/<slug>/ used to keep worker_dir at
+    # the registered clone, producing a contradictory C layout.
+    pattern_override = getattr(args, "pattern", None)
+    if pattern_override is not None:
+        existing_overrides = base.get("layout_overrides") or {}
+        merged = dict(existing_overrides)
+        merged["pattern"] = pattern_override
+        merged.pop("worker_dir", None)
+        merged.pop("pattern_variant", None)
+        base["layout_overrides"] = merged
     # CLI overrides — only when caller actually provided a value.
     cli_overrides: dict[str, Any] = {
         "task_id": args.task_id,

--- a/tools/registry_parser.py
+++ b/tools/registry_parser.py
@@ -27,8 +27,12 @@ from typing import Iterator, Optional, Union
 
 logger = logging.getLogger(__name__)
 
-# The projects table is a fixed-width 5-column shape.
-COLUMN_COUNT = 5
+# The projects table grew from 5 columns (legacy) to 6 columns (Issue #374
+# `mirror_of`). We still parse 4-column hand-edited tables ('legacy' resolver
+# leniency) and ignore extra trailing columns rather than rejecting the whole
+# row, so a future addition doesn't silently drop registered projects.
+COLUMN_COUNT = 6
+LEGACY_COLUMN_COUNT = 5
 
 # Header rows (above the |---| separator) sometimes literally contain these
 # words in the second column. Catch them when the separator is missing or
@@ -46,7 +50,15 @@ class Project:
     name: str           # プロジェクト名 (slug)
     path: str           # URL, local path, or '-'
     description: str
-    common_tasks: str   # 「よくある作業例」 raw column value (may be empty)
+    common_tasks: str = ""   # 「よくある作業例」 raw column value (may be empty)
+    # Issue #374: when non-empty, this row is a mirror of <slug>. Resolver
+    # uses the presence of this signal — not just an active concurrent run —
+    # to choose Pattern B from the first dispatch (per-task back-port style
+    # workflow, distinct from accumulating self-edit work). 5-column legacy
+    # tables (and fork registries that haven't adopted the column yet) leave
+    # this empty and the resolver falls through to the conventional A/B/C
+    # decision tree.
+    mirror_of: str = ""
 
 
 # Per-line classification. ``kind`` values:
@@ -94,9 +106,12 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
             yield ParsedRow(line_no, raw_line, "header")
             continue
         # Schema check: at least 4 cells (通称/slug/パス/説明) and the slug
-        # column populated. The 5th 「よくある作業例」 column is optional —
-        # the legacy resolver accepted 4-column tables so dropping them here
-        # would silently break manually-edited registries (Codex review M).
+        # column populated. The 5th 「よくある作業例」 and 6th `mirror_of`
+        # columns are optional — the legacy resolver accepted 4-column
+        # tables, the pre-Issue-#374 registry was 5-column, and a fork that
+        # hasn't adopted the new column yet must keep parsing. Extra
+        # trailing cells are ignored rather than treated as schema breakage
+        # so the next column addition doesn't silently drop every row.
         if len(cells) < 4 or not cells[1]:
             yield ParsedRow(line_no, raw_line, "mismatch")
             continue
@@ -105,7 +120,8 @@ def iter_rows(text: str) -> Iterator[ParsedRow]:
             name=cells[1],
             path=cells[2],
             description=cells[3],
-            common_tasks=cells[4] if len(cells) >= COLUMN_COUNT else "",
+            common_tasks=cells[4] if len(cells) >= LEGACY_COLUMN_COUNT else "",
+            mirror_of=cells[5] if len(cells) >= COLUMN_COUNT else "",
         )
         yield ParsedRow(line_no, raw_line, "data", project)
 

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -451,6 +451,7 @@ def resolve(
     # virtual project pointing at the live checkout so audit mode and the
     # active-run/state.db driven Pattern A↔B logic below keep treating it
     # the same as a registered project.
+    project_synthesized_for_self_edit = False
     if project is None and is_claude_org_project(project_slug, claude_org_root):
         project = RegistryProject(
             name=project_slug,
@@ -459,6 +460,12 @@ def resolve(
             description="",
             common_tasks="",
         )
+        # Track that this row only exists because the auto-derived role is
+        # self-edit. If a later layout_overrides flips the role away from
+        # self-edit, the contract check below must not credit this row as
+        # a worktree base — gen_delegate_payload re-reads the registry and
+        # won't find it (Codex Round 1 Major).
+        project_synthesized_for_self_edit = True
 
     # Issue #370: claude-org mirror at {workers_dir}/claude-org should
     # anchor any Pattern A/B for that repo regardless of whether the slug
@@ -482,6 +489,13 @@ def resolve(
             path=str(claude_org_clone),
             description=project.description if project is not None else "",
             common_tasks=project.common_tasks if project is not None else "",
+            # Codex Round 3 Major: preserve ``mirror_of`` when re-pinning
+            # onto the local clone. The live registry row may carry
+            # ``| ... | https://... | ... | upstream-slug |`` (non-local
+            # path + mirror_of); without this carry-over the synthesis
+            # erased mirror_of and the first-run Pattern B short-circuit
+            # silently fell back to Pattern A.
+            mirror_of=project.mirror_of if project is not None else "",
         )
 
     # --- Role decision (computed first so Pattern B can branch on it) -----
@@ -532,11 +546,34 @@ def resolve(
                     conn.close()
             except sqlite3.Error:
                 active = False
-        if active:
+        # Issue #374: two more reasons Pattern B is required even on a
+        # first dispatch:
+        # - ``self_edit`` is a *repo policy* (Secretary's live claude-org
+        #   checkout must always be a worktree, single .git, no two-clone
+        #   sync), independent of the concurrency policy that ``active``
+        #   captures. Without this short-circuit the very first self-edit
+        #   delegation lands on Pattern A and writes into the live repo.
+        # - ``project.mirror_of`` flags a mirror back-port workflow — each
+        #   task is independent, never accumulating, so worktree-per-task
+        #   is the natural default. The 5-column legacy registry leaves
+        #   this empty and behaviour is unchanged for those projects.
+        # mirror_of additionally requires a local clone path: without one,
+        # ``gen_delegate_payload`` cannot derive a worktree base, and apply
+        # would fail with ``no usable base repo``. Surface that as a config
+        # error here rather than after a DB reservation (Codex Round 1
+        # Blocker).
+        if project.mirror_of and not is_local_git_repo(project.path):
+            raise ResolveError(
+                f"project {project_slug!r} has mirror_of={project.mirror_of!r} "
+                f"in the registry but path={project.path!r} is not a local "
+                "git repo. Pattern B (the mirror back-port default) requires "
+                "the mirror to be cloned at a usable local path; either "
+                "register the local clone path or remove the mirror_of "
+                "annotation."
+            )
+        force_b = active or self_edit or bool(project.mirror_of)
+        if force_b:
             pattern = "B"
-            # claude-org self-edit Pattern B places the worktree under
-            # Secretary's live repo (single .git, no two-clone sync). See
-            # Issue #289 / references/claude-org-self-edit.md.
             if self_edit:
                 variant = "live_repo_worktree"
                 worker_dir = claude_org_root / ".worktrees" / task_id
@@ -573,12 +610,86 @@ def resolve(
     # produced Pattern C without one). Codex Round 1 Major.
     if layout_overrides:
         explicit_worker_dir = bool(layout_overrides.get("worker_dir"))
+        explicit_role_override = bool(layout_overrides.get("role"))
         if "pattern" in layout_overrides and layout_overrides["pattern"]:
             pat = layout_overrides["pattern"]
             if pat not in VALID_PATTERNS:
                 raise ResolveError(
                     f"layout_overrides['pattern'] must be one of {VALID_PATTERNS}, got {pat!r}"
                 )
+            # Issue #374: ``--pattern`` is an override flag exposed for
+            # Secretary judgment, so the contract must surface invalid combos
+            # at preview time rather than letting apply discover them after
+            # a DB reservation. The contract:
+            #   - A is forbidden when the current role is claude-org-self-edit
+            #     (Pattern A would land the brief in workers_dir/claude-org-ja/,
+            #     a separate clone, which voids the single-.git invariant
+            #     Issue #289 codified for the live repo).
+            #   - B requires a worktree base — registered local clone OR the
+            #     synthesized claude-org mirror clone OR self-edit (live repo
+            #     base). When the only candidate is a URL/placeholder path
+            #     and no clone is detected, fail loudly here so apply does
+            #     not raise after the DB row exists.
+            #   - C is always permitted.
+            #   - The role override (if any) is applied later in this block,
+            #     so consult the *post-override* role when its key is present;
+            #     otherwise fall back to the auto-derived role/self_edit.
+            effective_role = (
+                layout_overrides["role"]
+                if explicit_role_override
+                else role
+            )
+            effective_self_edit = effective_role == "claude-org-self-edit"
+            if pat == "A" and effective_self_edit:
+                raise ResolveError(
+                    "layout_overrides['pattern']='A' is incompatible with "
+                    "role='claude-org-self-edit' (would dispatch into "
+                    "{workers_dir}/claude-org-ja/, breaking the live-repo "
+                    "single-.git invariant from Issue #289). Choose pattern=B "
+                    "or override the role away from claude-org-self-edit."
+                )
+            if pat == "B":
+                # Skip the base check when the caller is supplying their own
+                # worker_dir or pattern_variant — those branches re-derive
+                # the base further below (e.g. claude_org_repo_worktree).
+                explicit_variant_now = (
+                    layout_overrides.get("pattern_variant") is not None
+                )
+                if not (explicit_worker_dir or explicit_variant_now):
+                    # The synthesized self-edit project record only exists
+                    # in this resolve(); gen_delegate_payload re-reads the
+                    # registry and finds nothing there for the slug. So if
+                    # the role override is also flipping us out of
+                    # self-edit, that synthesized record cannot back the
+                    # plain Pattern B layout — drop it from the base check
+                    # so we surface the contract error here rather than
+                    # letting apply blow up later (Codex Round 1 Major).
+                    project_for_base = project
+                    if (
+                        project_synthesized_for_self_edit
+                        and not effective_self_edit
+                    ):
+                        project_for_base = None
+                    has_base = (
+                        effective_self_edit
+                        or claude_org_clone is not None
+                        or (
+                            project_for_base is not None
+                            and is_local_git_repo(project_for_base.path)
+                        )
+                    )
+                    if not has_base:
+                        raise ResolveError(
+                            "layout_overrides['pattern']='B' requires a "
+                            "resolvable worktree base, but none could be "
+                            f"determined for project={project_slug!r}. "
+                            "Pattern B needs one of: a registered project "
+                            "row whose path is a local git repo, the "
+                            "claude-org mirror clone, or role="
+                            "'claude-org-self-edit' (live repo base). "
+                            "Either register the project's local clone, set "
+                            "role accordingly, or fall back to pattern=C."
+                        )
             pattern = pat
             # Pattern explicitly set; reset variant unless TOML also supplied one.
             variant = layout_overrides.get("pattern_variant")
@@ -586,6 +697,54 @@ def resolve(
                 raise ResolveError(
                     f"layout_overrides['pattern_variant'] must be one of {VALID_VARIANTS} or None, got {variant!r}"
                 )
+            # Codex Round 3 Blocker: pattern_variant carries strong implications
+            # for *which repo* the worker dispatches into. Without these gates
+            # a caller could request
+            # ``pattern=B, pattern_variant=live_repo_worktree, role=default``
+            # on slug=clock-app and have the worker land inside Secretary's
+            # live claude-org repo — an entirely different project than the
+            # task targets. Tie each variant to the role/slug context that
+            # makes it meaningful so the override cannot redirect dispatch
+            # at the wrong repo.
+            if variant == "live_repo_worktree" and not effective_self_edit:
+                raise ResolveError(
+                    "layout_overrides['pattern_variant']='live_repo_worktree' "
+                    "is reserved for claude-org-self-edit dispatches (the "
+                    "variant pins worker_dir + base_repo at Secretary's live "
+                    f"claude-org repo). Got effective role={effective_role!r} "
+                    f"for slug={project_slug!r}; pattern B without self-edit "
+                    "should leave pattern_variant unset and let the resolver "
+                    "anchor on the registered project's clone instead."
+                )
+            if variant == "claude_org_repo_worktree" and (
+                project_slug != _CLAUDE_ORG_CLONE_DIRNAME
+                or claude_org_clone is None
+            ):
+                raise ResolveError(
+                    "layout_overrides['pattern_variant']='claude_org_repo_worktree' "
+                    f"requires project_slug={_CLAUDE_ORG_CLONE_DIRNAME!r} (or "
+                    "its registered alias) AND a detected claude-org mirror "
+                    f"clone at {workers_dir}/{_CLAUDE_ORG_CLONE_DIRNAME}. Got "
+                    f"slug={project_slug!r}, clone_present="
+                    f"{claude_org_clone is not None}; the variant cannot "
+                    "redirect dispatch at the wrong repo."
+                )
+            # Issue #374 (Codex Round 2 Blocker): the claude-org mirror
+            # case used to lose its variant on a plain ``--pattern B``
+            # override — auto-derive set ``claude_org_repo_worktree`` but
+            # the override above resets variant to None when the caller
+            # didn't supply ``pattern_variant``. Without this re-default
+            # the worker_dir stays at the clone root (auto-derive's
+            # Pattern A path) and gen_delegate_payload's variant-specific
+            # base_repo derivation never fires. Re-default the variant
+            # so the existing ``claude_org_repo_worktree`` re-derivation
+            # below picks up worker_dir correctly.
+            if (
+                pattern == "B"
+                and variant is None
+                and claude_org_clone is not None
+            ):
+                variant = "claude_org_repo_worktree"
             # Pattern B + variant=live_repo_worktree without explicit worker_dir
             # → re-derive to claude_org_root/.worktrees/{task_id}/ (Issue #289).
             if pattern == "B" and variant == "live_repo_worktree" and not explicit_worker_dir:
@@ -610,6 +769,50 @@ def resolve(
                         "explicitly or clone the mirror at that path."
                     )
                 worker_dir = (clone_for_override / ".worktrees" / task_id).resolve()
+            # Issue #374: a plain ``--pattern B`` (no variant, no explicit
+            # worker_dir) flips A → B for a registered project. The
+            # auto-derived worker_dir is still the Pattern A path
+            # (``workers_dir/<slug>/``); without re-deriving it here the
+            # override would leave the brief at the clone root and apply
+            # would refuse to treat it as a worktree. Skipped when
+            # claude_org_clone has already pinned the clone-root path —
+            # the post-override fallback below re-derives for that case.
+            if (
+                pattern == "B"
+                and variant is None
+                and not explicit_worker_dir
+                and claude_org_clone is None
+            ):
+                worker_dir = (
+                    workers_dir / project_slug / ".worktrees" / task_id
+                ).resolve()
+            # Same idea for ``--pattern A``: when the override drops
+            # B → A, pin worker_dir back at the clone root rather than
+            # leaving it in a stale ``.worktrees/<task_id>/`` path that
+            # auto-derive built for Pattern B. Codex Round 2 Major: the
+            # claude-org mirror branch must re-derive too — without this
+            # ``--pattern A`` on slug=claude-org leaves worker_dir at the
+            # auto-derived ``.worktrees/<task_id>/`` even though the
+            # final pattern is A, an incoherent layout.
+            if pattern == "A" and not explicit_worker_dir:
+                if claude_org_clone is not None:
+                    worker_dir = claude_org_clone.resolve()
+                else:
+                    worker_dir = (workers_dir / project_slug).resolve()
+            # ``--pattern C`` override: ephemeral default. Without this
+            # branch the override would dispatch into the *registered*
+            # project's directory (auto-derive's Pattern A worker_dir),
+            # silently re-using a clone instead of an ephemeral workspace.
+            # Default variant is ``ephemeral`` (gitignored_repo_root needs
+            # an explicit variant + targets at minimum and is left to the
+            # auto-derive path).
+            if (
+                pattern == "C"
+                and variant is None
+                and not explicit_worker_dir
+            ):
+                variant = "ephemeral"
+                worker_dir = (workers_dir / task_id).resolve()
         if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
             worker_dir = Path(layout_overrides["worker_dir"]).resolve()
         if "role" in layout_overrides and layout_overrides["role"]:


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#375](https://github.com/suisya-systems/claude-org-ja/pull/375)

Merge SHA: `8e960ffb6767d1220d25c36602fea36237aa86a3`

Source: ja PR [#375](https://github.com/suisya-systems/claude-org-ja/pull/375)
Merge SHA: `8e960ffb6767d1220d25c36602fea36237aa86a3`

| class | count |
|---|---|
| runtime | 6 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (6)</summary>

- `tests/test_gen_delegate_payload.py`
- `tests/test_registry_parser.py`
- `tests/test_resolve_worker_layout.py`
- `tools/gen_delegate_payload.py`
- `tools/registry_parser.py`
- `tools/resolve_worker_layout.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
