### PR TITLE
auto-mirror: ja#396 chore(claude): bump claude-org-runtime pin to >=0.1.3,<0.2 (Refs #376)

### DIFF
--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 3)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#396](https://github.com/suisya-systems/claude-org-ja/pull/396)

Merge SHA: `ae8c9eb93ddd9d5ee14d7a7bbb7b4a538a9cef76`

Source: ja PR [#396](https://github.com/suisya-systems/claude-org-ja/pull/396)
Merge SHA: `ae8c9eb93ddd9d5ee14d7a7bbb7b4a538a9cef76`

| class | count |
|---|---|
| runtime | 1 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 2 |

<details><summary>runtime (1)</summary>

- `tools/check_runtime_schema_drift.py`

</details>
<details><summary>unknown (2)</summary>

- `pyproject.toml`
- `requirements.txt`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
