### PR TITLE
auto-mirror: ja#395 feat(claude): add Read() deny entries for Phase 2 Read tool gap rows (#376)

### DIFF
--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -296,7 +296,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {
@@ -354,7 +359,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#395](https://github.com/suisya-systems/claude-org-ja/pull/395)

Merge SHA: `ca7f46691ba80c0ffcd80c9384ea588b199eab11`

Source: ja PR [#395](https://github.com/suisya-systems/claude-org-ja/pull/395)
Merge SHA: `ca7f46691ba80c0ffcd80c9384ea588b199eab11`

| class | count |
|---|---|
| runtime | 1 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (1)</summary>

- `tools/org_extension_schema.json`

</details>
<details><summary>translation (1)</summary>

- `docs/sandbox-probe/profiles/profile-tightened.json`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
