### PR TITLE
auto-mirror: ja#428 fix(hooks): make block-workers-delete.sh cwd-independent (Closes #426)

### DIFF
--- a/.hooks/block-workers-delete.sh
+++ b/.hooks/block-workers-delete.sh
@@ -55,13 +55,21 @@ if echo "$COMMAND" | grep -qE '(^|[|&;[:space:]])renga[[:space:]]'; then
 fi
 
 # workers ディレクトリのパスを org-config.md から読み取って解決する
-# Hook はプロジェクトルート (claude-org/) から実行される前提
-WORKERS_REL=$(grep 'workers_dir:' registry/org-config.md 2>/dev/null | sed 's/.*workers_dir:[[:space:]]*//' | tr -d '[:space:]')
+# org-config.md の workers_dir はリポジトリルート起点の相対パスなので、
+# config の読み込みも workers パスの正規化も ORG_ROOT 起点で行う
+# （CLAUDE_ORG_PATH 未設定時は cwd を fallback。Secretary は cwd がプロジェクトルートなので動作する）
+ORG_ROOT="${CLAUDE_ORG_PATH:-$(pwd)}"
+ORG_CONFIG="$ORG_ROOT/registry/org-config.md"
+WORKERS_REL=$(grep 'workers_dir:' "$ORG_CONFIG" 2>/dev/null | sed 's/.*workers_dir:[[:space:]]*//' | tr -d '[:space:]' || true)
 if [[ -z "$WORKERS_REL" ]]; then
   # org-config.md が読めない場合はスキップ（Hook の責務外）
   exit 0
 fi
-WORKERS_CANONICAL=$(portable_realpath "$WORKERS_REL")
+case "$WORKERS_REL" in
+  /*) WORKERS_ABS="$WORKERS_REL" ;;
+  *)  WORKERS_ABS="$ORG_ROOT/$WORKERS_REL" ;;
+esac
+WORKERS_CANONICAL=$(portable_realpath "$WORKERS_ABS")
 
 # 判定ロジック: 「再帰削除コマンドが含まれる」AND「workers パスが含まれる」
 # 引数パースではなく文字列マッチで判定する（for ループ等の回避パターンにも対応）

--- a/.hooks/test-block-workers-delete.sh
+++ b/.hooks/test-block-workers-delete.sh
@@ -7,7 +7,10 @@ set -euo pipefail
 HOOK=".hooks/block-workers-delete.sh"
 PASS=0
 FAIL=0
-WORKERS_DIR=$(realpath -m "../workers")
+# hook と同じ流儀で workers パスを解決する（registry/org-config.md の workers_dir は
+# ORG_ROOT 起点の相対パスとして定義されているため、CLAUDE_ORG_PATH があれば優先する）
+TEST_ORG_ROOT="${CLAUDE_ORG_PATH:-$(pwd)}"
+WORKERS_DIR=$(realpath -m "$TEST_ORG_ROOT/../workers")
 
 run_test() {
   local description="$1"
@@ -136,6 +139,58 @@ run_test "Edit ツール (Bash ではない)" \
 run_test "空コマンド" \
   "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"\"}}" \
   0
+
+echo ""
+
+# --- cwd 非依存性のテスト ---
+# 回帰: hook が registry/org-config.md を cwd 相対で読んでいた頃、Dispatcher cwd=.dispatcher/
+# では grep が exit 2 を返し set -euo pipefail で全 Bash がブロックされていた。
+# また、WORKERS_REL の正規化を cwd 起点で行うと絶対パス指定の workers 削除を検知できない。
+# CLAUDE_ORG_PATH 起点で config / workers パスを解決していることを担保する。
+echo "[cwd 非依存性 (CLAUDE_ORG_PATH 起点解決)]"
+
+HOOK_ABS="$(realpath "$HOOK")"
+# .dispatcher 配下を擬似 cwd として使う。ORG_ROOT は TEST_ORG_ROOT に揃える
+# （WORKERS_DIR と整合した workers パス解決を hook 側で起こすため）
+ALT_CWD="$(pwd)/.dispatcher"
+
+if [[ ! -d "$ALT_CWD" ]]; then
+  echo "  SKIP: .dispatcher ディレクトリが無いため cwd 非依存テストを省略"
+else
+  run_test_cwd() {
+    local description="$1"
+    local cwd="$2"
+    local org_path="$3"
+    local input_json="$4"
+    local expected_exit="$5"
+
+    actual_exit=0
+    ( cd "$cwd" && CLAUDE_ORG_PATH="$org_path" bash "$HOOK_ABS" ) <<< "$input_json" >/dev/null 2>&1 || actual_exit=$?
+
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+      echo "  PASS: $description"
+      PASS=$((PASS + 1))
+    else
+      echo "  FAIL: $description (expected exit $expected_exit, got $actual_exit)"
+      FAIL=$((FAIL + 1))
+    fi
+  }
+
+  run_test_cwd "Dispatcher cwd + 良性コマンド (回帰: 全 Bash ブロック)" \
+    "$ALT_CWD" "$TEST_ORG_ROOT" \
+    '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
+    0
+
+  run_test_cwd "Dispatcher cwd + workers 絶対パスの rm -rf (Blocker 回帰)" \
+    "$ALT_CWD" "$TEST_ORG_ROOT" \
+    "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf ${WORKERS_DIR}/dummy-task\"}}" \
+    2
+
+  run_test_cwd "Dispatcher cwd + CLAUDE_ORG_PATH 未設定 + 良性コマンド (config 不在 fallback)" \
+    "$ALT_CWD" "" \
+    '{"tool_name":"Bash","tool_input":{"command":"ls"}}' \
+    0
+fi
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#428](https://github.com/suisya-systems/claude-org-ja/pull/428)

Merge SHA: `a5b690cca55d229176b2335a4a744384b300e779`

Source: ja PR [#428](https://github.com/suisya-systems/claude-org-ja/pull/428)
Merge SHA: `a5b690cca55d229176b2335a4a744384b300e779`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `.hooks/block-workers-delete.sh`
- `.hooks/test-block-workers-delete.sh`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
