### PR TITLE
auto-mirror: ja#427 fix(installer): jq fail-close + README/getting-started drift fix

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,12 +1,12 @@
-# One-liner installer for claude-org (Windows / PowerShell 7+).
+# One-liner installer for claude-org-ja (Windows / PowerShell 7+).
 # Usage:
-#   iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.ps1 | iex
+#   iwr -useb https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.ps1 | iex
 #   pwsh -NoProfile -File scripts/install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh) and prints
+#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
 #      installation hints when something is missing.
-#   2. Clones suisya-systems/claude-org (asks before reusing an
+#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
 #      server is registered with Claude Code.
@@ -17,7 +17,7 @@
 
 [CmdletBinding()]
 param(
-    [string]$Dir = 'claude-org',
+    [string]$Dir = 'claude-org-ja',
     [switch]$DryRun,
     [switch]$SkipMcp,
     [switch]$Help
@@ -31,7 +31,7 @@ if ($Help) {
 Usage: install.ps1 [-Dir <path>] [-DryRun] [-SkipMcp] [-Help]
 
 Options:
-  -Dir <path>   Target directory for the clone (default: .\claude-org).
+  -Dir <path>   Target directory for the clone (default: .\claude-org-ja).
   -DryRun       Print commands that would run without executing them.
   -SkipMcp      Skip `renga mcp install` (use when already registered).
   -Help         Show this help and exit.
@@ -39,7 +39,7 @@ Options:
     return
 }
 
-$RepoUrl = 'https://github.com/suisya-systems/claude-org.git'
+$RepoUrl = 'https://github.com/suisya-systems/claude-org-ja.git'
 # CLAUDE_ORG_REF pins the clone to a specific branch or tag for
 # reproducibility. Default `main` preserves latest-features behaviour
 # when the env var is unset.
@@ -82,7 +82,7 @@ function Read-YesNo {
     return ($reply -match '^(y|yes)$')
 }
 
-Write-Host '== claude-org installer =='
+Write-Host '== claude-org-ja installer =='
 Write-Host ''
 
 Write-Host 'Checking prerequisites...'
@@ -91,6 +91,7 @@ if (-not (Test-Prerequisite 'git'    'https://git-scm.com/downloads'))          
 if (-not (Test-Prerequisite 'claude' 'https://claude.ai/code (Claude Code CLI)'))               { $missing = $true }
 if (-not (Test-Prerequisite 'renga'  'npm install -g @suisya-systems/renga@0.18.0'))            { $missing = $true }
 if (-not (Test-Prerequisite 'gh'     'https://cli.github.com/'))                                { $missing = $true }
+if (-not (Test-Prerequisite 'jq'     'https://jqlang.org/download/'))                           { $missing = $true }
 Write-Host ''
 
 if ($missing) {
@@ -164,7 +165,7 @@ if (Test-Path -LiteralPath $Dir) {
             # message verbatim and matches install.sh's behaviour.
             [Console]::Error.WriteLine("install.ps1: failed to clone ref '$Ref' from $RepoUrl.")
             [Console]::Error.WriteLine("install.ps1: check that `$env:CLAUDE_ORG_REF names an existing branch or tag.")
-            [Console]::Error.WriteLine("install.ps1: branches and tags are accepted; see https://github.com/suisya-systems/claude-org/releases for stable tags.")
+            [Console]::Error.WriteLine("install.ps1: branches and tags are accepted; see https://github.com/suisya-systems/claude-org-ja/releases for stable tags.")
             exit 1
         }
     }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# One-liner installer for claude-org (Linux / macOS).
+# One-liner installer for claude-org-ja (Linux / macOS).
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org/main/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/suisya-systems/claude-org-ja/main/scripts/install.sh | bash
 #   bash scripts/install.sh [--dir <path>] [--dry-run] [--skip-mcp]
 #
 # This script:
-#   1. Checks for required commands (git, claude, renga, gh) and prints
+#   1. Checks for required commands (git, claude, renga, gh, jq) and prints
 #      installation hints when something is missing.
-#   2. Clones suisya-systems/claude-org (asks before reusing an
+#   2. Clones suisya-systems/claude-org-ja (asks before reusing an
 #      existing directory).
 #   3. Runs `renga mcp install` (user-scope) so the renga-peers MCP
 #      server is registered with Claude Code.
@@ -17,8 +17,8 @@
 # permission prompts.
 set -euo pipefail
 
-REPO_URL="https://github.com/suisya-systems/claude-org.git"
-TARGET_DIR="claude-org"
+REPO_URL="https://github.com/suisya-systems/claude-org-ja.git"
+TARGET_DIR="claude-org-ja"
 DRY_RUN=0
 SKIP_MCP=0
 # CLAUDE_ORG_REF pins the clone to a specific branch or tag for
@@ -31,7 +31,7 @@ usage() {
 Usage: install.sh [--dir <path>] [--dry-run] [--skip-mcp] [--help]
 
 Options:
-  --dir <path>   Target directory for the clone (default: ./claude-org).
+  --dir <path>   Target directory for the clone (default: ./claude-org-ja).
   --dry-run      Print the commands that would run without executing them.
   --skip-mcp     Skip `renga mcp install` (use when already registered).
   -h, --help     Show this help and exit.
@@ -93,135 +93,160 @@ run() {
   fi
 }
 
-# Detect a Windows-style POSIX shell (Git Bash / MSYS2 / Cygwin). WSL
-# reports OSTYPE=linux-gnu and is intentionally excluded — there the
-# Linux PATH conventions apply, so the extra fallbacks would just slow
-# things down without fixing anything.
-#
-# OSTYPE is the cheap probe; `uname -s` is a fallback for shells that
-# don't export OSTYPE (some minimal POSIX shims). Either matching is
-# enough.
-IS_WINDOWS_SHELL=0
+# Detect Git Bash / MSYS2 / Cygwin running on Windows. The PowerShell
+# `iwr | iex` flow uses install.ps1; the matching bash one-liner from
+# PowerShell (`bash <(curl ...)`) and direct `bash scripts/install.sh`
+# from a Git Bash shell both land here, where two Windows-specific gaps
+# in the POSIX prerequisite check show up:
+#   1. Bash's `command -v foo` tries `foo.exe` on MSYS but does NOT try
+#      `foo.cmd` / `foo.bat`, so npm-installed shims (`renga.cmd`) are
+#      invisible to a plain `command -v renga`.
+#   2. Some installers (Claude Code's per-user installer, cargo,
+#      scoop) drop binaries in dirs that aren't on the bash PATH when
+#      bash is launched fresh from PowerShell, even though they are on
+#      the user's Windows PATH.
+# Both gaps need explicit handling; everywhere else, `IS_WINDOWS_BASH=0`
+# keeps the legacy POSIX path intact.
 case "${OSTYPE:-}" in
-  msys*|cygwin*|win32*) IS_WINDOWS_SHELL=1 ;;
+  msys*|cygwin*|win32*) IS_WINDOWS_BASH=1 ;;
+  *) IS_WINDOWS_BASH=0 ;;
 esac
