### PR TITLE
auto-mirror: ja#408 chore: bump runtime pin to >=0.1.6 and declare sandbox schema surface (Refs #378 #376)

### DIFF
--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -35,7 +35,7 @@ from pathlib import Path
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 6)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -26,6 +26,7 @@
     "check-worker-boundary.sh",
     "block-dispatcher-out-of-scope.sh"
   ],
+  "$comment_roles_sandbox": "Phase 1 schema surface: each entry under `roles.<role>` may also include an optional `sandbox` object using the same shape and structured-anchor entry form documented under `worker_roles.$comment_sandbox` / `worker_roles.$comment_sandbox_anchor`. This lets secretary / dispatcher / curator declare Layer 3 sandbox intent alongside the existing Layer 2 `required_allow` / `required_deny` audit constraints. Roles without `sandbox` are treated as sandbox-disabled (backward compatible). Concrete bodies for individual roles are not landed by this PR — only the surface is permitted; see `docs/contracts/role-pattern-sandbox-contract.md` for the contract that future fills must satisfy.",
   "roles": {
     "repo_shared": {
       "description": "Repo-shared settings (.claude/settings.json) — tracked in git; hosts repo-wide safety hooks (block-no-verify, block-dangerous-git).",
@@ -146,7 +147,9 @@
         "Write(*/workers/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.claude/settings.local.json)",
         "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
+        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+        "Write(*/.worktrees/*/.claude/settings.local.json)",
+        "Edit(*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [
         {
@@ -275,7 +278,9 @@
     }
   },
   "worker_roles": {
-    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time.",
+    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time; Pattern B context placeholders are documented under `$comment_sandbox_anchor`.",
+    "$comment_sandbox": "Phase 1 schema surface: each `worker_roles.<role>` may include an optional `sandbox` object of the form {enabled: bool, filesystem: {denyRead: [entry], denyWrite: [entry], additionalDirectories: [string]}, failIfUnavailable: bool, default false}. The sandbox object is forwarded as-is to the rendered settings.local.json (consumed by claude-org-ja's bwrap launcher). At render time the generator applies Layer 3 suppression: each filesystem.denyRead / denyWrite entry whose realpath escapes the sandbox read roots (worker_dir + additionalDirectories) is dropped from the rendered sandbox object because the sandbox cannot reach the path anyway. This is common on WSL (where /home/<user>/... may be a /mnt/c/... symlink) and devcontainers (/workspaces symlinks). Layer 2 `permissions.deny` `Read(...)` / `Write(...)` entries are NEVER suppressed. Suppression metadata is exposed via `claude-org-runtime settings show --explain`. Roles without `sandbox` are treated as sandbox-disabled (backward compatible).",
+    "$comment_sandbox_anchor": "Phase 1 schema surface: `denyRead` / `denyWrite` entries may now be either (a) a legacy raw string (anchored at worker_dir for relative paths, treated literally for absolute paths) or (b) a structured object {anchor: 'home'|'worker_dir'|'claude_org_path'|'base_clone'|'absolute', path: string, suppressOnSymlinkEscape: bool default true, layer2Fallback: optional Layer-2 permissions.deny mirror entry}. The structured form fixes the legacy ambiguity where '~/.aws/**'-style entries were misjudged as worker_dir-relative. 'home' resolves to the current user's home directory, 'absolute' is treated literally, 'worker_dir' / 'claude_org_path' / 'base_clone' use the corresponding generator-context substitutions. When `suppressOnSymlinkEscape` is false the entry is preserved even if its realpath escapes the sandbox read roots (useful for entries the operator wants in the rendered output regardless of reachability). When `layer2Fallback` is set, the value is the Layer-2 `permissions.deny` mirror string emitted whenever the Layer-3 entry is suppressed, so credential reads via the `Read` tool stay blocked. Pattern B context placeholders ({base_clone}, {task_id}, {branch_ref}, {pattern}) are recognized substitution variables in addition to the legacy {worker_dir} / {claude_org_path}; they are substituted in entry.path and additionalDirectories before realpath evaluation when supplied via the generator API. Backward compat: legacy raw-string entries continue to parse via the runtime adapter and need not be migrated when this schema surface is adopted.",
     "default": {
       "description": "Standard worker template — git read/write within the worktree, no push, no recursive delete. Mirrors the historical org-delegate Step 3 inline JSON.",
       "permissions": {
@@ -296,7 +301,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {
@@ -354,7 +364,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#408](https://github.com/suisya-systems/claude-org-ja/pull/408)

Merge SHA: `6ccddcce4905070a8e25a1712d3a0858183ac7ff`

Source: ja PR [#408](https://github.com/suisya-systems/claude-org-ja/pull/408)
Merge SHA: `6ccddcce4905070a8e25a1712d3a0858183ac7ff`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 2 |

<details><summary>runtime (2)</summary>

- `tools/check_runtime_schema_drift.py`
- `tools/org_extension_schema.json`

</details>
<details><summary>unknown (2)</summary>

- `pyproject.toml`
- `requirements.txt`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
