### PR TITLE
auto-mirror: ja#411 feat: add concrete sandbox bodies to roles.{secretary,dispatcher,curator} (Refs #378 #376)

### DIFF
--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/README.md
@@ -1,0 +1,126 @@
+# Sandbox-intent semantic drift fixtures
+
+Inputs for the semantic golden drift check in
+[`tools/check_runtime_schema_drift.py`](../../../../tools/check_runtime_schema_drift.py).
+Each fixture pairs a small input schema fragment with the expected
+`SandboxMetadata.to_jsonable()` (the "explain JSON") output of
+`claude_org_runtime.settings.generator.render_role_with_metadata()`.
+The byte-identical schema check (existing path) catches structural
+divergence; this semantic check catches behavioural divergence in the
+suppression evaluator on top of identical schema bytes.
+
+## Fixture format
+
+```jsonc
+{
+  "description": "what this fixture exercises",
+  "inputs": {
+    "role": "...",                // required, key inside schema's worker_roles or roles
+    "role_kind": "worker"|"org",  // optional, defaults to "worker"
+    "worker_dir": "...",          // required absolute path
+    "claude_org_path": "...",     // required absolute path
+    "base_clone": "...",          // optional, Pattern B placeholder
+    "task_id": "...",             // optional, Pattern B placeholder
+    "branch_ref": "...",          // optional, Pattern B placeholder
+    "pattern": "A"|"B"|"C"|null,  // optional, informational only
+    "wsl_detected": true|false,   // stub for runtime's wsl_detector
+    "realpath_map": [             // fake realpath rules; first match wins
+      {"prefix": "/some/path", "replacement": "/another/path"}
+    ],
+
+    // Choose exactly one of the next two — the loader rejects setting
+    // both, and rejects setting neither.
+    "schema_fragment": { ... },   // (a) inline mini-schema dict
+    "schema_source": "shipped",   // (b) load tools/org_extension_schema.json
+
+    "home_dir": "/H"              // optional; required if any deny entry uses
+                                  //   anchor:"home". Swaps $HOME/$USERPROFILE
+                                  //   for the duration of the render so
+                                  //   os.path.expanduser('~') is deterministic.
+  },
+  "expected_explain": { ... },    // SandboxMetadata.to_jsonable() output
+
+  "expected_rendered_sandbox": {  // optional; rendered RenderResult.settings.sandbox
+    "enabled": true, ...          // (kept deny entries + additionalDirectories,
+  }                               // post-substitution, suppressed entries dropped).
+                                  // Set when the fixture wants to detect a
+                                  // regression that drops a kept entry — the
+                                  // explain JSON only describes *suppressions*,
+                                  // so without this a removed `denyWrite` would
+                                  // not be detected if its suppression state
+                                  // didn't change.
+}
+```
+
+`realpath_map` rules apply to a path `p` when `p == prefix` or
+`p.startswith(prefix + "/")`. The matched prefix is replaced and the
+result is returned. Paths that match no rule pass through unchanged.
+
+### `schema_source: "shipped"` vs inline `schema_fragment`
+
+- Use `schema_fragment` when the fixture's purpose is to exercise a
+  specific evaluator path with a minimal, hand-rolled mini-schema —
+  the original sandbox_default / sandbox_doc_audit /
+  sandbox_pattern_b_self_edit fixtures use this form.
+- Use `schema_source: "shipped"` when the fixture's purpose is to
+  pin behaviour against the *actual concrete sandbox body* that ships
+  in [`tools/org_extension_schema.json`](../../../../tools/org_extension_schema.json).
+  The Phase 1 PR3 `role_secretary.json` / `role_dispatcher.json` /
+  `role_curator.json` fixtures use this form so the concrete bodies
+  for the three org roles are verified, not just the evaluator. A
+  hand-rolled mini-schema cannot detect a regression in the shipped
+  body; the shipped form can.
+
+### `layer2Fallback` is forward-looking, not auto-mirrored today
+
+A structured deny entry may carry a `layer2Fallback` string per
+`worker_roles.$comment_sandbox_anchor` in the schema. The intent is
+that when the Layer-3 entry is suppressed (e.g. on WSL the home-
+anchored `~/.aws/**` deny escapes sandbox read roots), the runtime
+mirrors the fallback string into `permissions.deny`. The version of
+`claude-org-runtime` pinned by this repo does NOT yet implement that
+mirror — the `layer2Fallback` field is preserved on the suppression
+record's `entry` but not emitted into `permissions.deny`. Fixtures
+therefore only compare suppressions and the rendered sandbox dict;
+they do not assert anything about `permissions.deny`. Effective
+Layer 2 deny for credentials still has to be declared by hand via
+`roles.<role>.required_deny`.
+
+### `home_dir` and `anchor: "home"`
+
+The runtime resolves `anchor: "home"` via `os.path.expanduser("~")`,
+which on POSIX reads `$HOME` (Windows: `$USERPROFILE`) — host-dependent
+by default. Setting `inputs.home_dir = "/H"` (or any stable path) makes
+the loader temporarily swap those env vars for the duration of the
+render so home-anchored entries produce a byte-portable
+`expected_explain`. Restore-on-finally is unconditional: a stray
+exception cannot leak the fake `$HOME` into other tests.
+
+Fixtures that do not use `anchor: "home"` should omit `home_dir`.
+
+## Out-of-scope intentionally
+
+- **`verification_depth`**: this is a delegate-payload / brief
+  convention surfaced via `tools/gen_delegate_payload.py`, not a
+  sandbox enforcement dimension. The renderer's
+  `render_role_with_metadata()` does not branch on it and the explain
+  JSON does not include it. Fixtures here MUST NOT add a
+  `verification_depth` field to either `inputs` or
+  `expected_explain` — depth is enforcement-out-of-scope by design.
+- **Concrete sandbox bodies for `worker_roles.*`**: not landed in the
+  Phase 1 PR3 changeset; the worker_roles A/B/C pattern variation
+  needs a `sandbox_by_pattern` schema decision (deferred to PR4 per
+  the Codex pre-design review). The three `role_secretary` /
+  `role_dispatcher` / `role_curator` fixtures pin the org-side bodies
+  added in PR3. `worker_roles.default` / `claude-org-self-edit` /
+  `doc-audit` shipped-body fixtures are tracked for a later changeset.
+
+## Adding a new fixture
+
+1. Drop the JSON file into this directory.
+2. Run `python tools/check_runtime_schema_drift.py --semantic` and
+   confirm it prints OK. Mismatches print a unified diff between the
+   committed `expected_explain` and the runtime's actual output.
+3. The pytest companion at
+   [`tests/test_runtime_schema_drift_semantic.py`](../../../test_runtime_schema_drift_semantic.py)
+   discovers fixtures by glob, so no test wiring is needed.

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json
@@ -1,0 +1,188 @@
+{
+  "description": "Curator role (org-side, role_kind=org) rendered against the in-tree shipped tools/org_extension_schema.json (schema_source=shipped). Pins both the explain JSON (suppressions) and the rendered sandbox body (kept deny entries) so a regression that drops e.g. denyWrite: .state from the shipped body — not just one that flips its suppression state — is detected. worker_dir = claude_org_path/.curator; additionalDirectories is narrow (just {claude_org_path}/knowledge) per docs/contracts/role-pattern-sandbox-contract.md §3.3.1 read surface and §3.3.3 Phase 1 prescription. With the narrow read scope, denyWrite entries (.state/ registry/ tools/ dashboard/ .claude/skills/ workers_dir/**, from §3.3.2 / §3.3.3) all fall outside read_roots and are SUPPRESSED at Layer 3 — by design: the entries document intent and would activate if read scope were ever widened, while at runtime the same paths are protected by absence-of-mount. Major 2 from the Codex pre-design review: knowledge/raw/ deletion-vs-move discipline is operation-semantic, NOT path-based, so the shipped body intentionally does NOT mechanize it via denyWrite. Worker_dir-anchored credential entries are kept (target inside read_roots); home-anchored entries are suppressed with realpath under home_dir=/H, layer2Fallback strings preserved in the suppression record.",
+  "inputs": {
+    "role": "curator",
+    "role_kind": "org",
+    "worker_dir": "/home/u/co/.curator",
+    "claude_org_path": "/home/u/co",
+    "home_dir": "/H",
+    "wsl_detected": false,
+    "realpath_map": [],
+    "schema_source": "shipped"
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": false,
+    "sandbox_read_roots": [
+      "/home/u/co/.curator",
+      "/home/u/co/knowledge"
+    ],
+    "suppressions": [
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".config/gh/hosts.yml",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.config/gh/hosts.yml",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".aws/**",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.aws/*)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.aws",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".ssh/**",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.ssh/*)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.ssh",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "claude_org_path",
+          "path": ".state",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/.state",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "claude_org_path",
+          "path": "registry",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/registry",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "claude_org_path",
+          "path": "tools",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/tools",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "claude_org_path",
+          "path": "dashboard",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/dashboard",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "claude_org_path",
+          "path": ".claude/skills",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/.claude/skills",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyWrite",
+        "entry": {
+          "anchor": "absolute",
+          "path": "/home/u/co/../workers/**",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/home/u/co/../workers",
+        "sandbox_read_roots": [
+          "/home/u/co/.curator",
+          "/home/u/co/knowledge"
+        ]
+      }
+    ]
+  },
+  "expected_rendered_sandbox": {
+    "enabled": true,
+    "failIfUnavailable": false,
+    "filesystem": {
+      "additionalDirectories": [
+        "/home/u/co/knowledge"
+      ],
+      "denyRead": [
+        {
+          "anchor": "worker_dir",
+          "path": ".env",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(.env)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": ".env.*",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(.env.*)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": "**/credentials*",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(**/credentials*)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": "**/*.pem",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(**/*.pem)"
+        }
+      ],
+      "denyWrite": []
+    }
+  }
+}

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json
@@ -1,0 +1,128 @@
+{
+  "description": "Dispatcher role (org-side, role_kind=org) rendered against the in-tree shipped tools/org_extension_schema.json (schema_source=shipped). Pins both the explain JSON (suppressions) and the rendered sandbox body (kept deny entries) so a regression that drops e.g. denyWrite: tools/dashboard/tests/.claude/skills/docs/registry from the shipped body — not just one that flips its suppression state — is detected. The dispatcher runs in permission_mode=bypassPermissions which makes Layer 2 a no-op (docs/contracts/role-pattern-sandbox-contract.md §3.2 line 270-272), so the shipped body intentionally OMITS layer2Fallback on every entry — Major 1 from the Codex pre-design review for PR3. Layer 3 is the primary enforcement vector. worker_dir = claude_org_path/.dispatcher; additionalDirectories adds claude_org_path so .state/ knowledge/raw/ registry/ tools/ are reachable for read (per §3.2.1) and so denyWrite entries for tools/ dashboard/ tests/ .claude/skills/ docs/ registry/ resolve inside read_roots and are kept (closing the §3.2.4 Bash-redirect carve-out where .hooks/block-dispatcher-out-of-scope.sh only matches Edit/Write). claude_org_path-anchored credential entries are kept (target inside read_roots); home-anchored entries are suppressed with realpath under home_dir=/H. workers_dir/** is intentionally NOT in denyWrite — it falls outside read_roots and is protected at Layer 4 by .hooks/block-dispatcher-out-of-scope.sh + .hooks/block-workers-delete.sh.",
+  "inputs": {
+    "role": "dispatcher",
+    "role_kind": "org",
+    "worker_dir": "/home/u/co/.dispatcher",
+    "claude_org_path": "/home/u/co",
+    "home_dir": "/H",
+    "wsl_detected": false,
+    "realpath_map": [],
+    "schema_source": "shipped"
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": false,
+    "sandbox_read_roots": [
+      "/home/u/co/.dispatcher",
+      "/home/u/co"
+    ],
+    "suppressions": [
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".config/gh/hosts.yml",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.config/gh/hosts.yml",
+        "sandbox_read_roots": [
+          "/home/u/co/.dispatcher",
+          "/home/u/co"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".aws/**",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.aws",
+        "sandbox_read_roots": [
+          "/home/u/co/.dispatcher",
+          "/home/u/co"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".ssh/**",
+          "suppressOnSymlinkEscape": true
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.ssh",
+        "sandbox_read_roots": [
+          "/home/u/co/.dispatcher",
+          "/home/u/co"
+        ]
+      }
+    ]
+  },
+  "expected_rendered_sandbox": {
+    "enabled": true,
+    "failIfUnavailable": false,
+    "filesystem": {
+      "additionalDirectories": [
+        "/home/u/co"
+      ],
+      "denyRead": [
+        {
+          "anchor": "claude_org_path",
+          "path": "**/credentials*",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": "**/*.pem",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": ".env",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": ".env.*",
+          "suppressOnSymlinkEscape": true
+        }
+      ],
+      "denyWrite": [
+        {
+          "anchor": "claude_org_path",
+          "path": "tools",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": "dashboard",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": "tests",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": ".claude/skills",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": "docs",
+          "suppressOnSymlinkEscape": true
+        },
+        {
+          "anchor": "claude_org_path",
+          "path": "registry",
+          "suppressOnSymlinkEscape": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
+++ b/tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json
@@ -1,0 +1,104 @@
+{
+  "description": "Secretary role (org-side, role_kind=org) rendered against the in-tree shipped tools/org_extension_schema.json (schema_source=shipped). Pins both the explain JSON (suppressions) and the rendered sandbox body (kept deny entries + additionalDirectories) so a regression that drops an entry from the shipped body — not just one that flips its suppression state — is detected. worker_dir = claude_org_path (the secretary runs in the live repo); additionalDirectories adds workers_dir at {claude_org_path}/../workers per docs/contracts/role-pattern-sandbox-contract.md §3.1.1. Worker_dir-anchored credential entries (.env / .env.* / **/credentials* / **/*.pem) resolve under read_roots and are kept with their layer2Fallback strings preserved; home-anchored entries (~/.config/gh/hosts.yml / ~/.aws/** / ~/.ssh/**) escape read_roots and are suppressed (entries also keep their layer2Fallback strings in the suppression record so a future Layer-2 mirror emit can use them). home_dir=/H stabilizes the home-anchored realpath across hosts (HOME/USERPROFILE swap) so expected_explain is byte-portable.",
+  "inputs": {
+    "role": "secretary",
+    "role_kind": "org",
+    "worker_dir": "/home/u/co",
+    "claude_org_path": "/home/u/co",
+    "home_dir": "/H",
+    "wsl_detected": false,
+    "realpath_map": [],
+    "schema_source": "shipped"
+  },
+  "expected_explain": {
+    "enabled": true,
+    "wsl_detected": false,
+    "sandbox_read_roots": [
+      "/home/u/co",
+      "/home/u/workers"
+    ],
+    "suppressions": [
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".config/gh/hosts.yml",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.config/gh/hosts.yml",
+        "sandbox_read_roots": [
+          "/home/u/co",
+          "/home/u/workers"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".aws/**",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.aws/*)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.aws",
+        "sandbox_read_roots": [
+          "/home/u/co",
+          "/home/u/workers"
+        ]
+      },
+      {
+        "layer": "sandbox.filesystem.denyRead",
+        "entry": {
+          "anchor": "home",
+          "path": ".ssh/**",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(~/.ssh/*)"
+        },
+        "reason": "realpath escapes sandbox read roots",
+        "realpath": "/H/.ssh",
+        "sandbox_read_roots": [
+          "/home/u/co",
+          "/home/u/workers"
+        ]
+      }
+    ]
+  },
+  "expected_rendered_sandbox": {
+    "enabled": true,
+    "failIfUnavailable": false,
+    "filesystem": {
+      "additionalDirectories": [
+        "/home/u/co/../workers"
+      ],
+      "denyRead": [
+        {
+          "anchor": "worker_dir",
+          "path": ".env",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(.env)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": ".env.*",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(.env.*)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": "**/credentials*",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(**/credentials*)"
+        },
+        {
+          "anchor": "worker_dir",
+          "path": "**/*.pem",
+          "suppressOnSymlinkEscape": true,
+          "layer2Fallback": "Read(**/*.pem)"
+        }
+      ],
+      "denyWrite": []
+    }
+  }
+}

--- a/tests/test_runtime_schema_drift_semantic.py
+++ b/tests/test_runtime_schema_drift_semantic.py
@@ -1,0 +1,142 @@
+"""Semantic golden drift tests for ``tools/check_runtime_schema_drift.py``.
+
+The byte-identical schema check that lives in
+``check_runtime_schema_drift`` validates that
+``tools/org_extension_schema.json`` and the schema bundled with
+``claude-org-runtime`` agree as JSON. That is necessary but not
+sufficient: the runtime's ``render_role_with_metadata()`` evaluator
+may change the shape of the rendered explain JSON (suppression
+reason wording, ``sandbox_read_roots`` order, structured-anchor
+substitution, etc.) without touching the schema bytes at all.
+
+These tests render each fixture under
+``tests/fixtures/runtime_schema_drift/sandbox_intent/`` through the
+fixture-supplied fake ``realpath`` shim and assert that the rendered
+``SandboxMetadata.to_jsonable()`` matches the committed
+``expected_explain``. Discovery is glob-based so adding a fixture
+requires no test wiring.
+
+The check intentionally bypasses the pin-window guard in
+``check_runtime_schema_drift.main`` because the fixtures depend on
+the *currently importable* runtime, not on whatever pin range
+``pyproject.toml`` declares. The pin guard exists to prevent a
+contributor's locally-previewed runtime from blocking unrelated PRs;
+inside the test runner we run against whatever runtime is installed
+and surface drift as a hard failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+import check_runtime_schema_drift as csd  # noqa: E402
+
+
+FIXTURE_DIR = (
+    REPO_ROOT / "tests" / "fixtures" / "runtime_schema_drift" / "sandbox_intent"
+)
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+class FixtureExplainGoldenTest(unittest.TestCase):
+    """Each fixture's ``expected_explain`` matches what the installed
+    ``claude_org_runtime.settings.generator.render_role_with_metadata``
+    actually produces for the fixture inputs."""
+
+    def test_fixture_directory_is_populated(self) -> None:
+        # Smoke check: at least one fixture exists, otherwise the per-
+        # fixture loop below would silently pass with zero cases.
+        self.assertTrue(
+            _fixture_paths(),
+            f"No semantic fixtures found in {FIXTURE_DIR}; the semantic "
+            "drift check would be a no-op.",
+        )
+
+    def test_fixture_explain_matches_runtime(self) -> None:
+        for fixture_path in _fixture_paths():
+            with self.subTest(fixture=fixture_path.name):
+                fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+                # Single render shared by both checks — the home_dir
+                # env swap should only happen once per fixture.
+                result = csd._render_fixture_result(fixture)
+                expected = fixture["expected_explain"]
+                actual = result.sandbox.to_jsonable()
+                self.assertEqual(
+                    actual,
+                    expected,
+                    f"Semantic drift in {fixture_path.name}:\n"
+                    f"expected: "
+                    f"{json.dumps(expected, indent=2, sort_keys=True)}\n"
+                    f"actual:   "
+                    f"{json.dumps(actual, indent=2, sort_keys=True)}",
+                )
+                if "expected_rendered_sandbox" in fixture:
+                    expected_sandbox = fixture["expected_rendered_sandbox"]
+                    actual_sandbox = result.settings.get("sandbox")
+                    self.assertEqual(
+                        actual_sandbox,
+                        expected_sandbox,
+                        f"Rendered sandbox drift in {fixture_path.name} "
+                        "(kept deny entries / additionalDirectories):\n"
+                        f"expected: "
+                        f"{json.dumps(expected_sandbox, indent=2, sort_keys=True)}\n"
+                        f"actual:   "
+                        f"{json.dumps(actual_sandbox, indent=2, sort_keys=True)}",
+                    )
+
+    def test_fixture_does_not_carry_verification_depth_field(self) -> None:
+        # ``verification_depth`` is a delegate-payload convention, not a
+        # sandbox enforcement dimension. Fixtures must not introduce
+        # it anywhere in the file (top-level *or* nested inside
+        # ``schema_fragment``) so the check keeps a tight enforcement
+        # surface. Reuses the same recursive helper the CLI runs so
+        # both surfaces give the same answer.
+        for fixture_path in _fixture_paths():
+            with self.subTest(fixture=fixture_path.name):
+                fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+                violations = csd._validate_fixture_policy(fixture_path, fixture)
+                self.assertEqual(
+                    violations,
+                    [],
+                    f"{fixture_path.name} violates the out-of-scope-field "
+                    f"policy: {violations}",
+                )
+
+
+class RealpathShimTest(unittest.TestCase):
+    """Unit-level tests for the fake-realpath helper."""
+
+    def test_prefix_replacement(self) -> None:
+        fn = csd._build_realpath_fn(
+            [{"prefix": "/home/u/wd", "replacement": "/mnt/c/Users/u/wd"}]
+        )
+        self.assertEqual(fn("/home/u/wd"), "/mnt/c/Users/u/wd")
+        self.assertEqual(
+            fn("/home/u/wd/secrets.env"),
+            "/mnt/c/Users/u/wd/secrets.env",
+        )
+        self.assertEqual(fn("/home/u/wdother"), "/home/u/wdother")
+        self.assertEqual(fn("/elsewhere"), "/elsewhere")
+
+    def test_first_match_wins(self) -> None:
+        fn = csd._build_realpath_fn(
+            [
+                {"prefix": "/a/b", "replacement": "/X"},
+                {"prefix": "/a", "replacement": "/Y"},
+            ]
+        )
+        self.assertEqual(fn("/a/b/c"), "/X/c")
+        self.assertEqual(fn("/a/c"), "/Y/c")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_runtime_schema_drift.py
+++ b/tools/check_runtime_schema_drift.py
@@ -11,35 +11,65 @@ runtime-incompatible schema change.
 
 Pin-window tolerance
 --------------------
-ja pins ``claude-org-runtime>=0.1.1,<0.2``. When the installed runtime
-is *outside* that window (e.g. a contributor previewed 0.2.0 locally
-before ja widened its pin), this check **skips with a warning** rather
-than failing — the bundled schema is by definition allowed to evolve
-ahead of ja's pin window, and a hard failure here would just block
-unrelated PRs.
+ja pins ``claude-org-runtime`` to a narrow window (see
+``RUNTIME_PIN_LOWER_INCLUSIVE`` / ``RUNTIME_PIN_UPPER_EXCLUSIVE``).
+When the installed runtime is *outside* that window, the **byte check
+skips with a warning** rather than failing — the bundled schema is by
+definition allowed to evolve ahead of ja's pin window, and a hard
+failure here would just block unrelated PRs. Inside the window the
+byte check treats any structural difference as a hard failure.
 
-When the installed runtime is *inside* the window, any difference is a
-hard failure: the two schemas are supposed to be byte-identical.
+The ``--semantic`` check, in contrast, runs unconditionally when
+explicitly requested: an operator invoking it against a preview
+runtime is asking "does my evaluator-shape golden still match?", and
+silently skipping would defeat the point of the flag. The same
+unconditional semantics apply to the matching pytest test.
+
+Two drift dimensions
+--------------------
+The byte-identical schema check is necessary but not sufficient. Two
+schemas can be byte-identical and still produce divergent rendered
+sandbox suppression metadata if the runtime's
+``render_role_with_metadata()`` evaluator changes shape (e.g. a new
+suppression reason wording, a new placeholder substituted, a different
+``sandbox_read_roots`` order). The "byte-identical" framing alone is
+therefore incomplete after the Phase 1 sandbox-intent work landed.
+
+The ``--semantic`` flag adds a complementary semantic golden drift
+check: small in-repo fixtures under
+``tests/fixtures/runtime_schema_drift/sandbox_intent/`` carry both an
+input schema fragment and the expected explain JSON
+(``SandboxMetadata.to_jsonable()``). The check renders each fixture
+through ``render_role_with_metadata()`` with a fixture-supplied fake
+``realpath`` shim (so platform-dependent paths don't pollute the
+diff) and asserts the rendered explain JSON matches byte-for-byte.
 
 Exit codes: 0 = OK or skipped (out-of-window), 1 = drift detected.
 """
 
 from __future__ import annotations
 
+import argparse
+import difflib
 import json
+import os
 import sys
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
+from typing import Any, Callable
 
 # Mirror of the ``claude-org-runtime`` pin in pyproject.toml /
 # requirements.txt. Keep this constant in sync when widening the pin
 # (Phase 5e+ scope per CLAUDE.local.md). Stored as tuples for ordered
 # comparison; only major.minor.micro are honoured.
-RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 1)
+RUNTIME_PIN_LOWER_INCLUSIVE = (0, 1, 6)
 RUNTIME_PIN_UPPER_EXCLUSIVE = (0, 2, 0)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 JA_SCHEMA = REPO_ROOT / "tools" / "org_extension_schema.json"
+SEMANTIC_FIXTURE_DIR = (
+    REPO_ROOT / "tests" / "fixtures" / "runtime_schema_drift" / "sandbox_intent"
+)
 
 
 def _parse_version(ver: str) -> tuple[int, ...]:
@@ -100,29 +130,260 @@ def _normalise(obj: object) -> object:
     return obj
 
 
-def main(argv: list[str] | None = None) -> int:
-    del argv  # currently no flags; kept for signature consistency
-    try:
-        installed_str = _pkg_version("claude-org-runtime")
-    except PackageNotFoundError:
-        print(
-            "check_runtime_schema_drift: claude-org-runtime is not installed; "
-            "run `pip install -e .` first.",
-            file=sys.stderr,
-        )
-        return 1
-    installed = _parse_version(installed_str)
-    if not _runtime_in_pin_window(installed):
-        print(
-            f"check_runtime_schema_drift: WARN — installed claude-org-runtime "
-            f"{installed_str} is outside ja's pin window "
-            f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
-            f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
-            "skipping strict drift check (runtime is allowed to ship a new "
-            "minor before ja widens the pin)."
-        )
-        return 0
+def _strip_ja_only_sandbox_bodies(schema: object) -> object:
+    """Drop ja-only ``sandbox`` bodies from each role / worker_role.
 
+    Phase 1 PR3 (Refs claude-org-ja#378 #376) lands concrete
+    ``sandbox`` bodies on ``roles.{secretary,dispatcher,curator}`` in
+    ja's ``tools/org_extension_schema.json``, driven by the Phase 0
+    contract at ``docs/contracts/role-pattern-sandbox-contract.md``.
+    The ``claude-org-runtime`` bundled schema only carries the
+    *structural* sandbox surface (Phase 1 PR1) — concrete bodies are
+    ja-side org policy, not runtime template defaults, and intentionally
+    do not ship in the runtime package. The byte check would otherwise
+    flag this as drift on every PR3+ commit.
+
+    The semantic check (``--semantic``) keeps end-to-end coverage of
+    the in-tree concrete bodies via the
+    ``tests/fixtures/runtime_schema_drift/sandbox_intent/role_*.json``
+    fixtures (``schema_source: "shipped"``), so stripping here does
+    not lose verification — it just lets the byte check focus on the
+    schema *surface* contract, which is where ja and runtime must agree.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    out: dict[str, Any] = {}
+    for top_key, top_val in schema.items():
+        if top_key not in ("roles", "worker_roles") or not isinstance(top_val, dict):
+            out[top_key] = top_val
+            continue
+        new_bucket: dict[str, Any] = {}
+        for role_name, role_def in top_val.items():
+            if isinstance(role_def, dict) and "sandbox" in role_def:
+                new_bucket[role_name] = {
+                    k: v for k, v in role_def.items() if k != "sandbox"
+                }
+            else:
+                new_bucket[role_name] = role_def
+        out[top_key] = new_bucket
+    return out
+
+
+def _build_realpath_fn(
+    rules: list[dict[str, str]],
+) -> Callable[[str], str]:
+    """Build a deterministic ``realpath`` shim from fixture rules.
+
+    Each rule is a ``{"prefix", "replacement"}`` pair. For an input path
+    ``p`` the first matching rule wins: a rule matches when ``p`` equals
+    ``prefix`` or starts with ``prefix + "/"``; the matched prefix is
+    swapped for ``replacement``. Paths with no matching rule pass
+    through unchanged. The behaviour mirrors the fake-realpath stubs
+    used by the runtime's own settings-generator unit tests.
+    """
+    compiled = list(rules or [])
+
+    def _realpath(p: str) -> str:
+        for rule in compiled:
+            prefix = rule["prefix"]
+            replacement = rule["replacement"]
+            if p == prefix:
+                return replacement
+            if p.startswith(prefix + "/"):
+                return replacement + p[len(prefix):]
+        return p
+
+    return _realpath
+
+
+def _schema_role_uses_home_anchor(
+    schema: dict[str, Any], role_kind: str, role: str
+) -> bool:
+    """Return True iff the resolved role declares any deny entry with anchor=home.
+
+    Used by the fixture loader to enforce that any fixture rendering a
+    role whose sandbox body uses ``anchor: "home"`` must set
+    ``inputs.home_dir`` explicitly. Without that the host's real
+    ``$HOME`` leaks into the suppression record's ``realpath`` and the
+    fixture's ``expected_explain`` becomes host-dependent — exactly the
+    portability gap the README warns about.
+    """
+    bucket_key = "roles" if role_kind == "org" else "worker_roles"
+    role_def = (schema.get(bucket_key) or {}).get(role)
+    if not isinstance(role_def, dict):
+        return False
+    sandbox = role_def.get("sandbox")
+    if not isinstance(sandbox, dict):
+        return False
+    fs = sandbox.get("filesystem")
+    if not isinstance(fs, dict):
+        return False
+    for layer_key in ("denyRead", "denyWrite"):
+        for entry in fs.get(layer_key) or []:
+            if isinstance(entry, dict) and entry.get("anchor") == "home":
+                return True
+    return False
+
+
+def _resolve_fixture_schema(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Resolve which schema dict to feed the renderer for this fixture.
+
+    Two forms are supported:
+
+    - ``inputs.schema_fragment``: an inline mini-schema (the legacy form,
+      useful for tightly-scoped evaluator coverage that is independent of
+      the current shipped contents of ``tools/org_extension_schema.json``).
+    - ``inputs.schema_source = "shipped"``: load the in-tree
+      ``tools/org_extension_schema.json`` and feed it to the renderer.
+      This is what the Phase 1 PR3 ``role_secretary`` / ``role_dispatcher``
+      / ``role_curator`` fixtures use to verify the *actual* concrete
+      sandbox bodies as shipped — without it the fixtures would only
+      exercise hand-rolled mini-schemas and could silently drift from the
+      body operators see.
+
+    Exactly one of the two must be set; passing both is rejected to keep
+    the fixture's intent unambiguous.
+    """
+    has_fragment = "schema_fragment" in inputs
+    source = inputs.get("schema_source")
+    if has_fragment and source is not None:
+        raise ValueError(
+            "fixture must set exactly one of inputs.schema_fragment or "
+            "inputs.schema_source, not both"
+        )
+    if source is not None:
+        if source != "shipped":
+            raise ValueError(
+                f"unknown schema_source: {source!r}; "
+                "only 'shipped' is currently supported"
+            )
+        return json.loads(JA_SCHEMA.read_text(encoding="utf-8"))
+    if not has_fragment:
+        raise ValueError(
+            "fixture must set inputs.schema_fragment (inline) "
+            "or inputs.schema_source = 'shipped' (read "
+            "tools/org_extension_schema.json)"
+        )
+    return inputs["schema_fragment"]
+
+
+def _render_fixture_result(fixture: dict[str, Any]) -> Any:
+    """Render one fixture and return the full ``RenderResult``.
+
+    Imports the runtime lazily so a missing install surfaces the same
+    way the byte check does.
+
+    Fixtures that exercise ``anchor: home`` entries set ``inputs.home_dir``
+    to a stable path. The runtime's ``_anchor_base_path`` resolves the
+    home anchor via ``os.path.expanduser('~')`` which reads ``$HOME`` on
+    POSIX (and ``$USERPROFILE`` on Windows), so we temporarily swap those
+    env vars for the duration of the render and restore them afterwards.
+    Without this hook the home-anchored realpath would be host-dependent
+    and ``expected_explain`` could not be byte-compared across machines —
+    the original fixture set sidestepped this by avoiding ``anchor: home``
+    altogether (see fixture-dir README), but the Phase 1 PR3 ``role_*``
+    fixtures must verify the shipped credential entries which use
+    ``anchor: home``.
+    """
+    from claude_org_runtime.settings.generator import (  # noqa: PLC0415
+        render_role_with_metadata,
+    )
+
+    inputs = fixture["inputs"]
+    realpath_fn = _build_realpath_fn(inputs.get("realpath_map", []))
+    wsl_detected = bool(inputs.get("wsl_detected", False))
+    schema = _resolve_fixture_schema(inputs)
+    home_dir = inputs.get("home_dir")
+    if home_dir is None and _schema_role_uses_home_anchor(
+        schema, inputs.get("role_kind", "worker"), inputs["role"]
+    ):
+        raise ValueError(
+            f"fixture for role {inputs['role']!r} (role_kind="
+            f"{inputs.get('role_kind', 'worker')!r}) must set "
+            "inputs.home_dir because the role's sandbox body declares "
+            "at least one deny entry with anchor='home' — without the "
+            "swap the host's $HOME would leak into the suppression "
+            "record realpath and expected_explain would not be portable."
+        )
+
+    def _do_render() -> Any:
+        return render_role_with_metadata(
+            schema,
+            role=inputs["role"],
+            worker_dir=inputs["worker_dir"],
+            claude_org_path=inputs["claude_org_path"],
+            role_kind=inputs.get("role_kind", "worker"),
+            base_clone=inputs.get("base_clone"),
+            task_id=inputs.get("task_id"),
+            branch_ref=inputs.get("branch_ref"),
+            pattern=inputs.get("pattern"),
+            realpath_fn=realpath_fn,
+            wsl_detector=lambda: wsl_detected,
+        )
+
+    if home_dir is None:
+        return _do_render()
+    if not isinstance(home_dir, str):
+        raise ValueError(
+            f"inputs.home_dir must be a string, got {type(home_dir).__name__}"
+        )
+    # Swap HOME and USERPROFILE so os.path.expanduser('~') is
+    # deterministic. Restore-on-finally is mandatory: a stray
+    # exception leaving HOME pointed at the fixture's fake path
+    # would make every subsequent test render diverge.
+    _swap_keys = ("HOME", "USERPROFILE")
+    original = {k: os.environ.get(k) for k in _swap_keys}
+    for k in _swap_keys:
+        os.environ[k] = home_dir
+    try:
+        return _do_render()
+    finally:
+        for k, v in original.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _render_fixture_explain(fixture: dict[str, Any]) -> dict[str, Any]:
+    """Render one fixture and return the canonical explain JSON."""
+    return _render_fixture_result(fixture).sandbox.to_jsonable()
+
+
+def _render_fixture_rendered_sandbox(fixture: dict[str, Any]) -> Any:
+    """Render one fixture and return the rendered ``sandbox`` dict.
+
+    The explain JSON only describes *suppressed* deny entries; the
+    *kept* deny entries (and the rest of the sandbox body) live on
+    ``result.settings.sandbox``. Without comparing the rendered body
+    a regression that drops e.g. ``denyWrite: tools`` from the
+    dispatcher would not be detected by ``expected_explain`` alone.
+    Fixtures that want kept-entry coverage set ``expected_rendered_sandbox``.
+    """
+    return _render_fixture_result(fixture).settings.get("sandbox")
+
+
+def _format_explain_diff(
+    fixture_path: Path,
+    expected: dict[str, Any],
+    actual: dict[str, Any],
+) -> str:
+    expected_text = json.dumps(expected, indent=2, sort_keys=True).splitlines(
+        keepends=True
+    )
+    actual_text = json.dumps(actual, indent=2, sort_keys=True).splitlines(
+        keepends=True
+    )
+    diff = difflib.unified_diff(
+        expected_text,
+        actual_text,
+        fromfile=f"expected ({fixture_path.name})",
+        tofile=f"actual ({fixture_path.name})",
+    )
+    return "".join(diff)
+
+
+def _check_byte_drift(installed_str: str) -> int:
     bundled_path = _bundled_schema_path()
     if not bundled_path.is_file():
         print(
@@ -141,7 +402,9 @@ def main(argv: list[str] | None = None) -> int:
     bundled = json.loads(bundled_path.read_text(encoding="utf-8"))
     ja = json.loads(JA_SCHEMA.read_text(encoding="utf-8"))
 
-    if _normalise(bundled) == _normalise(ja):
+    bundled_norm = _normalise(_strip_ja_only_sandbox_bodies(bundled))
+    ja_norm = _normalise(_strip_ja_only_sandbox_bodies(ja))
+    if bundled_norm == ja_norm:
         print(
             f"check_runtime_schema_drift: OK (claude-org-runtime "
             f"{installed_str} bundled schema matches {JA_SCHEMA.name})"
@@ -161,6 +424,217 @@ def main(argv: list[str] | None = None) -> int:
         file=sys.stderr,
     )
     return 1
+
+
+_FIXTURE_OUT_OF_SCOPE_FIELDS = ("verification_depth",)
+
+
+def _find_forbidden_keys(
+    obj: Any, forbidden: tuple[str, ...]
+) -> list[tuple[str, str]]:
+    """Walk ``obj`` and return ``(json_pointer, key)`` for every
+    forbidden key found at any depth.
+
+    Recurses through dicts and lists; ignores everything else. The
+    ``json_pointer`` is a slash-joined path so violations point at
+    the offending location even when the forbidden key is nested
+    inside ``inputs.schema_fragment.worker_roles.<role>.…``.
+    """
+    hits: list[tuple[str, str]] = []
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                child_path = f"{path}/{key}" if path else key
+                if key in forbidden:
+                    hits.append((child_path, key))
+                _walk(value, child_path)
+        elif isinstance(node, list):
+            for idx, value in enumerate(node):
+                _walk(value, f"{path}/{idx}")
+
+    _walk(obj, "")
+    return hits
+
+
+def _validate_fixture_policy(
+    fixture_path: Path, fixture: dict[str, Any]
+) -> list[str]:
+    """Return a list of policy violations for one fixture.
+
+    Currently enforces only that the out-of-scope fields listed in
+    ``_FIXTURE_OUT_OF_SCOPE_FIELDS`` (notably ``verification_depth``,
+    which is a delegate-payload convention rather than a sandbox
+    enforcement dimension) do not appear *anywhere* in the fixture —
+    not just at the top level of ``inputs`` / ``expected_explain``,
+    but also nested inside ``schema_fragment``. A shallow check would
+    let a fixture sneak ``verification_depth`` into the schema body
+    and silently establish a precedent the rest of the codebase has
+    to maintain. Mirrors the policy check in
+    ``tests/test_runtime_schema_drift_semantic.py`` so the manual CLI
+    run gives the same answer as the unittest suite.
+    """
+    violations: list[str] = []
+    hits = _find_forbidden_keys(fixture, _FIXTURE_OUT_OF_SCOPE_FIELDS)
+    for path, key in hits:
+        violations.append(
+            f"{fixture_path.name}: {key!r} must not appear in fixture "
+            f"(found at {path!r}; out-of-scope for sandbox semantic "
+            "contract; see fixture-dir README)."
+        )
+    return violations
+
+
+def _check_semantic_drift(installed_str: str) -> int:
+    if not SEMANTIC_FIXTURE_DIR.is_dir():
+        print(
+            f"check_runtime_schema_drift: semantic fixture dir not found at "
+            f"{SEMANTIC_FIXTURE_DIR}",
+            file=sys.stderr,
+        )
+        return 1
+    fixture_paths = sorted(SEMANTIC_FIXTURE_DIR.glob("*.json"))
+    if not fixture_paths:
+        print(
+            f"check_runtime_schema_drift: no semantic fixtures found in "
+            f"{SEMANTIC_FIXTURE_DIR}",
+            file=sys.stderr,
+        )
+        return 1
+    drift_seen = False
+    policy_violations: list[str] = []
+    for fixture_path in fixture_paths:
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        policy_violations.extend(_validate_fixture_policy(fixture_path, fixture))
+        # Render once; both checks read from the same RenderResult so a
+        # transient env-var swap (home_dir) doesn't have to happen twice.
+        result = _render_fixture_result(fixture)
+        expected = fixture["expected_explain"]
+        actual = result.sandbox.to_jsonable()
+        if expected != actual:
+            drift_seen = True
+            print(
+                "check_runtime_schema_drift: SEMANTIC DRIFT — "
+                f"{fixture_path.relative_to(REPO_ROOT)} explain JSON differs "
+                f"from claude-org-runtime {installed_str} render output.",
+                file=sys.stderr,
+            )
+            diff = _format_explain_diff(fixture_path, expected, actual)
+            if diff:
+                print(diff, file=sys.stderr)
+        if "expected_rendered_sandbox" in fixture:
+            expected_sandbox = fixture["expected_rendered_sandbox"]
+            actual_sandbox = result.settings.get("sandbox")
+            if expected_sandbox != actual_sandbox:
+                drift_seen = True
+                print(
+                    "check_runtime_schema_drift: SEMANTIC DRIFT — "
+                    f"{fixture_path.relative_to(REPO_ROOT)} rendered sandbox "
+                    f"body differs from claude-org-runtime {installed_str} "
+                    "output (kept deny entries / additionalDirectories).",
+                    file=sys.stderr,
+                )
+                diff = _format_explain_diff(
+                    fixture_path, expected_sandbox, actual_sandbox
+                )
+                if diff:
+                    print(diff, file=sys.stderr)
+    if policy_violations:
+        for v in policy_violations:
+            print(
+                f"check_runtime_schema_drift: FIXTURE POLICY — {v}",
+                file=sys.stderr,
+            )
+    if drift_seen:
+        print(
+            "  Update the affected fixture(s) under "
+            f"{SEMANTIC_FIXTURE_DIR.relative_to(REPO_ROOT)}/ if the runtime "
+            "behaviour change is intended, or fix the runtime if it is not.",
+            file=sys.stderr,
+        )
+        return 1
+    if policy_violations:
+        return 1
+    print(
+        f"check_runtime_schema_drift: semantic OK (claude-org-runtime "
+        f"{installed_str}, {len(fixture_paths)} fixture(s))"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Drift check between ja's tools/org_extension_schema.json and "
+            "the bundled claude-org-runtime schema. With no flags runs the "
+            "byte-identical check; --semantic switches to the render-output "
+            "golden diff against fixture explain JSON; pass --byte "
+            "--semantic together to run both."
+        ),
+    )
+    parser.add_argument(
+        "--semantic",
+        action="store_true",
+        help=(
+            "Run the semantic golden drift check against fixtures under "
+            "tests/fixtures/runtime_schema_drift/sandbox_intent/. "
+            "Without --byte this replaces the byte check; combine with "
+            "--byte to run both."
+        ),
+    )
+    parser.add_argument(
+        "--byte",
+        action="store_true",
+        help=(
+            "Run the byte-identical schema check (the default when no "
+            "flags are passed). Combine with --semantic to run both."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    run_byte = args.byte or not args.semantic
+    run_semantic = args.semantic
+
+    try:
+        installed_str = _pkg_version("claude-org-runtime")
+    except PackageNotFoundError:
+        print(
+            "check_runtime_schema_drift: claude-org-runtime is not installed; "
+            "run `pip install -e .` first.",
+            file=sys.stderr,
+        )
+        return 1
+    installed = _parse_version(installed_str)
+    in_window = _runtime_in_pin_window(installed)
+
+    rc = 0
+    if run_byte:
+        # Byte check honours the pin window: a runtime preview release
+        # is allowed to ship a schema ahead of ja's pin, so a hard
+        # failure here would just block unrelated PRs. Skip with a
+        # warning when out-of-window.
+        if not in_window:
+            print(
+                f"check_runtime_schema_drift: WARN — installed "
+                f"claude-org-runtime {installed_str} is outside ja's pin "
+                f"window "
+                f">={'.'.join(map(str, RUNTIME_PIN_LOWER_INCLUSIVE))},"
+                f"<{'.'.join(map(str, RUNTIME_PIN_UPPER_EXCLUSIVE[:2]))}; "
+                "skipping byte drift check (runtime is allowed to ship a "
+                "new minor before ja widens the pin)."
+            )
+        else:
+            rc = _check_byte_drift(installed_str) or rc
+    if run_semantic:
+        # Semantic check runs unconditionally when explicitly
+        # requested. Operators invoking `--semantic` against a
+        # 0.2-preview runtime want exactly this answer ("does the
+        # explain JSON still match my goldens against the new
+        # evaluator?"), and silently skipping would defeat the point
+        # of the flag. The matching pytest test is the same shape:
+        # it always runs against whatever runtime is importable.
+        rc = _check_semantic_drift(installed_str) or rc
+    return rc
 
 
 if __name__ == "__main__":

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Source of truth for per-role settings.local.json shape. Both tools/check_role_configs.py and docs/skills/org-setup/references/permissions.md project from this schema. See Issue #85.",
+  "$comment": "Source of truth for per-role settings.local.json shape (Layer 2 audit constraints in `roles[*]`, concrete worker templates in `worker_roles[*]`, Phase 1 PR3 also Layer 3 sandbox bodies in `roles.{secretary,dispatcher,curator}.sandbox`). Consumers: tools/check_role_configs.py validates emitted `.claude/settings.local.json` files against `roles[*]` audit constraints; docs/skills/org-setup/references/permissions.md projects the per-role shape; tools/check_runtime_schema_drift.py byte-compares this file against the schema bundled with `claude-org-runtime` (skipped outside the pin window) and `--semantic` runs the semantic golden drift check against tests/fixtures/runtime_schema_drift/sandbox_intent/ — which now includes role_secretary.json / role_dispatcher.json / role_curator.json fixtures that load this file via `schema_source: \"shipped\"`. See Issue #85 for the original schema-as-SoT decision and Refs claude-org-ja#378 #376 for the Phase 1 sandbox surface.",
   "version": 1,
   "global": {
     "forbidden_allow_exact": [
@@ -26,6 +26,7 @@
     "check-worker-boundary.sh",
     "block-dispatcher-out-of-scope.sh"
   ],
+  "$comment_roles_sandbox": "Phase 1 schema surface: each entry under `roles.<role>` may also include an optional `sandbox` object using the same shape and structured-anchor entry form documented under `worker_roles.$comment_sandbox` / `worker_roles.$comment_sandbox_anchor`. This lets secretary / dispatcher / curator declare Layer 3 sandbox intent alongside the existing Layer 2 `required_allow` / `required_deny` audit constraints. Roles without `sandbox` are treated as sandbox-disabled (backward compatible). Phase 1 PR3 (Refs claude-org-ja#378 #376) lands concrete bodies for `roles.secretary` / `roles.dispatcher` / `roles.curator`; each role's per-`sandbox` `$comment_sandbox` field documents the contract sections it is driven from and which prescriptions are deferred (e.g. curator knowledge/raw move-only is operation-semantic and not mechanizable here). `worker_roles.*` concrete bodies are NOT landed in PR3 — they need a `sandbox_by_pattern` schema decision (deferred to PR4). See `docs/contracts/role-pattern-sandbox-contract.md` for the contract that all bodies must satisfy.",
   "roles": {
     "repo_shared": {
       "description": "Repo-shared settings (.claude/settings.json) — tracked in git; hosts repo-wide safety hooks (block-no-verify, block-dangerous-git).",
@@ -85,6 +86,7 @@
     "secretary": {
       "description": "Secretary (窓口) — repo .claude/settings.local.json.",
       "docs_section": "窓口",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the secretary role. Read scope = secretary's worker_dir (= live repo at claude_org_path) plus the workers_dir at <claude_org_path>/../workers (per docs/contracts/role-pattern-sandbox-contract.md §3.1.1 prescribed read surface). Layer 3 denyRead covers credential paths named in §3.1.1 — worker_dir-anchored .env / .env.* / **/credentials* / **/*.pem, plus home-anchored ~/.config/gh/hosts.yml / ~/.aws/** / ~/.ssh/** with §1.3 adaptive suppression. The home-anchored entries carry a `layer2Fallback` string each; per worker_roles.$comment_sandbox_anchor that string is intended as the Layer-2 permissions.deny mirror emitted when the Layer-3 entry is suppressed (e.g. on WSL). NOTE: claude-org-runtime up to and including the version pinned in pyproject.toml does NOT yet auto-mirror `layer2Fallback` into permissions.deny — the schema declares the intent but the runtime evaluator only preserves the field on the suppression record's entry. So today these strings are forward-looking documentation; effective Layer 2 deny for credentials still needs to be declared via roles.secretary.required_deny. Settings.local.json paths under workers/ are NOT mirrored here — the existing roles.secretary.required_deny rules enforce those at Layer 2 (Edit/Write tool path) and Layer 3 cannot reach the worker dirs anyway. Knowledge/raw and curated/ scrub policies remain convention-only per knowledge-curation-contract.md and are NOT mechanized here. ~/.claude/plans/ from §3.1.1 read surface is NOT in additionalDirectories because the substitution mapping has no {home} placeholder (only worker_dir / claude_org_path / Pattern B context); a runtime-side substitution extension is the natural fix and is tracked as a follow-up.",
       "settings_paths": [".claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -146,7 +148,9 @@
         "Write(*/workers/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.claude/settings.local.json)",
         "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
+        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+        "Write(*/.worktrees/*/.claude/settings.local.json)",
+        "Edit(*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [
         {
@@ -158,11 +162,65 @@
       "disallow_allow_regex": [
         "^Bash\\(\\*\\)$",
         "^Bash$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}/../workers"
+          ],
+          "denyRead": [
+            {
+              "anchor": "worker_dir",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/credentials*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/*.pem)"
+            },
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.aws/*)"
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.ssh/*)"
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "dispatcher": {
       "description": "Dispatcher — .dispatcher/.claude/settings.local.json. Runs in bypassPermissions mode (Sonnet constraint), so permissions.allow / deny are no-ops; PreToolUse hooks are the only enforcement layer.",
       "docs_section": "ディスパッチャー",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the dispatcher role. Layer 3 is the primary enforcement vector here because permission_mode=bypassPermissions makes Layer 2 a no-op (docs/contracts/role-pattern-sandbox-contract.md §3.2 line 270-272 / §3.2.3 line 325). Therefore the structured-anchor entries deliberately omit `layer2Fallback` (Major 1 from the Codex pre-design review): a Layer 2 mirror would be discarded under bypassPermissions and giving operators the impression that a fallback is in place would mis-state the protection level. Read scope = worker_dir (.dispatcher/) + claude_org_path (broad, per §3.2.1 read surface enumeration: .state/, knowledge/raw/, registry/, tools/). denyRead covers credential paths (home-anchored ~/.aws/** / ~/.ssh/** / ~/.config/gh/hosts.yml plus claude_org_path-anchored .env / .env.* / **/credentials* / **/*.pem) so Bash-mediated reads via cat/head/etc. are caught at the syscall layer. denyWrite covers paths the dispatcher must NOT modify (tools/ dashboard/ tests/ .claude/skills/ docs/ registry/ — derived from §3.2.2 Denied writes) so Bash redirect (echo > tools/foo) is caught at Layer 3 — closing the §3.2.4 carve-out where .hooks/block-dispatcher-out-of-scope.sh only matches Edit/Write. workers_dir is intentionally NOT in denyWrite at Layer 3: it falls outside read_roots so a denyWrite entry would be suppressed; that surface is protected at Layer 4 by .hooks/block-dispatcher-out-of-scope.sh + .hooks/block-workers-delete.sh. Residual risk: if the sandbox is unavailable (failIfUnavailable=false fall-open), Layer 2 is no-op AND Layer 3 is absent, leaving only Layer 4 hooks for credentials / Bash-redirect — see PR body for the deferred follow-up.",
       "settings_paths": [".dispatcher/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -202,11 +260,90 @@
         "^Bash\\(\\*\\)$",
         "^Bash$",
         "^Bash\\(git \\*\\)$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}"
+          ],
+          "denyRead": [
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true
+            }
+          ],
+          "denyWrite": [
+            {
+              "anchor": "claude_org_path",
+              "path": "tools",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "dashboard",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "tests",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".claude/skills",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "docs",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "registry",
+              "suppressOnSymlinkEscape": true
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "curator": {
       "description": "Curator — .curator/.claude/settings.local.json (narrow / empty by design).",
       "docs_section": "キュレーター",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the curator role. Read scope = worker_dir (.curator/) + {claude_org_path}/knowledge — narrow per docs/contracts/role-pattern-sandbox-contract.md §3.3.1 (curator reads knowledge/raw/, knowledge/curated/, knowledge/skill-candidates.md only) and §3.3.3 Phase 1 prescription (additionalDirectories = [knowledge, .curator]). denyRead covers credential paths (worker_dir-anchored .env / .env.* / **/credentials* / **/*.pem, plus home-anchored ~/.config/gh/hosts.yml / ~/.aws/** / ~/.ssh/** with §1.3 adaptive suppression). The credential entries carry a `layer2Fallback` string each, intended as the Layer-2 permissions.deny mirror per worker_roles.$comment_sandbox_anchor — same forward-looking caveat as roles.secretary: claude-org-runtime up to and including the version pinned in pyproject.toml does NOT yet auto-mirror `layer2Fallback`, so today these strings are documentation. denyWrite enumerates the org-internal paths the curator must NOT modify (.state/ registry/ tools/ dashboard/ .claude/skills/ workers_dir/**, from §3.3.2 / §3.3.3 prescription). With the narrow read scope these denyWrite entries fall outside read_roots and are SUPPRESSED at Layer 3 — by design: the entries document intent and would activate if read scope were ever widened, while at runtime the same paths are protected by absence-of-mount (a path that is not in the bwrap mount namespace cannot be written to from inside the sandbox). Major 2 from the Codex pre-design review: knowledge/raw/ deletion-vs-move discipline is operation-semantic (rm vs mv), NOT path-based — Layer 3 cannot express 'move-only' via path globs (denyWrite knowledge/raw/** would break legitimate move-to-archive; allow knowledge/raw/** would not stop rm). That row is therefore deferred as a Bash-matcher hook follow-up and is intentionally NOT mechanized in this body.",
       "settings_paths": [".curator/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [],
@@ -218,7 +355,92 @@
         "^Bash$",
         "^Bash\\(git .*\\)$",
         "^Bash\\(git:\\*\\)$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}/knowledge"
+          ],
+          "denyRead": [
+            {
+              "anchor": "worker_dir",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/credentials*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/*.pem)"
+            },
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.aws/*)"
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.ssh/*)"
+            }
+          ],
+          "denyWrite": [
+            {
+              "anchor": "claude_org_path",
+              "path": ".state",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "registry",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "tools",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "dashboard",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".claude/skills",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "absolute",
+              "path": "{claude_org_path}/../workers/**",
+              "suppressOnSymlinkEscape": true
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "worker": {
       "description": "Worker (dynamic template, audit constraints) — <worker_dir>/.claude/settings.local.json. See also top-level worker_roles section for the concrete templates that generate_worker_settings.py emits.",
@@ -275,7 +497,9 @@
     }
   },
   "worker_roles": {
-    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time.",
+    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time; Pattern B context placeholders are documented under `$comment_sandbox_anchor`.",
+    "$comment_sandbox": "Phase 1 schema surface: each `worker_roles.<role>` may include an optional `sandbox` object of the form {enabled: bool, filesystem: {denyRead: [entry], denyWrite: [entry], additionalDirectories: [string]}, failIfUnavailable: bool, default false}. The sandbox object is forwarded as-is to the rendered settings.local.json (consumed by claude-org-ja's bwrap launcher). At render time the generator applies Layer 3 suppression: each filesystem.denyRead / denyWrite entry whose realpath escapes the sandbox read roots (worker_dir + additionalDirectories) is dropped from the rendered sandbox object because the sandbox cannot reach the path anyway. This is common on WSL (where /home/<user>/... may be a /mnt/c/... symlink) and devcontainers (/workspaces symlinks). Layer 2 `permissions.deny` `Read(...)` / `Write(...)` entries are NEVER suppressed. Suppression metadata is exposed via `claude-org-runtime settings show --explain`. Roles without `sandbox` are treated as sandbox-disabled (backward compatible).",
+    "$comment_sandbox_anchor": "Phase 1 schema surface: `denyRead` / `denyWrite` entries may now be either (a) a legacy raw string (anchored at worker_dir for relative paths, treated literally for absolute paths) or (b) a structured object {anchor: 'home'|'worker_dir'|'claude_org_path'|'base_clone'|'absolute', path: string, suppressOnSymlinkEscape: bool default true, layer2Fallback: optional Layer-2 permissions.deny mirror entry}. The structured form fixes the legacy ambiguity where '~/.aws/**'-style entries were misjudged as worker_dir-relative. 'home' resolves to the current user's home directory, 'absolute' is treated literally, 'worker_dir' / 'claude_org_path' / 'base_clone' use the corresponding generator-context substitutions. When `suppressOnSymlinkEscape` is false the entry is preserved even if its realpath escapes the sandbox read roots (useful for entries the operator wants in the rendered output regardless of reachability). When `layer2Fallback` is set, the value is the Layer-2 `permissions.deny` mirror string INTENDED to be emitted whenever the Layer-3 entry is suppressed; the field is forward-looking — `claude-org-runtime` versions up to and including the one pinned by `tools/check_runtime_schema_drift.py` do NOT auto-mirror it into `permissions.deny`, the runtime evaluator only preserves the field on the suppression record's `entry`. Effective Layer 2 deny for credentials therefore still has to be declared via `roles.<role>.required_deny` / `worker_roles.<role>.permissions.deny` directly, not relied on via `layer2Fallback` alone. Pattern B context placeholders ({base_clone}, {task_id}, {branch_ref}, {pattern}) are recognized substitution variables in addition to the legacy {worker_dir} / {claude_org_path}; they are substituted in entry.path and additionalDirectories before realpath evaluation when supplied via the generator API. Backward compat: legacy raw-string entries continue to parse via the runtime adapter and need not be migrated when this schema surface is adopted.",
     "default": {
       "description": "Standard worker template — git read/write within the worktree, no push, no recursive delete. Mirrors the historical org-delegate Step 3 inline JSON.",
       "permissions": {
@@ -296,7 +520,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {
@@ -354,7 +583,12 @@
           "Bash(git push *)",
           "Bash(git push)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)"
         ]
       },
       "hooks": {


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#411](https://github.com/suisya-systems/claude-org-ja/pull/411)

Merge SHA: `cc0a51dcd881c3687fcfae9171f52a13aca4b74f`

Source: ja PR [#411](https://github.com/suisya-systems/claude-org-ja/pull/411)
Merge SHA: `cc0a51dcd881c3687fcfae9171f52a13aca4b74f`

| class | count |
|---|---|
| runtime | 7 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (7)</summary>

- `tests/fixtures/runtime_schema_drift/sandbox_intent/README.md`
- `tests/fixtures/runtime_schema_drift/sandbox_intent/role_curator.json`
- `tests/fixtures/runtime_schema_drift/sandbox_intent/role_dispatcher.json`
- `tests/fixtures/runtime_schema_drift/sandbox_intent/role_secretary.json`
- `tests/test_runtime_schema_drift_semantic.py`
- `tools/check_runtime_schema_drift.py`
- `tools/org_extension_schema.json`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