-if [[ "$IS_WINDOWS_SHELL" != "1" ]] && command -v uname >/dev/null 2>&1; then
+if [[ "$IS_WINDOWS_BASH" != "1" ]]; then
   case "$(uname -s 2>/dev/null || true)" in
-    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS_SHELL=1 ;;
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS_BASH=1 ;;
+  esac
+fi
+
+# Linux / macOS classification for OS-specific install hints (node /
+# npm tip, Python venv guidance). Windows / Git Bash is handled by
+# IS_WINDOWS_BASH above; force IS_LINUX/IS_MAC=0 there so the three
+# flags stay mutually exclusive even when OSTYPE is set without
+# uname agreeing.
+if [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+  IS_LINUX=0; IS_MAC=0
+else
+  case "$(uname -s 2>/dev/null || true)" in
+    Linux*)  IS_LINUX=1; IS_MAC=0 ;;
+    Darwin*) IS_LINUX=0; IS_MAC=1 ;;
+    *)       IS_LINUX=0; IS_MAC=0 ;;
   esac
 fi
 
 resolve_command() {
-  # Echoes the resolved path of a command, or returns non-zero when not
-  # found. On Git Bash / MSYS, `command -v claude` does NOT auto-append
-  # PATHEXT (`.exe` / `.cmd` / `.bat`) the way the exec layer does at
-  # actual invocation time, so a tool installed as `claude.cmd` shows
-  # up as missing here even though `claude foo` would have worked.
-  # That trips the prerequisite gate for users who run
-  # `curl ... | bash` from PowerShell, where claude / renga are
-  # installed via npm or cargo and end up at `<name>.cmd` /
-  # `<name>.exe` rather than as bare-name shims.
-  #
-  # The fallback ladder mirrors install.ps1's `py -3` candidate-list
-  # philosophy: try the cheap thing first, then explicit extensions,
-  # then a small set of common Windows install locations under $HOME.
-  local cmd="$1" found="" ext cand
-  if found=$(command -v "$cmd" 2>/dev/null); then
-    printf '%s\n' "$found"
-    return 0
+  # Pure resolver: prints the resolved path on stdout and returns 0,
+  # or returns 1 with no output. Side effects (PATH prepend) live in
+  # require_or_warn so this stays composable for the explicit
+  # `RENGA_BIN=$(resolve_command renga ...)` capture below.
+  local cmd="$1" resolved="" ext prefix candidate
+  if resolved=$(command -v "$cmd" 2>/dev/null); then
+    printf '%s\n' "$resolved"; return 0
   fi
-  if [[ "$IS_WINDOWS_SHELL" != "1" ]]; then
-    return 1
-  fi
+  [[ "$IS_WINDOWS_BASH" == "1" ]] || return 1
+  # (b) Windows-specific extensions that bash's command -v skips.
   for ext in .exe .cmd .bat; do
-    if found=$(command -v "${cmd}${ext}" 2>/dev/null); then
-      printf '%s\n' "$found"
-      return 0
+    if resolved=$(command -v "$cmd$ext" 2>/dev/null); then
+      printf '%s\n' "$resolved"; return 0
     fi
   done
-  # Common Windows install locations that aren't always on PATH when
-  # bash is launched from PowerShell. Order: language-package managers
-  # (npm / cargo) first, since claude / renga ship through them; then
-  # POSIX-style $HOME bin dirs; then scoop shims for users on that
-  # package manager.
-  for cand in \
-    "$HOME/AppData/Roaming/npm/${cmd}.cmd" \
-    "$HOME/AppData/Roaming/npm/${cmd}.exe" \
-    "$HOME/AppData/Roaming/npm/${cmd}" \
-    "$HOME/.cargo/bin/${cmd}.exe" \
-    "$HOME/.cargo/bin/${cmd}" \
-    "$HOME/.local/bin/${cmd}.exe" \
-    "$HOME/.local/bin/${cmd}" \
-    "$HOME/AppData/Local/Programs/${cmd}/${cmd}.exe" \
-    "$HOME/scoop/shims/${cmd}.exe" \
-    "$HOME/scoop/shims/${cmd}.cmd"; do
-    # Use -f, not -x: npm-installed `.cmd` shims on Windows ship
-    # without the POSIX execute bit (they're invoked by cmd.exe, not
-    # by /bin/sh), but Windows can still launch them and Git Bash
-    # forwards the call. -f keeps `.exe` and bare POSIX shims working
-    # too.
-    if [[ -f "$cand" ]]; then
-      printf '%s\n' "$cand"
-      return 0
-    fi
+  # (c) Well-known per-user install prefixes that may not be on bash's
+  # PATH when invoked via `bash <(curl ...)` from PowerShell. Order
+  # matters: npm comes first because both `renga` and (sometimes)
+  # `claude` ship there as `.cmd` shims; cargo / scoop / Programs
+  # follow for native `.exe` builds.
+  for prefix in \
+    "$HOME/AppData/Roaming/npm" \
+    "$HOME/.cargo/bin" \
+    "$HOME/.local/bin" \
+    "$HOME/scoop/shims" \
+    "$HOME/AppData/Local/Programs/$cmd"; do
+    # Extension-bearing variants first so a real Windows install wins
+    # over any stale bare-name POSIX wrapper npm sometimes leaves
+    # alongside them; bare "" last so `node` / `python`-style POSIX
+    # shims still resolve when no `.exe` / `.cmd` exists.
+    for ext in .exe .cmd .bat ""; do
+      candidate="$prefix/$cmd$ext"
+      # `-f`, not `-x`: npm-generated `.cmd` shims ship without the
+      # POSIX execute bit (Windows only cares about the extension),
+      # so `-x` would skip exactly the case we're trying to catch.
+      if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"; return 0
+      fi
+    done
   done
   return 1
 }
 
 require_or_warn() {
   # $1 = command name, $2 = install hint URL/text.
-  local cmd="$1" hint="$2" path dir
-  if path=$(resolve_command "$cmd"); then
-    echo "  [ok]   $cmd: $path"
-    # When resolve_command found the tool via a Windows-only fallback,
-    # its parent dir may not be on PATH yet. Prepend it so later steps
-    # that invoke the tool through PATH (`.exe` invocations, bare
-    # POSIX shims) keep working. NOTE: this is NOT enough on its own
-    # for `.cmd` / `.bat` shims — Git Bash / MSYS bash's exec layer
-    # auto-appends `.exe` for bare-name invocations but does NOT try
-    # `.cmd` / `.bat`. So tools resolved as `<name>.cmd` (renga is the
-    # canonical case — `npm install -g @suisya-systems/renga` lays
-    # down `renga.cmd`) must be invoked via the absolute path captured
-    # by the caller. See RENGA_BIN below.
-    dir=$(dirname "$path")
-    case ":$PATH:" in
-      *":$dir:"*) ;;
-      *) PATH="$dir:$PATH" ;;
-    esac
+  local cmd="$1" hint="$2" resolved="" parent
+  if resolved=$(resolve_command "$cmd"); then
+    echo "  [ok]   $cmd: $resolved"
+    # If the resolution came from a fallback prefix that isn't on
+    # bash's PATH, prepend it so sibling tools / later `command -v`
+    # lookups in this script can find it without re-running the
+    # ladder. Skip when the dir is already there to keep PATH stable.
+    if [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+      parent=$(dirname -- "$resolved")
+      case ":$PATH:" in
+        *":$parent:"*) ;;
+        *) PATH="$parent:$PATH" ;;
+      esac
+    fi
     return 0
   fi
   echo "  [miss] $cmd not found. Install hint: $hint"
