### PR TITLE
auto-mirror: ja#451 feat(claude): fallback Pattern B base_repo to workers_dir/<slug> (Closes #450)

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -261,6 +261,88 @@ class TestApplyDelegatePlan(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# settings_args dispatch-context pass-through (Phase 1 PR4)
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsGenerateCmd(unittest.TestCase):
+    """Verifies _build_settings_generate_cmd forwards the dispatch context
+    (--pattern / --base-clone / --task-id / --branch-ref) so the runtime
+    can substitute `worker_roles.<role>.sandbox_by_pattern` placeholders.
+    """
+
+    _MANDATORY = {
+        "role": "default",
+        "worker-dir": "/wd",
+        "claude-org-path": "/co",
+        "out": "/wd/.claude/settings.local.json",
+    }
+
+    def _build(self, **extra: str) -> list[str]:
+        args = dict(self._MANDATORY)
+        args.update(extra)
+        return gdp._build_settings_generate_cmd(args, runtime_cmd="claude-org-runtime")
+
+    def test_pattern_a_omits_pattern_b_only_flags(self):
+        cmd = self._build(pattern="A", **{"task-id": "t-1", "branch-ref": "feat/x"})
+        # Pattern A leaves base-clone unset because the resolver does not
+        # supply it; the runtime must error if a Pattern A body references
+        # {base_clone}, so we MUST NOT pass an empty --base-clone here.
+        self.assertNotIn("--base-clone", cmd)
+        self.assertIn("--pattern", cmd)
+        self.assertEqual(cmd[cmd.index("--pattern") + 1], "A")
+        self.assertEqual(cmd[cmd.index("--task-id") + 1], "t-1")
+        self.assertEqual(cmd[cmd.index("--branch-ref") + 1], "feat/x")
+
+    def test_pattern_b_passes_full_dispatch_context(self):
+        cmd = self._build(
+            pattern="B",
+            **{
+                "base-clone": "/bc",
+                "task-id": "T123",
+                "branch-ref": "feat/self-edit",
+            },
+        )
+        self.assertEqual(cmd[cmd.index("--pattern") + 1], "B")
+        self.assertEqual(cmd[cmd.index("--base-clone") + 1], "/bc")
+        self.assertEqual(cmd[cmd.index("--task-id") + 1], "T123")
+        self.assertEqual(cmd[cmd.index("--branch-ref") + 1], "feat/self-edit")
+
+    def test_pattern_c_ephemeral_omits_branch_ref(self):
+        # Pattern C ephemeral has planned_branch=None; settings_args
+        # therefore omits branch-ref entirely. The cmd builder MUST drop
+        # the flag rather than emit "--branch-ref None" or empty string.
+        cmd = self._build(pattern="C", **{"task-id": "t-c"})
+        self.assertNotIn("--branch-ref", cmd)
+        self.assertNotIn("--base-clone", cmd)
+        self.assertEqual(cmd[cmd.index("--pattern") + 1], "C")
+        self.assertEqual(cmd[cmd.index("--task-id") + 1], "t-c")
+
+    def test_pre_pr4_settings_args_renders_minimum_cmd(self):
+        # Backward compatibility: a settings_args dict that lacks the
+        # PR4-added keys (e.g. an old caller that constructs the dict by
+        # hand) must still render a runnable cmd — the runtime CLI's
+        # required args are only the four mandatory ones.
+        cmd = self._build()
+        self.assertEqual(
+            cmd,
+            [
+                "claude-org-runtime",
+                "settings",
+                "generate",
+                "--role",
+                "default",
+                "--worker-dir",
+                "/wd",
+                "--claude-org-path",
+                "/co",
+                "--out",
+                "/wd/.claude/settings.local.json",
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
 # CLI smoke tests (preview + apply paths)
 # ---------------------------------------------------------------------------
 
@@ -1270,9 +1352,389 @@ class TestPatternBClaudeOrgRepoWorktreePlan(unittest.TestCase):
         self.assertTrue((worker_dir / "CLAUDE.md").exists())
 
 
+# ---------------------------------------------------------------------------
+# Issue #450: Pattern B base_repo fallback to workers_dir/<slug>
+# ---------------------------------------------------------------------------
+
+
+class TestPatternBUrlOnlyRegistryFallback(unittest.TestCase):
+    """Issue #450: registry rows with a URL-only path (e.g. renga registered
+    as ``| renga | renga | https://github.com/.../renga.git | ... |``) used to
+    fall through all three base_repo branches in build_delegate_plan, leaving
+    base_repo=None and causing apply to raise WorktreeApplyError. The fallback
+    must pick up a manually-cloned local repo at ``workers_dir/<project_slug>``
+    so Pattern B delegation works for URL-only registry entries."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Replace the auto-seeded registry with a URL-only row for ``renga``
+        # so the build_delegate_plan path lookup yields a non-local path.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| renga | renga | https://github.com/suisya-systems/renga.git "
+            "| Renga | dev |\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _init_bare_repo(self, base: Path) -> None:
+        base.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "-C", str(base), "init", "-q"], check=True
+        )
+
+    def _init_repo_with_origin(self, base: Path, origin_url: str) -> None:
+        base.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "-C", str(base), "init", "-q"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(base), "remote", "add", "origin", origin_url],
+            check=True,
+        )
+
+    def _force_pattern_b(self, slug: str) -> None:
+        self.sb.add_active_run(
+            task_id=f"prev-{slug}",
+            project_slug=slug,
+            worker_dir=str(self.sb.workers / slug),
+        )
+
+    def test_fallback_to_workers_dir_slug_when_registry_path_is_url(self):
+        """workers_dir/<slug> with origin URL matching the registered github
+        repo → base_repo resolves to that clone."""
+        clone = self.sb.workers / "renga"
+        self._init_repo_with_origin(
+            clone, "https://github.com/suisya-systems/renga.git"
+        )
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-fallback-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.layout.pattern_variant)
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(Path(plan.base_repo).resolve(), clone.resolve())
+
+    def _set_registry(self, url: str) -> None:
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| renga | renga | {url} | Renga | dev |\n",
+            encoding="utf-8",
+        )
+
+    def test_ssh_style_registry_url_still_enforces_origin_match(self):
+        """Codex Round 3 Blocker: ``git@github.com:org/renga.git`` SSH-style
+        registry entries used to bypass the github gate because the helper
+        keyed on ``"://"``. ``_extract_github_repo_name`` accepts both forms
+        so the gate must too — a bare-init clone under an SSH-registered
+        slug must still be rejected."""
+        self._set_registry("git@github.com:suisya-systems/renga.git")
+        clone = self.sb.workers / "renga"
+        self._init_bare_repo(clone)  # no origin
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-ssh-bare-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+    def test_explicit_port_ssh_url_still_enforces_origin_match(self):
+        """Codex Round 4 Blocker: ``ssh://git@github.com:22/org/repo.git``
+        (explicit-port SSH form) used to escape the github gate because the
+        regex's ``[^/:\\s]+`` owner slot was eaten by the port digits, so
+        ``_extract_github_repo_name`` returned None and origin matching was
+        skipped. Regex now tolerates an optional ``:port``. Bare-init clone
+        under such a registry entry must still be rejected."""
+        self._set_registry("ssh://git@github.com:22/suisya-systems/renga.git")
+        clone = self.sb.workers / "renga"
+        self._init_bare_repo(clone)  # no origin
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-ssh-port-bare-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+    def test_ssh_style_registry_url_accepts_matching_origin(self):
+        """SSH-registered renga + clone whose origin (https or ssh) resolves
+        to the same github repo name → fallback accepts. Owner is
+        intentionally unpinned so forks remain accepted, mirroring
+        ``find_claude_org_clone``."""
+        self._set_registry("git@github.com:suisya-systems/renga.git")
+        clone = self.sb.workers / "renga"
+        # Mismatched owner (fork), same repo name — must still match.
+        self._init_repo_with_origin(
+            clone, "https://github.com/happy-ryo/renga.git"
+        )
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-ssh-match-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(Path(plan.base_repo).resolve(), clone.resolve())
+
+    def test_fallback_rejected_when_clone_has_no_origin(self):
+        """Codex Round 2 Blocker: a bare ``git init`` clone with no origin
+        must not be accepted as a base for a github-registered project —
+        otherwise any leftover same-named directory silently adopts the
+        registered slug. ``origin`` URL must match the registered repo
+        name for github URLs."""
+        clone = self.sb.workers / "renga"
+        self._init_bare_repo(clone)  # no origin remote
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-no-origin-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+    def test_no_fallback_when_workers_dir_slug_missing(self):
+        """No directory at workers_dir/<slug> → base_repo stays None
+        (existing apply-time error path preserved)."""
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-no-clone-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+    def test_fallback_rejected_when_clone_origin_url_mismatches_registry(self):
+        """A leftover unrelated github repo at workers_dir/<slug> must not be
+        adopted as the base — would redirect dispatch into the wrong repo
+        (Issue #370 precedent). Origin URL repo-name match guards against it."""
+        clone = self.sb.workers / "renga"
+        self._init_repo_with_origin(
+            clone, "https://github.com/some-other-org/not-renga.git"
+        )
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-mismatch-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+    def test_pattern_b_override_uses_url_only_fallback_for_preflight(self):
+        """Issue #450 consistency: ``--pattern B`` override preflight must
+        accept the same workers_dir/<slug> base that auto-derived Pattern B
+        uses, otherwise the same setup errors at preview only when forced."""
+        clone = self.sb.workers / "renga"
+        self._init_repo_with_origin(
+            clone, "https://github.com/suisya-systems/renga.git"
+        )
+        # No add_active_run — this is the no-concurrent-run case where
+        # ``--pattern B`` override is the only way to get Pattern B.
+        plan = gdp.build_delegate_plan(
+            task_id="renga-override-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "B"},
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(
+            Path(plan.base_repo).resolve(), clone.resolve()
+        )
+
+    def test_no_fallback_when_workers_dir_slug_is_not_git_repo(self):
+        """A plain directory (no .git) at workers_dir/<slug> must not be
+        accepted as a base_repo — would yield "fatal: not a git repository"
+        from git worktree add. Stay None and surface the existing error."""
+        (self.sb.workers / "renga").mkdir()
+        self._force_pattern_b("renga")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-plain-dir-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertIsNone(plan.base_repo)
+
+
 def _env_update_goldens() -> bool:
     import os
     return os.environ.get("UPDATE_GOLDENS") == "1"
+
+
+# ---------------------------------------------------------------------------
+# Issue #374: ``--pattern {A|B|C}`` override propagates into brief / send_plan
+# ---------------------------------------------------------------------------
+
+
+class TestPatternOverrideCLI(unittest.TestCase):
+    """Issue #374: Secretary may force a specific pattern via ``--pattern``.
+    The override must reach (a) the resolved layout, (b) the DELEGATE body
+    rendering, and (c) the ``summary`` block in send_plan.json. Invalid
+    combinations must surface as preview-time errors rather than after a DB
+    reservation.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _common_args(self, *, slug: str = "clock-app") -> list[str]:
+        return [
+            "--task-id", "override-task",
+            "--project-slug", slug,
+            "--description", "force the pattern",
+            "--claude-org-root", str(self.sb.claude_org_root),
+            "--state-db-path", str(self.sb.db_path),
+        ]
+
+    def _run_preview_json(self, argv: list[str]) -> dict:
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main(["preview", *argv, "--json"])
+        self.assertEqual(rc, 0)
+        return json.loads(buf.getvalue())
+
+    def test_force_pattern_c_overrides_auto_a(self):
+        """Without override, clock-app + no active run = Pattern A. With
+        ``--pattern C`` the layout flips to ephemeral and planned_branch
+        becomes None (Pattern C has no branch by contract)."""
+        data = self._run_preview_json([*self._common_args(), "--pattern", "C"])
+        s = data["summary"]
+        self.assertEqual(s["pattern"], "C")
+        self.assertIsNone(s["planned_branch"])
+        # The DELEGATE body label reflects the override.
+        self.assertIn("ディレクトリパターン: C", data["delegate_body"])
+
+    def test_apply_writes_override_into_send_plan_summary(self):
+        """End-to-end: apply with ``--pattern C`` produces a send_plan.json
+        whose summary carries the overridden pattern (= what dispatcher
+        will see when it copies the manifest into renga-peers)."""
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "apply", *self._common_args(),
+                "--pattern", "C",
+                "--skip-settings",
+            ])
+        self.assertEqual(rc, 0)
+        # send_plan.json lives alongside the brief (Pattern C ephemeral
+        # writes to workers_dir/<task_id>/CLAUDE.md).
+        worker_dir = self.sb.workers / "override-task"
+        send_plan_path = worker_dir / "send_plan.json"
+        self.assertTrue(send_plan_path.exists())
+        send_plan = json.loads(send_plan_path.read_text(encoding="utf-8"))
+        self.assertEqual(send_plan["summary"]["pattern"], "C")
+
+    def test_cli_pattern_drops_toml_worker_dir_and_variant(self):
+        """Codex Round 2 Major: ``--pattern X`` together with ``--from-toml``
+        used to keep the TOML's ``[worker].dir`` and ``[worker].pattern_variant``
+        in the override dict, so the resolver treated worker_dir as
+        explicitly set and skipped its pattern-driven re-derivation. Result
+        was an inconsistent layout (e.g. ``pattern=C`` but worker_dir on
+        the registered clone). The CLI flag must override fully."""
+        # TOML pre-pins Pattern A worker_dir to a deterministic path.
+        toml_path = self.sb.root / "in.toml"
+        explicit_dir = self.sb.workers / "clock-app"
+        toml_path.write_text(
+            "[task]\n"
+            'id = "toml-pattern"\n'
+            'description = "drop dir on cli pattern"\n'
+            "\n[worker]\n"
+            f'dir = "{explicit_dir.as_posix()}"\n'
+            'pattern = "A"\n'
+            'role = "default"\n'
+            'self_edit = false\n'
+            "\n[project]\n"
+            'name = "clock-app"\n'
+            f'\n[paths]\nclaude_org = "{self.sb.claude_org_root.as_posix()}"\n',
+            encoding="utf-8",
+        )
+        from contextlib import redirect_stdout
+        from io import StringIO
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = gdp.main([
+                "preview",
+                "--from-toml", str(toml_path),
+                "--state-db-path", str(self.sb.db_path),
+                "--pattern", "C",
+                "--json",
+            ])
+        self.assertEqual(rc, 0)
+        s = json.loads(buf.getvalue())["summary"]
+        # CLI pattern wins over TOML's pattern.
+        self.assertEqual(s["pattern"], "C")
+        # And worker_dir gets re-derived for the new pattern (workers_dir/<task_id>),
+        # not left at the TOML-supplied registered clone path.
+        self.assertEqual(
+            Path(s["worker_dir"]).resolve(),
+            (self.sb.workers / "toml-pattern").resolve(),
+        )
+        # Variant from TOML (or derived for old pattern) is dropped — Pattern
+        # C ephemeral default.
+        self.assertEqual(s["pattern_variant"], "ephemeral")
+
+    def test_force_pattern_a_on_self_edit_slug_errors_in_preview(self):
+        """Resolver rejects pattern=A on a self-edit slug — the error must
+        propagate out of ``preview`` rather than letting the bad layout
+        slip through."""
+        # ResolveError is raised inside build_delegate_plan, which runs
+        # under preview without reaching apply.
+        from tools.resolve_worker_layout import ResolveError as _RE
+
+        with self.assertRaises(_RE):
+            gdp.main([
+                "preview",
+                *self._common_args(slug="claude-org-ja"),
+                "--pattern", "A",
+            ])
 
 
 if __name__ == "__main__":

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -337,6 +337,30 @@ def build_delegate_plan(
             base_repo = candidate
         elif project_path and rwl.is_local_git_repo(project_path):
             base_repo = Path(project_path).resolve()
+        else:
+            # Issue #450: registry rows may carry only a URL (no local path),
+            # with a manually-cloned repo at workers_dir/<project_slug> (renga
+            # is the motivating case). Pattern B needs a local base for
+            # ``git worktree add``; fall back to that conventional location
+            # before giving up. The helper validates the clone's origin URL
+            # so an unrelated repo left at that path can't redirect dispatch
+            # (Issue #370 precedent).
+            base_repo = rwl.find_workers_dir_clone(
+                project_slug, project_path, Path(workers_dir_for_norm)
+            )
+
+    # Phase 1 PR4: surface base_clone into settings_args for Pattern B so the
+    # runtime can substitute `{base_clone}` in
+    # `worker_roles.<role>.sandbox_by_pattern.B.filesystem`. resolve_worker_layout
+    # leaves this slot empty (the resolver does not materialize base_repo) and
+    # gen_delegate_payload is the right place to fill it in because base_repo
+    # is computed here (lines 310-339 above) from project_path / variant. For
+    # Pattern A / C base_repo is None and base-clone is omitted from
+    # settings_args — the runtime then errors if a Pattern A / C sandbox body
+    # references {base_clone}, which is the desired loud-failure behaviour.
+    settings_args = dict(layout.settings_args)
+    if base_repo is not None:
+        settings_args["base-clone"] = str(base_repo)
 
     return DelegatePlan(
         task_id=task_id,
@@ -346,7 +370,7 @@ def build_delegate_plan(
         layout=layout,
         delegate_body=delegate_body,
         brief_out_path=brief_out_path,
-        settings_args=dict(layout.settings_args),
+        settings_args=settings_args,
         permission_mode=permission_mode,
         verification_depth=verification_depth,
         closes_issue=closes_issue,
@@ -601,6 +625,52 @@ def _write_brief(plan: DelegatePlan) -> Path:
     return out
 
 
+def _build_settings_generate_cmd(
+    settings_args: dict[str, Any],
+    *,
+    runtime_cmd: str,
+) -> list[str]:
+    """Build the ``claude-org-runtime settings generate`` argv list.
+
+    Pure helper extracted from :func:`_run_settings_generate` so the
+    Phase 1 PR4 dispatch-context pass-through (``--pattern`` /
+    ``--base-clone`` / ``--task-id`` / ``--branch-ref``) is unit-testable
+    without subprocess mocking.
+
+    The mandatory flags (``--role`` / ``--worker-dir`` / ``--claude-org-path``
+    / ``--out``) are always emitted in a stable order. The optional
+    dispatch-context flags are emitted only when the corresponding key is
+    present and non-None in ``settings_args`` — the runtime CLI accepts
+    each independently and errors only if the rendered body references a
+    placeholder for which the corresponding context is missing (that
+    loud-failure surface is intentional: Pattern A / C without
+    ``--base-clone`` must NOT silently substitute an empty string into a
+    ``{base_clone}``-using sandbox body).
+    """
+    cmd = [
+        runtime_cmd,
+        "settings",
+        "generate",
+        "--role",
+        settings_args["role"],
+        "--worker-dir",
+        settings_args["worker-dir"],
+        "--claude-org-path",
+        settings_args["claude-org-path"],
+        "--out",
+        settings_args["out"],
+    ]
+    for flag, key in (
+        ("--pattern", "pattern"),
+        ("--base-clone", "base-clone"),
+        ("--task-id", "task-id"),
+        ("--branch-ref", "branch-ref"),
+    ):
+        if key in settings_args and settings_args[key] is not None:
+            cmd.extend([flag, str(settings_args[key])])
+    return cmd
+
+
 def _run_settings_generate(
     plan: DelegatePlan,
     *,
@@ -620,19 +690,7 @@ def _run_settings_generate(
     settings_args = plan.settings_args
     out = Path(settings_args["out"])
     out.parent.mkdir(parents=True, exist_ok=True)
-    cmd = [
-        runtime_cmd,
-        "settings",
-        "generate",
-        "--role",
-        settings_args["role"],
-        "--worker-dir",
-        settings_args["worker-dir"],
-        "--claude-org-path",
-        settings_args["claude-org-path"],
-        "--out",
-        settings_args["out"],
-    ]
+    cmd = _build_settings_generate_cmd(settings_args, runtime_cmd=runtime_cmd)
     try:
         subprocess.run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
@@ -748,6 +806,21 @@ def _add_task_args(p: argparse.ArgumentParser) -> None:
         type=Path,
         default=None,
         help="Load task arguments from a worker_brief-style TOML instead of CLI flags.",
+    )
+    # Issue #374: Secretary-side pattern override. The resolver enforces a
+    # strict contract (B requires a usable base, A forbidden on self-edit,
+    # C always permitted); see ``ResolveError`` raised from
+    # ``resolve_worker_layout.resolve``. Default None means "let the
+    # resolver auto-derive" — preserves the pre-#374 behaviour.
+    p.add_argument(
+        "--pattern",
+        choices=("A", "B", "C"),
+        default=None,
+        help=(
+            "Force a specific dispatch pattern (A/B/C). Validated by the "
+            "resolver: B requires a worktree base; A forbidden on "
+            "claude-org-self-edit; C always permitted."
+        ),
     )
 
 
@@ -899,6 +972,27 @@ def _gather_plan_kwargs(args: argparse.Namespace) -> dict[str, Any]:
     base: dict[str, Any] = {}
     if args.from_toml is not None:
         base.update(_load_task_args_from_toml(args.from_toml))
+    # Issue #374: ``--pattern`` is a layout override, not a task field, so
+    # merge it into ``layout_overrides`` rather than into the top-level
+    # kwargs. CLI wins over a TOML [worker].pattern of the same key, matching
+    # the rest of the merge order documented above. ``None`` means "no CLI
+    # override", which preserves any TOML value already merged into base.
+    #
+    # When the CLI flag is supplied, also drop the TOML's [worker].dir and
+    # [worker].pattern_variant from the override dict — otherwise the
+    # resolver treats them as explicit values and skips its pattern-driven
+    # re-derivation, leaving worker_dir / variant on the previous pattern's
+    # convention. Codex Round 2 Major: ``--pattern C`` on a TOML that
+    # carries [worker].dir = workers/<slug>/ used to keep worker_dir at
+    # the registered clone, producing a contradictory C layout.
+    pattern_override = getattr(args, "pattern", None)
+    if pattern_override is not None:
+        existing_overrides = base.get("layout_overrides") or {}
+        merged = dict(existing_overrides)
+        merged["pattern"] = pattern_override
+        merged.pop("worker_dir", None)
+        merged.pop("pattern_variant", None)
+        base["layout_overrides"] = merged
     # CLI overrides — only when caller actually provided a value.
     cli_overrides: dict[str, Any] = {
         "task_id": args.task_id,

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -275,7 +275,14 @@ _CLAUDE_ORG_REPO_NAMES: tuple[str, ...] = ("claude-org-ja",)
 # A local-path origin (worker-dir clones use these) has no ``github.com``
 # segment, so the regex naturally rejects it — even when the upstream dir
 # happens to be named ``claude-org-ja``.
-_GITHUB_OWNER_REPO_RE = re.compile(r"github\.com[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$")
+# Codex Round 4 Blocker (Issue #450 follow-up): allow an optional ``:port``
+# between ``github.com`` and the owner/repo segment so the explicit-port SSH
+# form ``ssh://git@github.com:22/org/repo.git`` (and the equivalent
+# ``https://github.com:443/...``) match. Without this the owner slot ate the
+# port digits and the rest of the URL never reached the repo capture.
+_GITHUB_OWNER_REPO_RE = re.compile(
+    r"github\.com(?::\d+)?[:/]([^/:\s]+)/([^/:\s]+?)(?:\.git)?/?$"
+)
 
 
 def _extract_github_repo_name(url: str) -> Optional[str]:
@@ -356,6 +363,57 @@ def find_claude_org_clone(
         return None
     repo_name = _extract_github_repo_name(url)
     return candidate if repo_name in _CLAUDE_ORG_MIRROR_REPO_NAMES else None
+
+
+def find_workers_dir_clone(
+    project_slug: str,
+    project_path: Optional[str],
+    workers_dir: Path,
+) -> Optional[Path]:
+    """Return ``workers_dir/<project_slug>`` if it is a local git repo that
+    matches the registered project, else None.
+
+    Issue #450: registry rows registered with a URL-only path (e.g.
+    ``| renga | renga | https://github.com/.../renga.git | ... |``) typically
+    have a manually-cloned local repo at the conventional
+    ``workers_dir/<project_slug>`` location. Pattern B needs a local base
+    for ``git worktree add``; use that clone when none of the prior base
+    branches resolve.
+
+    Slug match (``workers_dir/<project_slug>``) alone is not enough — a
+    leftover unrelated repo at that path would silently redirect dispatch
+    (the Issue #370 precedent for "別 repo への誤派遣"). When the registered
+    path looks like a github URL, additionally require the clone's
+    ``origin`` URL to point at a github repo with the same name (owner is
+    intentionally not pinned so forks are accepted, mirroring
+    :func:`find_claude_org_clone`). For non-github registry URLs the
+    trust signal falls back to the slug + local-git-repo check; the
+    motivating renga case is github so this gate covers the practical risk.
+    """
+    candidate = (Path(workers_dir) / project_slug).resolve()
+    if not is_local_git_repo(str(candidate)):
+        return None
+    # ``_extract_github_repo_name`` accepts both ``https://github.com/o/r.git``
+    # and ``git@github.com:o/r.git`` (the regex is scheme-agnostic), so we
+    # MUST NOT gate on ``"://"`` — that would let SSH-style registry URLs
+    # bypass the origin gate (Codex Round 3 Blocker).
+    registered_name = _extract_github_repo_name(project_path or "")
+    if registered_name is not None:
+        # Registered URL is a github remote (the motivating renga case):
+        # the clone's ``origin`` MUST also be a github remote with the same
+        # repo name. A bare ``git init`` with no origin, or an origin
+        # pointing at an unrelated repo, is rejected — otherwise any
+        # leftover same-named directory would be silently adopted
+        # (Codex Round 2 Blocker; Issue #370 precedent).
+        origin = _git_origin_url(candidate)
+        clone_name = _extract_github_repo_name(origin) if origin else None
+        if clone_name != registered_name:
+            return None
+    # Non-github registry URL (gitlab, bitbucket, custom git server) or a
+    # placeholder like "-": ``_extract_github_repo_name`` returns None and
+    # we fall back to the slug + local-git-repo trust signal. The motivating
+    # renga case is github so the strict gate above covers the practical risk.
+    return candidate
 
 
 def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
@@ -451,6 +509,7 @@ def resolve(
     # virtual project pointing at the live checkout so audit mode and the
     # active-run/state.db driven Pattern A↔B logic below keep treating it
     # the same as a registered project.
+    project_synthesized_for_self_edit = False
     if project is None and is_claude_org_project(project_slug, claude_org_root):
         project = RegistryProject(
             name=project_slug,
@@ -459,6 +518,12 @@ def resolve(
             description="",
             common_tasks="",
         )
+        # Track that this row only exists because the auto-derived role is
+        # self-edit. If a later layout_overrides flips the role away from
+        # self-edit, the contract check below must not credit this row as
+        # a worktree base — gen_delegate_payload re-reads the registry and
+        # won't find it (Codex Round 1 Major).
+        project_synthesized_for_self_edit = True
 
     # Issue #370: claude-org mirror at {workers_dir}/claude-org should
     # anchor any Pattern A/B for that repo regardless of whether the slug
@@ -482,6 +547,13 @@ def resolve(
             path=str(claude_org_clone),
             description=project.description if project is not None else "",
             common_tasks=project.common_tasks if project is not None else "",
+            # Codex Round 3 Major: preserve ``mirror_of`` when re-pinning
+            # onto the local clone. The live registry row may carry
+            # ``| ... | https://... | ... | upstream-slug |`` (non-local
+            # path + mirror_of); without this carry-over the synthesis
+            # erased mirror_of and the first-run Pattern B short-circuit
+            # silently fell back to Pattern A.
+            mirror_of=project.mirror_of if project is not None else "",
         )
 
     # --- Role decision (computed first so Pattern B can branch on it) -----
@@ -532,11 +604,34 @@ def resolve(
                     conn.close()
             except sqlite3.Error:
                 active = False
-        if active:
+        # Issue #374: two more reasons Pattern B is required even on a
+        # first dispatch:
+        # - ``self_edit`` is a *repo policy* (Secretary's live claude-org
+        #   checkout must always be a worktree, single .git, no two-clone
+        #   sync), independent of the concurrency policy that ``active``
+        #   captures. Without this short-circuit the very first self-edit
+        #   delegation lands on Pattern A and writes into the live repo.
+        # - ``project.mirror_of`` flags a mirror back-port workflow — each
+        #   task is independent, never accumulating, so worktree-per-task
+        #   is the natural default. The 5-column legacy registry leaves
+        #   this empty and behaviour is unchanged for those projects.
+        # mirror_of additionally requires a local clone path: without one,
+        # ``gen_delegate_payload`` cannot derive a worktree base, and apply
+        # would fail with ``no usable base repo``. Surface that as a config
+        # error here rather than after a DB reservation (Codex Round 1
+        # Blocker).
+        if project.mirror_of and not is_local_git_repo(project.path):
+            raise ResolveError(
+                f"project {project_slug!r} has mirror_of={project.mirror_of!r} "
+                f"in the registry but path={project.path!r} is not a local "
+                "git repo. Pattern B (the mirror back-port default) requires "
+                "the mirror to be cloned at a usable local path; either "
+                "register the local clone path or remove the mirror_of "
+                "annotation."
+            )
+        force_b = active or self_edit or bool(project.mirror_of)
+        if force_b:
             pattern = "B"
-            # claude-org self-edit Pattern B places the worktree under
-            # Secretary's live repo (single .git, no two-clone sync). See
-            # Issue #289 / references/claude-org-self-edit.md.
             if self_edit:
                 variant = "live_repo_worktree"
                 worker_dir = claude_org_root / ".worktrees" / task_id
@@ -573,12 +668,98 @@ def resolve(
     # produced Pattern C without one). Codex Round 1 Major.
     if layout_overrides:
         explicit_worker_dir = bool(layout_overrides.get("worker_dir"))
+        explicit_role_override = bool(layout_overrides.get("role"))
         if "pattern" in layout_overrides and layout_overrides["pattern"]:
             pat = layout_overrides["pattern"]
             if pat not in VALID_PATTERNS:
                 raise ResolveError(
                     f"layout_overrides['pattern'] must be one of {VALID_PATTERNS}, got {pat!r}"
                 )
+            # Issue #374: ``--pattern`` is an override flag exposed for
+            # Secretary judgment, so the contract must surface invalid combos
+            # at preview time rather than letting apply discover them after
+            # a DB reservation. The contract:
+            #   - A is forbidden when the current role is claude-org-self-edit
+            #     (Pattern A would land the brief in workers_dir/claude-org-ja/,
+            #     a separate clone, which voids the single-.git invariant
+            #     Issue #289 codified for the live repo).
+            #   - B requires a worktree base — registered local clone OR the
+            #     synthesized claude-org mirror clone OR self-edit (live repo
+            #     base). When the only candidate is a URL/placeholder path
+            #     and no clone is detected, fail loudly here so apply does
+            #     not raise after the DB row exists.
+            #   - C is always permitted.
+            #   - The role override (if any) is applied later in this block,
+            #     so consult the *post-override* role when its key is present;
+            #     otherwise fall back to the auto-derived role/self_edit.
+            effective_role = (
+                layout_overrides["role"]
+                if explicit_role_override
+                else role
+            )
+            effective_self_edit = effective_role == "claude-org-self-edit"
+            if pat == "A" and effective_self_edit:
+                raise ResolveError(
+                    "layout_overrides['pattern']='A' is incompatible with "
+                    "role='claude-org-self-edit' (would dispatch into "
+                    "{workers_dir}/claude-org-ja/, breaking the live-repo "
+                    "single-.git invariant from Issue #289). Choose pattern=B "
+                    "or override the role away from claude-org-self-edit."
+                )
+            if pat == "B":
+                # Skip the base check when the caller is supplying their own
+                # worker_dir or pattern_variant — those branches re-derive
+                # the base further below (e.g. claude_org_repo_worktree).
+                explicit_variant_now = (
+                    layout_overrides.get("pattern_variant") is not None
+                )
+                if not (explicit_worker_dir or explicit_variant_now):
+                    # The synthesized self-edit project record only exists
+                    # in this resolve(); gen_delegate_payload re-reads the
+                    # registry and finds nothing there for the slug. So if
+                    # the role override is also flipping us out of
+                    # self-edit, that synthesized record cannot back the
+                    # plain Pattern B layout — drop it from the base check
+                    # so we surface the contract error here rather than
+                    # letting apply blow up later (Codex Round 1 Major).
+                    project_for_base = project
+                    if (
+                        project_synthesized_for_self_edit
+                        and not effective_self_edit
+                    ):
+                        project_for_base = None
+                    # Issue #450: the workers_dir/<slug> fallback that
+                    # gen_delegate_payload uses for URL-only registry rows
+                    # must be honored here too, otherwise ``--pattern B``
+                    # preview errors at preflight while normal active-run
+                    # driven Pattern B succeeds on the same setup.
+                    url_only_base = find_workers_dir_clone(
+                        project_slug,
+                        project_for_base.path if project_for_base else None,
+                        workers_dir,
+                    )
+                    has_base = (
+                        effective_self_edit
+                        or claude_org_clone is not None
+                        or (
+                            project_for_base is not None
+                            and is_local_git_repo(project_for_base.path)
+                        )
+                        or url_only_base is not None
+                    )
+                    if not has_base:
+                        raise ResolveError(
+                            "layout_overrides['pattern']='B' requires a "
+                            "resolvable worktree base, but none could be "
+                            f"determined for project={project_slug!r}. "
+                            "Pattern B needs one of: a registered project "
+                            "row whose path is a local git repo, a manually "
+                            f"cloned repo at workers_dir/{project_slug}, "
+                            "the claude-org mirror clone, or role="
+                            "'claude-org-self-edit' (live repo base). "
+                            "Either register the project's local clone, set "
+                            "role accordingly, or fall back to pattern=C."
+                        )
             pattern = pat
             # Pattern explicitly set; reset variant unless TOML also supplied one.
             variant = layout_overrides.get("pattern_variant")
@@ -586,6 +767,54 @@ def resolve(
                 raise ResolveError(
                     f"layout_overrides['pattern_variant'] must be one of {VALID_VARIANTS} or None, got {variant!r}"
                 )
+            # Codex Round 3 Blocker: pattern_variant carries strong implications
+            # for *which repo* the worker dispatches into. Without these gates
+            # a caller could request
+            # ``pattern=B, pattern_variant=live_repo_worktree, role=default``
+            # on slug=clock-app and have the worker land inside Secretary's
+            # live claude-org repo — an entirely different project than the
+            # task targets. Tie each variant to the role/slug context that
+            # makes it meaningful so the override cannot redirect dispatch
+            # at the wrong repo.
+            if variant == "live_repo_worktree" and not effective_self_edit:
+                raise ResolveError(
+                    "layout_overrides['pattern_variant']='live_repo_worktree' "
+                    "is reserved for claude-org-self-edit dispatches (the "
+                    "variant pins worker_dir + base_repo at Secretary's live "
+                    f"claude-org repo). Got effective role={effective_role!r} "
+                    f"for slug={project_slug!r}; pattern B without self-edit "
+                    "should leave pattern_variant unset and let the resolver "
+                    "anchor on the registered project's clone instead."
+                )
+            if variant == "claude_org_repo_worktree" and (
+                project_slug != _CLAUDE_ORG_CLONE_DIRNAME
+                or claude_org_clone is None
+            ):
+                raise ResolveError(
+                    "layout_overrides['pattern_variant']='claude_org_repo_worktree' "
+                    f"requires project_slug={_CLAUDE_ORG_CLONE_DIRNAME!r} (or "
+                    "its registered alias) AND a detected claude-org mirror "
+                    f"clone at {workers_dir}/{_CLAUDE_ORG_CLONE_DIRNAME}. Got "
+                    f"slug={project_slug!r}, clone_present="
+                    f"{claude_org_clone is not None}; the variant cannot "
+                    "redirect dispatch at the wrong repo."
+                )
+            # Issue #374 (Codex Round 2 Blocker): the claude-org mirror
+            # case used to lose its variant on a plain ``--pattern B``
+            # override — auto-derive set ``claude_org_repo_worktree`` but
+            # the override above resets variant to None when the caller
+            # didn't supply ``pattern_variant``. Without this re-default
+            # the worker_dir stays at the clone root (auto-derive's
+            # Pattern A path) and gen_delegate_payload's variant-specific
+            # base_repo derivation never fires. Re-default the variant
+            # so the existing ``claude_org_repo_worktree`` re-derivation
+            # below picks up worker_dir correctly.
+            if (
+                pattern == "B"
+                and variant is None
+                and claude_org_clone is not None
+            ):
+                variant = "claude_org_repo_worktree"
             # Pattern B + variant=live_repo_worktree without explicit worker_dir
             # → re-derive to claude_org_root/.worktrees/{task_id}/ (Issue #289).
             if pattern == "B" and variant == "live_repo_worktree" and not explicit_worker_dir:
@@ -610,6 +839,50 @@ def resolve(
                         "explicitly or clone the mirror at that path."
                     )
                 worker_dir = (clone_for_override / ".worktrees" / task_id).resolve()
+            # Issue #374: a plain ``--pattern B`` (no variant, no explicit
+            # worker_dir) flips A → B for a registered project. The
+            # auto-derived worker_dir is still the Pattern A path
+            # (``workers_dir/<slug>/``); without re-deriving it here the
+            # override would leave the brief at the clone root and apply
+            # would refuse to treat it as a worktree. Skipped when
+            # claude_org_clone has already pinned the clone-root path —
+            # the post-override fallback below re-derives for that case.
+            if (
+                pattern == "B"
+                and variant is None
+                and not explicit_worker_dir
+                and claude_org_clone is None
+            ):
+                worker_dir = (
+                    workers_dir / project_slug / ".worktrees" / task_id
+                ).resolve()
+            # Same idea for ``--pattern A``: when the override drops
+            # B → A, pin worker_dir back at the clone root rather than
+            # leaving it in a stale ``.worktrees/<task_id>/`` path that
+            # auto-derive built for Pattern B. Codex Round 2 Major: the
+            # claude-org mirror branch must re-derive too — without this
+            # ``--pattern A`` on slug=claude-org leaves worker_dir at the
+            # auto-derived ``.worktrees/<task_id>/`` even though the
+            # final pattern is A, an incoherent layout.
+            if pattern == "A" and not explicit_worker_dir:
+                if claude_org_clone is not None:
+                    worker_dir = claude_org_clone.resolve()
+                else:
+                    worker_dir = (workers_dir / project_slug).resolve()
+            # ``--pattern C`` override: ephemeral default. Without this
+            # branch the override would dispatch into the *registered*
+            # project's directory (auto-derive's Pattern A worker_dir),
+            # silently re-using a clone instead of an ephemeral workspace.
+            # Default variant is ``ephemeral`` (gitignored_repo_root needs
+            # an explicit variant + targets at minimum and is left to the
+            # auto-derive path).
+            if (
+                pattern == "C"
+                and variant is None
+                and not explicit_worker_dir
+            ):
+                variant = "ephemeral"
+                worker_dir = (workers_dir / task_id).resolve()
         if "worker_dir" in layout_overrides and layout_overrides["worker_dir"]:
             worker_dir = Path(layout_overrides["worker_dir"]).resolve()
         if "role" in layout_overrides and layout_overrides["role"]:
@@ -680,12 +953,28 @@ def resolve(
         planned_branch = layout_overrides["planned_branch"]
 
     # --- settings_args -----------------------------------------------------
+    # Phase 1 PR4: pass dispatch context through to `claude-org-runtime
+    # settings generate` so the renderer can resolve {task_id} / {branch_ref}
+    # / {base_clone} placeholders in `worker_roles.<role>.sandbox_by_pattern`.
+    # `pattern` is always set from the resolved layout. `task-id` and
+    # `branch-ref` (when known) are always passed — they are cheap and the
+    # runtime ignores them when the role has no sandbox_by_pattern body that
+    # references them. `base-clone` is left for gen_delegate_payload to fill
+    # in (Pattern B only) because the resolver does not currently materialize
+    # the worktree base path; for Pattern A / C base_clone is intentionally
+    # absent so the runtime errors loudly if the schema body references
+    # `{base_clone}` outside Pattern B (rather than substituting an empty
+    # string and emitting a malformed `/.git/worktrees/...` path).
     settings_args = {
         "role": role,
         "worker-dir": str(worker_dir),
         "claude-org-path": str(claude_org_root),
         "out": str(worker_dir / ".claude" / "settings.local.json"),
+        "pattern": pattern,
+        "task-id": task_id,
     }
+    if planned_branch is not None:
+        settings_args["branch-ref"] = planned_branch
 
     return WorkerLayout(
         pattern=pattern,


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#451](https://github.com/suisya-systems/claude-org-ja/pull/451)

Merge SHA: `4b1f88d93e03fd02d990282b1a85a68618b9fd95`

Source: ja PR [#451](https://github.com/suisya-systems/claude-org-ja/pull/451)
Merge SHA: `4b1f88d93e03fd02d990282b1a85a68618b9fd95`

| class | count |
|---|---|
| runtime | 3 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tests/test_gen_delegate_payload.py`
- `tools/gen_delegate_payload.py`
- `tools/resolve_worker_layout.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
