### PR TITLE
auto-mirror: ja#402 chore: bump runtime pin to >=0.1.5 and add worktrees deny (Closes #300)

### DIFF
--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 5)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -146,7 +146,9 @@
         "Write(*/workers/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.claude/settings.local.json)",
         "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
+        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+        "Write(*/.worktrees/*/.claude/settings.local.json)",
+        "Edit(*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [
         {
@@ -296,7 +298,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {
@@ -354,7 +361,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#402](https://github.com/suisya-systems/claude-org-ja/pull/402)

Merge SHA: `3ae59514d4af4d11c8001284f939bf632fb7a7eb`

Source: ja PR [#402](https://github.com/suisya-systems/claude-org-ja/pull/402)
Merge SHA: `3ae59514d4af4d11c8001284f939bf632fb7a7eb`

| class | count |
|---|---|
| runtime | 2 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 2 |

<details><summary>runtime (2)</summary>

- `tools/check_runtime_schema_drift.py`
- `tools/org_extension_schema.json`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-setup/references/permissions.md`

</details>
<details><summary>unknown (2)</summary>

- `pyproject.toml`
- `requirements.txt`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