-  if [[ "$IS_WINDOWS_SHELL" == "1" ]]; then
-    echo "         (Probed .exe/.cmd/.bat on PATH and common install dirs"
-    echo "          under \$HOME — npm / cargo / scoop / .local. None matched.)"
-  fi
   return 1
 }
 
-echo "== claude-org installer =="
+echo "== claude-org-ja installer =="
 echo
 
 echo "Checking prerequisites..."
+# Snapshot whether `renga` was already discoverable on the user's
+# interactive bash PATH *before* any prerequisite probe runs. That
+# is the right baseline for the trailing Git-Bash-on-Windows hint:
+# require_or_warn below may prepend a fallback dir to PATH for the
+# remainder of this process, but that change does not survive into
+# the user's shell. If the snapshot says "no" and we still resolve
+# renga via the fallback ladder, the user's `renga --layout ops`
+# step needs the shell-PATH advice regardless of whether the
+# resolved file was a `.exe` or a `.cmd`.
+if command -v renga >/dev/null 2>&1; then
+  RENGA_ON_USER_PATH=1
+else
+  RENGA_ON_USER_PATH=0
+fi
 missing=0
 require_or_warn git    "https://git-scm.com/downloads" || missing=1
 require_or_warn claude "https://claude.ai/code (Claude Code CLI)" || missing=1
