### PR TITLE
auto-mirror: ja#418 fix(claude): pr_watch ci_completed only on final verdict + bounded retry + test isolation (Closes #413)

### DIFF
--- a/tools/pr-watch.ps1
+++ b/tools/pr-watch.ps1
@@ -29,21 +29,27 @@ $ScriptPath = Join-Path $ScriptDir 'pr_watch.py'
 # but invoking it fails with "Unable to create process". Verifying with a
 # real exec lets us fall through to plain `python` / `python3` in that case.
 #
-# Issue #224: `--version` passing is necessary but not sufficient — pr_watch.py
-# does `from core_harness.audit import Journal`, so a Python whose
-# site-packages lacks core_harness will exit 1 with a confusing ImportError
-# at runtime. Probe the import too so we fall through to a sibling
-# interpreter that *does* have core_harness installed.
+# Issue #224 / pr-watch-race-fix: `--version` passing is necessary but
+# not sufficient — pr_watch.py uses the local `tools.state_db` package
+# which depends on the stdlib `sqlite3` module (and on Python 3, where
+# the f-strings in pr_watch.py parse). The earlier probe required
+# `core_harness.audit`, but that dependency was retired when M4 cut
+# pr_watch over to the SQLite events table; leaving the stale import
+# in the probe would unnecessarily reject a working interpreter and
+# fall through to "no working Python interpreter found". Probe
+# `sqlite3` instead — it's the actual external dependency now and is
+# part of the stdlib, so a stripped Python build (the only realistic
+# failure mode) is correctly rejected.
 function Test-Interpreter {
     param([string]$Exe, [string[]]$Prefix)
     if (-not (Get-Command $Exe -ErrorAction SilentlyContinue)) { return $false }
     try {
         $null = & $Exe @Prefix '--version' 2>&1
         if ($LASTEXITCODE -ne 0) { return $false }
-        # Combined probe: require Python 3 AND core_harness.audit importable.
+        # Combined probe: require Python 3 AND stdlib sqlite3 importable.
         # Bare `python`/`python3` on some systems still aliases to Python 2,
         # which would pass `--version` but die on pr_watch.py's f-strings.
-        $probe = 'import sys; assert sys.version_info[0] == 3; import core_harness.audit'
+        $probe = 'import sys; assert sys.version_info[0] == 3; import sqlite3'
         $null = & $Exe @Prefix '-c' $probe 2>&1
         return ($LASTEXITCODE -eq 0)
     } catch {
@@ -68,7 +74,7 @@ foreach ($cand in $candidates) {
 }
 
 if (-not $pyExec) {
-    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python interpreter found with core_harness.audit installed (tried py -3, python, python3).')
+    [Console]::Error.WriteLine('tools/pr-watch.ps1: no working Python 3 interpreter found with stdlib sqlite3 (tried py -3, python, python3).')
     exit 127
 }
 

--- a/tools/pr_watch.py
+++ b/tools/pr_watch.py
@@ -30,7 +30,15 @@ Behavior:
   ``<repo_root>/.state/state.db`` (anchored to ``tools/..`` so cwd
   doesn't matter).
 * Prints the final status as a single line on stdout and exits with
-  the gh process' exit code.
+  a deterministic exit code derived from the *resolved* status
+  (Issue #413 / Codex round-1 Major): ``passed``→0, ``failed``→1,
+  ``canceled``→2, ``incomplete``→8. The original ``gh`` exit code
+  is intentionally NOT propagated, because the resolver may upgrade
+  ``gh exit 8`` ("Checks pending") to a final ``passed`` verdict
+  via retry — returning 8 in that case would mislead shell callers
+  inspecting ``$?``. The post-CI merge-watch helper may further
+  override 0 → 9 on its own failure modes (timeout / no_run /
+  helper exception).
 
 M4 (Issue #267): events flow through the SQLite DB only —
 ``.state/journal.jsonl`` is decommissioned. The recorder uses the same
@@ -61,16 +69,31 @@ from pathlib import Path
 # secretary can intervene manually past that.
 MERGE_WATCH_MAX_SECONDS = 24 * 60 * 60
 
+# Issue #413: post-watch verdict-resolution retry. `gh pr checks --watch`
+# can return immediately on a freshly-created PR (before any check-run
+# row has propagated through GitHub's API), in which case the JSON
+# probe sees `[]` and the legacy code wrote a final
+# `ci_completed(status=incomplete)` event with `duration_sec=1`. The
+# retry loop absorbs `[]` / `pending` / `gh exit 8` as "still
+# observing" until either a final verdict (`passed` / `failed`)
+# appears or the budget is exhausted (in which case we record a final
+# `incomplete` once, capturing the elapsed time honestly).
+RETRY_BUDGET_SEC = 60
+RETRY_INTERVAL_SEC = 5
+
 # Make `tools.state_db.*` importable when running this script directly.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from tools.state_db.discover import resolve_state_db_path  # noqa: E402
+
 # Path used by tests via mock.patch — kept as a module-level Path so the
 # legacy test seam (`mock.patch.object(pr_watch, "JOURNAL_PATH", ...)`)
-# continues to redirect writes at the tempdir. M4 made the file be the
-# state DB rather than journal.jsonl.
-JOURNAL_PATH = REPO_ROOT / ".state" / "state.db"
+# continues to redirect writes at the tempdir. Issue #398: resolved
+# via discovery so worktree-cwd invocations target the main checkout's
+# state.db, not the worktree's empty `.state/`.
+JOURNAL_PATH = resolve_state_db_path()
 
 # Issue #326: after writing a CI-completion / merge / timeout event,
 # also push a peer message to secretary so it doesn't have to poll the
@@ -100,6 +123,7 @@ def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
                          status: str, duration: int) -> None:
     """Append a ``ci_completed`` event to the DB events table."""
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path = Path(db_path)
@@ -109,6 +133,8 @@ def _record_ci_completed(*, db_path: Path, pr: int, repo: str,
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/pr_watch.py")
         writer = StateWriter(conn)
         writer.append_event(
             kind="ci_completed",
@@ -271,6 +297,102 @@ def _fetch_checks(pr: int, repo: str) -> "list[dict] | None":
     return [c for c in data if isinstance(c, dict)]
 
 
+def _resolve_final_status(
+    pr: int,
+    repo: str,
+    exit_code: int,
+    *,
+    budget_sec: "float | None" = None,
+    retry_interval_sec: "float | None" = None,
+) -> str:
+    """Drive `_fetch_checks` until a final CI verdict is observed.
+
+    Issue #413: ``gh pr checks --watch`` occasionally returns
+    immediately when invoked on a freshly created PR — before any
+    check-run row has propagated. The first :func:`_fetch_checks`
+    response is then ``[]`` (transient empty), and the legacy code
+    classified that as ``incomplete`` and wrote it as the *final*
+    ``ci_completed`` event with ``duration_sec=1`` (e.g. PRs #411 /
+    #14 / #15 / #416 in a single session).
+
+    Final-verdict semantics:
+
+    * ``passed`` / ``failed`` → return immediately (deterministic).
+    * ``incomplete`` (empty list, ``pending`` bucket, or
+      ``gh exit 8``) → enter a bounded retry loop. Each iteration
+      sleeps ``retry_interval_sec`` and re-queries.
+    * ``_fetch_checks`` returns ``None`` (probe was unparseable —
+      empty / malformed stdout, JSON parse error, unexpected
+      shape) → also retried within the same budget (Codex round-2
+      Major: a single transient probe failure used to bypass the
+      retry loop and short-circuit to ``_classify(exit_code)``,
+      reintroducing the Issue #413 race when it coincided with
+      ``gh exit 8``).
+    * Budget exhausted with at least one parseable response →
+      return the last observed ``incomplete`` verdict (recorded as
+      a single, honest final event whose ``duration_sec`` reflects
+      the full observation window).
+    * Budget exhausted with NO parseable response → fall back to
+      :func:`_classify` against ``exit_code`` so the recorded
+      status still reflects what gh believed about CI even when
+      the JSON probe never succeeded.
+
+    Time / sleep are referenced via the ``time`` module attribute
+    lookup so existing tests (``mock.patch.object(pr_watch.time,
+    "monotonic", ...)``) keep working.
+    """
+    if budget_sec is None:
+        budget_sec = RETRY_BUDGET_SEC
+    if retry_interval_sec is None:
+        retry_interval_sec = RETRY_INTERVAL_SEC
+
+    # Codex round-2 Major: a transient JSON parse failure (the
+    # subprocess succeeded but stdout was empty / malformed for a
+    # single observation) used to short-circuit the retry budget and
+    # return :func:`_classify`(exit_code) — which on `gh exit 8`
+    # would record `incomplete` immediately, re-introducing the
+    # Issue #413 race. Treat both ``None`` (unparseable probe) and
+    # ``incomplete`` (transient empty / pending) as retryable, and
+    # only fall back to the exit-code classifier if NO parseable
+    # response is observed within the budget.
+    last_verdict: "str | None" = None
+    deadline_set = False
+    deadline = 0.0
+
+    def _set_deadline_once() -> None:
+        nonlocal deadline_set, deadline
+        if not deadline_set:
+            deadline = time.monotonic() + budget_sec
+            deadline_set = True
+
+    while True:
+        checks = _fetch_checks(pr, repo)
+        if checks is not None:
+            verdict = _classify_from_checks(checks)
+            if verdict in ("passed", "failed"):
+                return verdict
+            last_verdict = verdict
+        # Either probe was unparseable (checks is None) or the verdict
+        # is `incomplete`. Initialise the budget on the first observed
+        # need to wait, then back off and try again.
+        _set_deadline_once()
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(retry_interval_sec)
+
+    if last_verdict is None:
+        # Never got a parseable probe response. Catastrophic-end:
+        # honour the exit-code fallback so the recorded status still
+        # reflects what gh believed the watched PR's CI was doing.
+        sys.stderr.write(
+            "tools/pr_watch.py: warning: could not query check results "
+            "via `gh pr checks --json` within the retry budget; falling "
+            "back to exit-code classification.\n"
+        )
+        return _classify(exit_code)
+    return last_verdict
+
+
 def _watch_for_merge(
     *,
     pr: int,
@@ -361,6 +483,7 @@ def _watch_for_merge(
 def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
     """Append a single event row via StateWriter (used for merge-watch timeout)."""
     from tools.state_db import apply_schema, connect
+    from tools.state_db.discover import verify_or_exit
     from tools.state_db.writer import StateWriter
 
     db_path = Path(db_path)
@@ -370,6 +493,8 @@ def _record_event(*, db_path: Path, kind: str, payload: dict) -> None:
     try:
         if is_new_db:
             apply_schema(conn)
+        else:
+            verify_or_exit(db_path, conn=conn, prog="tools/pr_watch.py")
         writer = StateWriter(conn)
         writer.append_event(kind=kind, actor="pr_watch", payload=payload)
         writer.commit()
@@ -482,7 +607,6 @@ def main(argv: "list[str] | None" = None) -> int:
         # so callers (and the journal status mapping) see a portable signal.
         exit_code = 2
         canceled = True
-    duration = int(round(time.monotonic() - started))
 
     # gh's documented cancellation exit code is 2 (parent SIGINT or
     # subprocess-side Ctrl-C). Honor it directly so we don't overwrite a
@@ -490,20 +614,36 @@ def main(argv: "list[str] | None" = None) -> int:
     if canceled or exit_code == 2:
         status = "canceled"
     else:
-        # Issue #224: gh exit 1 from a transient watch-loop error must not
-        # be conflated with "CI failed". Re-derive the status from the
-        # per-check JSON; only fall back to the exit code if the probe
-        # itself fails.
-        checks = _fetch_checks(args.pr, repo)
-        if checks is None:
-            sys.stderr.write(
-                "tools/pr_watch.py: warning: could not query check results "
-                "via `gh pr checks --json`; falling back to exit-code "
-                "classification.\n"
-            )
-            status = _classify(exit_code)
-        else:
-            status = _classify_from_checks(checks)
+        # Issue #224: gh exit 1 from a transient watch-loop error must
+        # not be conflated with "CI failed". Issue #413: a freshly
+        # created PR may have no check rows yet when --watch returns,
+        # so an empty / pending JSON response is "still observing"
+        # rather than the final verdict. Drive the resolver until it
+        # returns a final verdict (or exhausts its retry budget).
+        status = _resolve_final_status(args.pr, repo, exit_code)
+
+    # Issue #413: duration is measured from the start of the watch to
+    # the moment we have a final verdict (post-retry), so a
+    # transient-empty race no longer reports `1s`.
+    duration = int(round(time.monotonic() - started))
+
+    # Codex review (round 1, Major): once the resolver picks the final
+    # verdict, the script's exit code must reflect that verdict, not
+    # whatever gh returned from the initial `--watch` invocation. With
+    # the retry loop, gh can exit ``8`` ("Checks pending") on the first
+    # observation and then a later JSON probe surfaces the actual
+    # ``passed`` state — returning ``8`` to the caller would falsely
+    # signal "incomplete" to shell-script consumers checking `$?`. The
+    # mapping below mirrors :func:`_classify` (gh's documented codes:
+    # 0=passed, 2=canceled, 8=incomplete) and adds 1 for failed. The
+    # later merge-watch block can still override ``0`` → ``9`` when
+    # the post-CI loop itself fails.
+    exit_code = {
+        "passed": 0,
+        "failed": 1,
+        "canceled": 2,
+        "incomplete": 8,
+    }.get(status, exit_code)
 
     _record_ci_completed(
         db_path=JOURNAL_PATH,
@@ -515,7 +655,13 @@ def main(argv: "list[str] | None" = None) -> int:
 
     # Issue #326: nudge secretary as soon as the CI verdict is recorded
     # so it doesn't have to poll the DB. Best-effort — silent fallback
-    # in non-renga environments (RENGA_SOCKET unset).
+    # in non-renga environments (RENGA_SOCKET unset). Issue #413: the
+    # peer notification, like the DB event, fires once per pr_watch
+    # invocation and only on the final verdict (the retry loop above
+    # already absorbed transient incomplete observations). If a
+    # progress channel is ever wanted, route it through a distinct
+    # event/message name (e.g. `ci_progress`) rather than overloading
+    # `CI_COMPLETED`.
     _notify_peer(
         f"CI_COMPLETED: PR #{args.pr} {status} "
         f"(duration {duration}s, repo {repo})"
@@ -527,6 +673,11 @@ def main(argv: "list[str] | None" = None) -> int:
     # the caller explicitly opted in via --merge-watch. The default is
     # off so pr_watch stays a "CI passed → return" command compatible
     # with secretary's 2c/T6 review-feedback loop.
+    # Codex pre-design review (Minor 1): `run_complete_on_merge` is
+    # the downstream actor for the green-PR path and is invoked here
+    # only when `status == "passed"`. `incomplete` / `failed` /
+    # `canceled` results never trigger merge-watch, so callers can
+    # treat the `passed`-gated invocation as the contract.
     if status == "passed" and args.merge_watch and not args.no_merge_watch:
         merge_result = _watch_for_merge(
             pr=args.pr,

--- a/tools/test_pr_watch.py
+++ b/tools/test_pr_watch.py
@@ -22,6 +22,45 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import pr_watch  # noqa: E402
 
 
+# Issue #398 / pr-watch-race-fix: tools/conftest.py auto-scrubs
+# ``RENGA_SOCKET`` when this suite runs under pytest. Direct
+# ``python tools/test_pr_watch.py`` / ``python -m unittest`` invocations
+# bypass conftest entirely, so we re-assert isolation at the unittest
+# layer too: setUpModule deletes the env var unconditionally so
+# ``tools.peer_notify.notify_peer`` short-circuits before reaching the
+# real ``renga mcp-peer`` subprocess. Without this guard,
+# ``test_watch_for_merge_timeout_records_event`` and similar tests that
+# invoke ``pr_watch.main`` / ``_watch_for_merge`` without an explicit
+# ``_notify_peer`` mock could leak fake CI / merge messages onto the
+# live peer channel (observed against PR #555 from a parallel worker).
+_RENGA_SOCKET_BEFORE: "str | None" = None
+
+
+def setUpModule() -> None:  # noqa: N802 (unittest hook)
+    global _RENGA_SOCKET_BEFORE
+    _RENGA_SOCKET_BEFORE = os.environ.pop("RENGA_SOCKET", None)
+
+
+def tearDownModule() -> None:  # noqa: N802 (unittest hook)
+    if _RENGA_SOCKET_BEFORE is not None:
+        os.environ["RENGA_SOCKET"] = _RENGA_SOCKET_BEFORE
+
+
+def _assert_peer_isolation() -> None:
+    """Defense-in-depth: reject the test if the runtime would spawn renga.
+
+    Even with ``RENGA_SOCKET`` cleared, a regression in
+    ``peer_notify.notify_peer`` that bypasses the env-guard could still
+    spawn a subprocess. Tests that exercise the unmocked ``_notify_peer``
+    path call this helper to fail fast instead of leaking.
+    """
+    assert "RENGA_SOCKET" not in os.environ, (
+        "test isolation breach: RENGA_SOCKET is set during a test that "
+        "does not mock _notify_peer; peer messages would leak onto the "
+        "live channel"
+    )
+
+
 def _read_ci_event(db_path: Path) -> dict:
     """Return the (single) ci_completed event from the DB as a payload dict
     flattened with the ``ts`` / ``event`` keys the tests expect."""
@@ -129,8 +168,63 @@ def _make_fake_run(
     return fake_run
 
 
+def _gh_exit_for_payload(payload):
+    """Mirror gh's exit-code protocol for `gh pr checks --json`.
+
+    ``1`` if any bucket is fail/cancel, ``8`` if any bucket is pending,
+    ``0`` otherwise. Used by the stateful stub below to keep retry-loop
+    fixtures aligned with real gh behavior.
+    """
+    for chk in payload or []:
+        b = (chk.get("bucket") or "").lower()
+        if b in ("fail", "cancel"):
+            return 1
+        if b == "pending":
+            return 8
+    return 0
+
+
+def _make_stateful_fake_run(
+    watch_exit: int,
+    checks_sequence: "list[list[dict]]",
+):
+    """Like :func:`_make_fake_run` but consumes one entry of
+    ``checks_sequence`` per ``gh pr checks --json`` call.
+
+    Designed for Issue #413 retry-loop regression fixtures: the first
+    fetch can return ``[]`` (transient empty) while a later fetch
+    returns the actual verdict. The last entry is reused if the
+    resolver fetches more than ``len(checks_sequence)`` times (a
+    convenient cap so callers don't have to over-pad the sequence).
+    """
+    idx = {"i": 0}
+
+    def fake_run(cmd, *args, **kwargs):
+        if "view" in cmd and "--json" in cmd and "number" in cmd:
+            return mock.Mock(returncode=0, stdout="{}", stderr="")
+        if "checks" in cmd and "--json" in cmd:
+            i = idx["i"]
+            if i < len(checks_sequence) - 1:
+                idx["i"] = i + 1
+            payload = checks_sequence[i] if i < len(checks_sequence) else checks_sequence[-1]
+            return mock.Mock(
+                returncode=_gh_exit_for_payload(payload),
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+        return mock.Mock(returncode=watch_exit)
+
+    return fake_run
+
+
 class ArgFormTests(unittest.TestCase):
     """Both `--pr <n>` and the legacy positional form must parse identically."""
+
+    def setUp(self) -> None:
+        # Belt-and-braces: the module-level setUp already cleared
+        # RENGA_SOCKET, but if a pytest plugin or an earlier test
+        # restored it we want to fail loudly rather than leak.
+        _assert_peer_isolation()
 
     def _run(self, argv: "list[str]") -> "tuple[int, dict]":
         fake_run = _make_fake_run(watch_exit=0)
@@ -138,6 +232,7 @@ class ArgFormTests(unittest.TestCase):
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
             with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
@@ -166,6 +261,9 @@ class ArgFormTests(unittest.TestCase):
 
 
 class JournalEmitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _assert_peer_isolation()
+
     def _run(
         self,
         tmp_journal: Path,
@@ -178,7 +276,10 @@ class JournalEmitTests(unittest.TestCase):
             checks_json=checks_json,
             checks_raises=checks_raises,
         )
+        # `_notify_peer` mocked at the seam so even a regression in
+        # peer_notify's env-guard cannot leak onto the live channel.
         with mock.patch.object(pr_watch, "JOURNAL_PATH", tmp_journal), \
+             mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
              mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
              mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
              mock.patch.object(pr_watch.time, "monotonic", side_effect=[100.0, 142.0]):
@@ -235,25 +336,172 @@ class JournalEmitTests(unittest.TestCase):
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "passed")
 
-    def test_pending_check_is_incomplete(self) -> None:
-        """A still-running check → status=incomplete (new in #224)."""
+    def test_pending_check_after_retry_exhaustion_is_incomplete(self) -> None:
+        """Issue #413: a still-running check now drives the retry
+        loop; only after the retry budget is exhausted do we record
+        a final ``incomplete`` event.
+
+        Pre-#413, this test asserted ``status=incomplete`` on the
+        first ``pending`` observation. That path is exactly the
+        race the fix addresses — a pending bucket must be retried,
+        not journaled immediately. We keep the bucket→status
+        coverage by exercising the exhaustion path here (the
+        per-bucket mapping itself is unit-tested in
+        :class:`ClassifyFromChecksTests`).
+        """
+        # Always-pending stub: every fetch returns the same payload.
+        fake_run = _make_fake_run(
+            watch_exit=8,  # gh exits 8 ("Checks pending") with this payload
+            checks_json=[
+                {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
+                {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
+            ],
+        )
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
-            self._run(
-                journal,
-                gh_exit=0,
-                checks_json=[
-                    {"name": "lint", "state": "COMPLETED", "bucket": "pass"},
-                    {"name": "deploy", "state": "IN_PROGRESS", "bucket": "pending"},
-                ],
-            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[100.0, 100.5, 9999.0, 9999.5]):
+                pr_watch.main([
+                    "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+                ])
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "incomplete")
 
-    def test_empty_checks_is_incomplete(self) -> None:
+    def test_transient_empty_then_passes_emits_one_final_event(self) -> None:
+        """Issue #413 regression-prevention fixture.
+
+        Repro: ``gh pr checks --watch`` returns immediately on a
+        freshly created PR (no check rows have propagated yet), so
+        the first ``gh pr checks --json`` call returns ``[]``. The
+        legacy code wrote ``ci_completed(status=incomplete,
+        duration_sec=1)`` as the FINAL event — observed in a single
+        session against PRs #411 / #14 / #15 / #416. The retry loop
+        must absorb the transient empty and emit exactly one
+        ``ci_completed`` event whose status is the actually-final
+        verdict (``passed`` here).
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=0,
+            checks_sequence=[
+                [],  # transient empty (first fetch after watch returns)
+                [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
+            ],
+        )
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
-            self._run(journal, gh_exit=0, checks_json=[])
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[100.0, 100.5, 101.0, 142.0]):
+                rc = pr_watch.main([
+                    "--pr", "413", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 0)
+            # Exactly one final event — not one per observation.
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            # Duration is measured from watch start to final verdict
+            # (post-retry), not to the first transient observation.
+            self.assertEqual(rec["duration_sec"], 42)
+
+    def test_transient_pending_then_passes_returns_zero(self) -> None:
+        """Codex round-1 Major: the script's exit code must follow the
+        final verdict, not gh's initial ``--watch`` exit code.
+
+        Repro: gh exits 8 (pending) on the first observation, then a
+        retry resolves to passed. The caller checks ``$?`` and must
+        see 0 — otherwise a CI-passed PR is mistaken for
+        ``incomplete`` by every shell consumer.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=8,
+            checks_sequence=[
+                [{"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "ci", "state": "COMPLETED", "bucket": "pass"}],
+            ],
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.1, 0.2, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "417", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 0)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+
+    def test_transient_pending_then_fails_emits_one_final_event(self) -> None:
+        """Symmetric coverage: a real CI failure that arrives after a
+        pending observation must still record exactly one final
+        ``ci_completed(status=failed)`` event.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=8,  # gh exits 8 on the initial pending observation
+            checks_sequence=[
+                [{"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"}],
+                [{"name": "ci", "state": "COMPLETED", "bucket": "fail"}],
+            ],
+        )
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.1, 0.2, 7.0]):
+                pr_watch.main([
+                    "--pr", "414", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(_count_ci_events(journal), 1)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "failed")
+
+    def test_retry_budget_exhausted_records_incomplete_once(self) -> None:
+        """When every retry observation is still empty/pending, the
+        budget eventually runs out. We then write a SINGLE final
+        ``ci_completed(status=incomplete)`` event whose
+        ``duration_sec`` reflects the full observation window — not
+        a misleading 1s.
+        """
+        fake_run = _make_stateful_fake_run(
+            watch_exit=0,
+            checks_sequence=[[]],  # always empty
+        )
+        # monotonic side_effect:
+        #   1st: started = 0.0
+        #   2nd: deadline = monotonic() + budget at top of retry loop
+        #   3rd: while-loop check (returns past deadline → exit loop)
+        #   4th: duration = monotonic() - started
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.5, 9999.0, 9999.5]):
+                pr_watch.main([
+                    "--pr", "415", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(_count_ci_events(journal), 1)
             rec = _read_ci_event(journal)
             self.assertEqual(rec["status"], "incomplete")
 
@@ -300,17 +548,91 @@ class JournalEmitTests(unittest.TestCase):
             self.assertEqual(rec["status"], "canceled")
 
     def test_json_probe_failure_falls_back_to_exit_code(self) -> None:
-        """If `gh pr checks --json` itself fails, use exit-code mapping."""
+        """If every `gh pr checks --json` probe fails (binary missing /
+        malformed stdout), the resolver retries within its budget and
+        only after exhaustion does it fall back to the exit-code
+        classifier.
+
+        Codex round-2 Major: a transient JSON parse failure used to
+        short-circuit the retry budget and bypass the resolver
+        entirely; the fix unifies the retry path so probe failures
+        and ``incomplete`` observations are both retryable.
+        """
+        # Always-FileNotFoundError stub: `_fetch_checks` returns None
+        # for every call.
+        fake_run = _make_fake_run(
+            watch_exit=0,
+            checks_raises=FileNotFoundError("gh missing"),
+        )
+        # monotonic side_effect:
+        #   1st: started = 100.0
+        #   2nd: deadline = monotonic() + budget (set on iter 1)
+        #   3rd: deadline check (already past → exit loop)
+        #   4th: duration = monotonic() - started
         with TempDir() as tmp:
             journal = tmp / ".state" / "state.db"
-            self._run(
-                journal,
-                gh_exit=0,
-                checks_raises=FileNotFoundError("gh missing"),
-            )
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[100.0, 100.5, 9999.0, 9999.5]):
+                pr_watch.main([
+                    "--pr", "205", "--repo", "octo/repo", "--interval", "5",
+                ])
             rec = _read_ci_event(journal)
-            # exit 0 → passed via _classify fallback.
+            # exit 0 → passed via _classify fallback (post-exhaustion).
             self.assertEqual(rec["status"], "passed")
+
+    def test_transient_probe_failure_then_passes(self) -> None:
+        """Codex round-2 Major regression test: a single transient
+        unparseable JSON response (e.g. ``gh`` returned empty stdout
+        for one observation) must NOT short-circuit the retry budget.
+
+        We simulate one ``FileNotFoundError`` (so ``_fetch_checks``
+        returns ``None``) then a passing observation. The pre-fix
+        code would have called ``_classify(exit_code=8)`` →
+        ``incomplete`` and recorded that as the final event,
+        re-introducing the Issue #413 race when a transient probe
+        failure coincided with ``gh exit 8``.
+        """
+        call_state = {"i": 0}
+
+        def fake_run(cmd, *args, **kwargs):
+            if "view" in cmd and "--json" in cmd and "number" in cmd:
+                return mock.Mock(returncode=0, stdout="{}", stderr="")
+            if "checks" in cmd and "--json" in cmd:
+                i = call_state["i"]
+                call_state["i"] = i + 1
+                if i == 0:
+                    raise FileNotFoundError("transient")
+                return mock.Mock(
+                    returncode=0,
+                    stdout=json.dumps(
+                        [{"name": "ci", "state": "COMPLETED",
+                          "bucket": "pass"}]
+                    ),
+                    stderr="",
+                )
+            return mock.Mock(returncode=8)  # gh --watch exit 8 (pending)
+
+        with TempDir() as tmp:
+            journal = tmp / ".state" / "state.db"
+            with mock.patch.object(pr_watch, "JOURNAL_PATH", journal), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
+                 mock.patch.object(pr_watch.time, "sleep", return_value=None), \
+                 mock.patch.object(pr_watch.time, "monotonic",
+                                   side_effect=[0.0, 0.1, 0.2, 1.0]):
+                rc = pr_watch.main([
+                    "--pr", "418", "--repo", "octo/repo", "--interval", "5",
+                ])
+            self.assertEqual(rc, 0)
+            rec = _read_ci_event(journal)
+            self.assertEqual(rec["status"], "passed")
+            self.assertEqual(_count_ci_events(journal), 1)
 
 
 class ClassifyFromChecksTests(unittest.TestCase):
@@ -373,13 +695,21 @@ class ClassifyFromChecksTests(unittest.TestCase):
 
 
 class PowerShellInterpreterProbeTests(unittest.TestCase):
-    """Issue #224 (b): pr-watch.ps1 must reject Pythons that lack core_harness.
+    """Issue #224 (b) / pr-watch-race-fix: pr-watch.ps1 must reject
+    Pythons that fail the combined ``Python 3 + stdlib sqlite3``
+    probe.
 
-    These tests exercise the actual PowerShell script via pwsh; they are
-    skipped on hosts where pwsh isn't available (e.g. minimal CI images).
-    The probe logic itself is small and self-contained, so we extract just
-    the Test-Interpreter function and call it with synthetic shim
-    interpreters.
+    Originally the probe required ``core_harness.audit``; that import
+    was retired during M4 (the events table replaced
+    ``.state/journal.jsonl``) and the probe in ``tools/pr-watch.ps1``
+    now imports stdlib ``sqlite3`` instead — the actual external
+    dependency of ``tools.state_db``.
+
+    These tests exercise the actual PowerShell script via pwsh; they
+    are skipped on hosts where pwsh isn't available (e.g. minimal CI
+    images). The probe logic itself is small and self-contained, so
+    we extract just the ``Test-Interpreter`` function and call it
+    with synthetic shim interpreters.
     """
 
     @classmethod
@@ -503,6 +833,15 @@ class TempDir:
 class MergeWatchTests(unittest.TestCase):
     """Issue #317: post-CI merge-watch loop in pr_watch.main."""
 
+    def setUp(self) -> None:
+        # Hard-isolate from the live renga peer channel — see the
+        # module-level setUp comment. The previously-observed leak
+        # (PR #555 PR_MERGE_WATCH_TIMEOUT visible to a parallel
+        # worker) originated from `test_watch_for_merge_timeout_*`,
+        # which calls `_watch_for_merge` without mocking
+        # `_notify_peer`.
+        _assert_peer_isolation()
+
     def _seed_run_for_merge(self, db: Path, *, pr_url: str,
                             pattern: str = "A") -> None:
         """Seed a run pointing at the PR. Default pattern='A' so the
@@ -596,6 +935,7 @@ class MergeWatchTests(unittest.TestCase):
                 watch_exit=0, view_sequence=[view_merged],
             )
             with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
@@ -655,6 +995,7 @@ class MergeWatchTests(unittest.TestCase):
                 return mock.Mock(returncode=0)
 
             with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
@@ -693,6 +1034,7 @@ class MergeWatchTests(unittest.TestCase):
                 return mock.Mock(returncode=1)
 
             with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
@@ -734,6 +1076,7 @@ class MergeWatchTests(unittest.TestCase):
                 return mock.Mock(returncode=0)
 
             with mock.patch.object(pr_watch, "JOURNAL_PATH", db), \
+                 mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
                  mock.patch.object(pr_watch.shutil, "which", return_value="/usr/bin/gh"), \
                  mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run), \
                  mock.patch.object(pr_watch.time, "monotonic", side_effect=[0.0, 1.0]):
@@ -778,7 +1121,13 @@ class MergeWatchTests(unittest.TestCase):
                     )
                 raise AssertionError(f"unexpected cmd: {cmd}")
 
-            with mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+            with mock.patch.object(pr_watch, "_notify_peer", return_value=False), \
+                 mock.patch.object(pr_watch.subprocess, "run", side_effect=fake_run):
+                # Hardened against the PR #555 leak: even though the
+                # module-level setUp scrubs RENGA_SOCKET, a regression
+                # in `peer_notify`'s env-guard would still spawn the
+                # `renga mcp-peer` binary if `_notify_peer` were
+                # unmocked. Mocking the seam directly closes the door.
                 result = pr_watch._watch_for_merge(
                     pr=555, repo="octo/repo", interval=0,
                     db_path=db, max_seconds=60,


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#418](https://github.com/suisya-systems/claude-org-ja/pull/418)

Merge SHA: `5a9f352001177c89bdffed75d9dd36ccf94b4529`

Source: ja PR [#418](https://github.com/suisya-systems/claude-org-ja/pull/418)
Merge SHA: `5a9f352001177c89bdffed75d9dd36ccf94b4529`

| class | count |
|---|---|
| runtime | 3 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tools/pr-watch.ps1`
- `tools/pr_watch.py`
- `tools/test_pr_watch.py`

</details>
<details><summary>translation (1)</summary>

- `docs/contracts/delegation-lifecycle-contract.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