+# Surface node + npm as prereqs on Linux/macOS so a fresh WSL2 /
+# Ubuntu / macOS box doesn't follow the renga "npm install -g ..."
+# hint into a "command not found: npm" wall. On Windows / Git Bash,
+# renga can ship via npm shims, scoop, cargo, or standalone
+# installers (resolve_command's fallback ladder handles all of
+# those), so a global node/npm requirement there would be a
+# regression for working installs — leave that path's prereqs alone.
+if [[ "$IS_LINUX" == "1" || "$IS_MAC" == "1" ]]; then
+  if [[ "$IS_LINUX" == "1" ]]; then
+    NODE_HINT='install Node 20 LTS via nvm — https://github.com/nvm-sh/nvm (then: nvm install --lts)'
+  else
+    NODE_HINT='brew install node  (or use nvm: https://github.com/nvm-sh/nvm)'
+  fi
+  require_or_warn node "$NODE_HINT" || missing=1
+  require_or_warn npm  "ships with Node — install Node first ($NODE_HINT)" || missing=1
+fi
 require_or_warn renga  "npm install -g @suisya-systems/renga@0.18.0" || missing=1
 require_or_warn gh     "https://cli.github.com/" || missing=1
+require_or_warn jq     "apt install jq / brew install jq / https://jqlang.org/download/" || missing=1
+# Capture the absolute path so the later `run renga mcp install` can
+# bypass bash's PATH-extension blind spot for `.cmd` shims (Git Bash
+# on Windows tries `.exe` but not `.cmd` / `.bat`, so a PATH-only
+# resolution would `exit 127` even after require_or_warn succeeded).
+# 2>/dev/null + `|| true` keeps `set -e` happy when renga is genuinely
+# missing — the missing= flag above already handles that case, and we
+# fall back to bare `renga` so the failure mode stays familiar.
+RENGA_BIN=$(resolve_command renga 2>/dev/null || true)
 echo
-
-# Capture renga's absolute path for the later `renga mcp install` step.
-# Git Bash / MSYS bash auto-appends `.exe` on bare-name invocations
-# but not `.cmd` / `.bat`, and `npm install -g @suisya-systems/renga`
-# lays down `renga.cmd` on Windows — so a bare `run renga mcp install`
-# would exit 127 (command not found) for npm-installed users even
-# though require_or_warn just printed [ok] for it. Prefer the
-# explicit absolute path on Windows; fall back to the bare name (so
-# POSIX users still see the same `+ renga mcp install` echo line they
-# always have, and so the dry-run smoke regex stays happy).
-RENGA_BIN=""
-if [[ "$IS_WINDOWS_SHELL" == "1" ]]; then
-  RENGA_BIN=$(resolve_command renga 2>/dev/null || true)
-fi
 
 if [[ "$missing" == "1" ]]; then
   cat <<'MSG' >&2
@@ -278,7 +303,7 @@ else
     if ! git clone --branch "$REF" "$REPO_URL" "$TARGET_DIR"; then
       echo "install.sh: failed to clone ref '$REF' from $REPO_URL." >&2
       echo "install.sh: check that CLAUDE_ORG_REF names an existing branch or tag." >&2
-      echo "install.sh: branches and tags are accepted; see https://github.com/suisya-systems/claude-org/releases for stable tags." >&2
+      echo "install.sh: branches and tags are accepted; see https://github.com/suisya-systems/claude-org-ja/releases for stable tags." >&2
       exit 1
     fi
   else
@@ -306,77 +331,141 @@ fi
 # claude-org-runtime package. Phase 5c (Issue #130) moved the install
 # path from `requirements.txt` to `pyproject.toml`; we prefer the
 # editable install so the dep set comes from the canonical source.
-# PY is a single-token interpreter command for POSIX (`python3` or
-# `python`). On Git Bash / MSYS, neither name is on PATH by default;
-# only the `py.exe` launcher is present. Git Bash users have hit this
-# enough times that the install.ps1 sibling already has a `py -3`
-# candidate for it. Mirror that here so `bash <(curl ...)` from
-# PowerShell doesn't dead-end the Python deps step on stock Windows.
-#
-# PY_LAUNCHER carries the optional `-3` flag so the call site can pin
-# the launcher to a Python 3 interpreter without hard-coding a major
-# version into every invocation. It is empty for the POSIX-friendly
-# names so they continue to invoke as `python3 -m pip ...`.
+# Probe each candidate with `--version` so the Microsoft Store App
+# Execution Alias stub on Windows (`python.exe` under `WindowsApps\`
+# that exits non-zero or pops the Store on real calls) doesn't get
+# selected. `py -3` is the Windows-specific fallback for stock boxes
+# that ship only the launcher; pinning `-3` skips any leftover 2.7.
+# PY_LAUNCHER carries the optional `-3` so the unquoted expansion in
+# `run $PY $PY_LAUNCHER ...` drops empty when not needed.
 PY=""
 PY_LAUNCHER=""
-if command -v python3 >/dev/null 2>&1; then
-  PY=python3
-elif command -v python >/dev/null 2>&1; then
-  PY=python
-elif [[ "$IS_WINDOWS_SHELL" == "1" ]] && command -v py >/dev/null 2>&1; then
-  # `command -v py` is safe here even though the renga case needed the
-  # full resolve_command ladder: Git Bash / MSYS bash auto-appends
-  # `.exe` for bare-name lookups but not `.cmd` / `.bat`, and the
-  # Python launcher ships as `py.exe` under `C:\Windows\` (always on
-  # PATH on a stock Python install). Verified empirically — see the
-  # commit message for the repro.
-  #
-  # Probe with --version so we don't accidentally pick up a launcher
-  # whose configured Python 3 is broken or removed; same defensive
-  # check install.ps1 does for the Microsoft Store stub.
-  if py -3 --version >/dev/null 2>&1; then
-    PY=py
-    PY_LAUNCHER="-3"
+for cand in python3 python; do
+  if command -v "$cand" >/dev/null 2>&1 && "$cand" --version >/dev/null 2>&1; then
+    PY="$cand"; break
+  fi
+done
+if [[ -z "$PY" && "$IS_WINDOWS_BASH" == "1" ]]; then
+  if command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+    PY="py"; PY_LAUNCHER="-3"
   fi
 fi
 PYPROJECT_FILE="$TARGET_DIR/pyproject.toml"
 REQ_FILE="$TARGET_DIR/requirements.txt"
-if [[ -f "$PYPROJECT_FILE" && -n "$PY" ]]; then
-  echo
-  echo "Installing Python deps via pyproject.toml (editable) ..."
-  run $PY $PY_LAUNCHER -m pip install --user -e "$TARGET_DIR"
-elif [[ -f "$REQ_FILE" && -n "$PY" ]]; then
-  # Backward-compat path for refs that predate Phase 5c (no
-  # pyproject.toml) but post-date Step B (have requirements.txt).
-  echo
-  echo "Installing Python deps (core-harness pin, requirements.txt) ..."
-  run $PY $PY_LAUNCHER -m pip install --user -r "$REQ_FILE"
-elif [[ ! -f "$PYPROJECT_FILE" && ! -f "$REQ_FILE" ]]; then
+
+USED_VENV=0
+if [[ ! -f "$PYPROJECT_FILE" && ! -f "$REQ_FILE" ]]; then
   # Older refs / fixtures predate Step B and ship neither file.
   # The shim CLIs only exist on Step-B-or-later commits, so skipping
   # here keeps the installer backward compatible.
   echo "Skipping Python deps (no pyproject.toml or requirements.txt)."
-else
+elif [[ -z "$PY" ]]; then
   echo "WARN: python not found; tools/check_role_configs.py will fail until you 'pip install -e .'."
+elif [[ "$IS_WINDOWS_BASH" == "1" ]]; then
+  # Windows / Git Bash: keep the legacy `pip install --user` path
+  # (Windows venv layout, the activate script difference, and stock
+  # python.org / `py -3` installers all behave well with --user).
+  # Probe the pip module first so any stripped-down install fails
+  # with named guidance instead of a bare "No module named pip".
+  # Skip the probe under --dry-run so the echo-only contract holds
+  # even when the operator's box happens to have pip stripped out.
+  if [[ "$DRY_RUN" != "1" ]] && ! $PY $PY_LAUNCHER -m pip --version >/dev/null 2>&1; then
+    cat <<'MSG' >&2
+install.sh: python is on PATH but its `pip` module is missing.
+Install pip (e.g. `python -m ensurepip --upgrade`, or reinstall
+Python with the standard installer that bundles pip).
+Then re-run this installer.
+MSG
+    exit 1
+  fi
+  if [[ -f "$PYPROJECT_FILE" ]]; then
+    echo
+    echo "Installing Python deps via pyproject.toml (editable) ..."
+    run $PY $PY_LAUNCHER -m pip install --user -e "$TARGET_DIR"
+  else
+    # Backward-compat path for refs that predate Phase 5c (no
+    # pyproject.toml) but post-date Step B (have requirements.txt).
+    echo
+    echo "Installing Python deps (core-harness pin, requirements.txt) ..."
+    run $PY $PY_LAUNCHER -m pip install --user -r "$REQ_FILE"
+  fi
+else
+  # Linux / macOS: always create $TARGET_DIR/.venv and editable-
+  # install into it. Conditional PEP 668 detection was rejected as
+  # unnecessary judgement work — even where `pip install --user`
+  # would still succeed (older Linux, plain macOS), a project-local
+  # venv keeps the dep set reproducible and the user's site-packages
+  # untouched. Externally-managed boxes (Debian 12+, Ubuntu 23.04+,
+  # Homebrew Python) just naturally land here too. This is *not* an
+  # auto-install of a missing tool — Python is already on the system;
+  # the venv is just an isolated install location.
+  VENV_DIR="$TARGET_DIR/.venv"
+  VENV_PY="$VENV_DIR/bin/python"
+  echo
+  if [[ -d "$VENV_DIR" ]]; then
+    echo "Reusing existing venv at $VENV_DIR ..."
+  else
+    echo "Creating venv at $VENV_DIR ..."
+    if [[ "$DRY_RUN" == "1" ]]; then
+      # Dry-run: echo only, never touch the filesystem. Both the
+      # venv creation and the pip install collapse to `run`'s echo,
+      # so a missing python3-venv on the operator's box can't make
+      # `--dry-run` exit non-zero.
+      run $PY $PY_LAUNCHER -m venv "$VENV_DIR"
+    else
+      # Real run. Capture stderr so a `python3-venv` / `ensurepip`
+      # absence shows the interpreter's own message *and* a named
+      # apt package the user can install. `--help` probes are not
+      # sufficient — `python -m venv --help` succeeds even when
+      # ensurepip is unavailable (the failure only surfaces during
+      # actual creation), so we test by doing.
+      venv_err=$(mktemp 2>/dev/null || echo "/tmp/install-sh.venv-err.$$")
+      if ! $PY $PY_LAUNCHER -m venv "$VENV_DIR" 2>"$venv_err"; then
+        cat "$venv_err" >&2
+        rm -f "$venv_err"
+        cat <<'MSG' >&2
+install.sh: failed to create the project venv.
+On Debian / Ubuntu, the venv module needs python3-venv (and
+ensurepip). Install:
+  sudo apt install -y python3-full
+(or: sudo apt install -y python3-venv python3-pip)
+Then re-run this installer.
+MSG
+        exit 1
+      fi
+      rm -f "$venv_err"
+    fi
+  fi
+  if [[ -f "$PYPROJECT_FILE" ]]; then
+    echo "Installing Python deps into venv (editable, pyproject.toml) ..."
+    run "$VENV_PY" -m pip install -e "$TARGET_DIR"
+  else
+    # Backward-compat (see Windows branch).
+    echo "Installing Python deps into venv (requirements.txt) ..."
+    run "$VENV_PY" -m pip install -r "$REQ_FILE"
+  fi
+  USED_VENV=1
 fi
 
 # --- Done ------------------------------------------------------------------
 
-# Mirror the same RENGA_BIN/$renga substitution in the Done banner.
-# Without it, a Windows user whose `renga` resolved as `renga.cmd`
-# would see prereq [ok] and the install succeed, then immediately hit
-# `command not found` when they ran the suggested next-step command —
-# Git Bash / MSYS bash auto-appends `.exe` for bare-name invocations
-# but not `.cmd` / `.bat`. Falling back to the bare name on POSIX
-# (RENGA_BIN empty) keeps the printed banner stable for everyone else.
-RENGA_NEXT_STEP="${RENGA_BIN:-renga}"
+# When the Linux/macOS path created a project-local venv, the user's
+# interactive shell still doesn't know about it (we ran pip via the
+# venv's python directly, not by sourcing activate). Tell them to
+# activate before any later `python tools/...` step. Windows keeps
+# the legacy --user path so USED_VENV stays 0 there.
+VENV_HINT=""
+if [[ "$USED_VENV" == "1" ]]; then
+  VENV_HINT="
+  source .venv/bin/activate       # activate Python venv (this terminal)"
+fi
 cat <<MSG
 
 Done. Next steps:
 
-  cd $TARGET_DIR
+  cd $TARGET_DIR$VENV_HINT
   bash scripts/install-hooks.sh   # enable pre-commit secret scanner
-  "$RENGA_NEXT_STEP" --layout ops              # launch the Secretary pane
+  renga --layout ops              # launch the Secretary pane
 
 Inside the Secretary's Claude Code pane, run:
 
@@ -385,3 +474,25 @@ Inside the Secretary's Claude Code pane, run:
 
 For details see docs/getting-started.md.
 MSG
+
+# Final hint: the PATH prepend done by require_or_warn only affected
+# this script's process. Use the pre-resolution snapshot taken before
+# any prerequisite probe ran (RENGA_ON_USER_PATH) as the baseline —
+# that's the user's interactive shell view, which `command -v renga`
+# checked here would misrepresent after the prepend. This catches
+# both `.cmd` shims (which MSYS bash never auto-resolves) AND `.exe`
+# binaries reached via a fallback dir that isn't on the user's
+# interactive bash PATH. POSIX environments skip this entirely.
+if [[ "$IS_WINDOWS_BASH" == "1" && -n "${RENGA_BIN:-}" \
+      && "$RENGA_ON_USER_PATH" != "1" ]]; then
+  renga_dir=$(dirname -- "$RENGA_BIN")
+  cat <<MSG
+
+Note (Windows / Git Bash): bash on this shell can't find 'renga' on
+PATH. The installer resolved it via fallback to:
+  $RENGA_BIN
+Before running 'renga --layout ops' interactively, either invoke it by
+full path or add its directory to your bash PATH (e.g. in ~/.bashrc):
+  export PATH="$renga_dir:\$PATH"
+MSG
+fi


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#427](https://github.com/suisya-systems/claude-org-ja/pull/427)

Merge SHA: `6449d1a33db1beaaa25c48a5949d824be55ff708`

Source: ja PR [#427](https://github.com/suisya-systems/claude-org-ja/pull/427)
Merge SHA: `6449d1a33db1beaaa25c48a5949d824be55ff708`

| class | count |
|---|---|
| runtime | 2 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `scripts/install.ps1`
- `scripts/install.sh`

</details>
<details><summary>translation (2)</summary>

- `README.md`
- `docs/getting-started.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
