### PR TITLE
auto-mirror: ja#453 test(claude): add attention watcher integration fixtures (Closes #445)

### DIFF
--- a/tests/fixtures/attention/expected_scan.json
+++ b/tests/fixtures/attention/expected_scan.json
@@ -1,0 +1,69 @@
+[
+  {
+    "key": "event:2",
+    "kind": "approval_blocked",
+    "severity": "urgent",
+    "title": "Worker approval required",
+    "body": "worker-T-approval is waiting for approval.",
+    "source": "state.db.events",
+    "task_id": "T-approval",
+    "worker": "worker-T-approval",
+    "created_at": "2026-05-01T01:00:00Z"
+  },
+  {
+    "key": "event:4",
+    "kind": "relay_gap_suspected",
+    "severity": "urgent",
+    "title": "Secretary relay gap suspected",
+    "body": "Relay gap detected for T-relay-suspected.",
+    "source": "state.db.events",
+    "task_id": "T-relay-suspected",
+    "worker": "worker-T-relay-suspected",
+    "created_at": "2026-05-01T02:30:00Z"
+  },
+  {
+    "key": "event:5",
+    "kind": "silent_worker_output",
+    "severity": "urgent",
+    "title": "Silent worker output",
+    "body": "worker-T-silent produced output without a peer message.",
+    "source": "state.db.events",
+    "task_id": "T-silent",
+    "worker": "worker-T-silent",
+    "created_at": "2026-05-01T02:45:00Z"
+  },
+  {
+    "key": "event:6",
+    "kind": "ci_failed",
+    "severity": "urgent",
+    "title": "CI failed",
+    "body": "PR #42 finished with failed.",
+    "source": "state.db.events",
+    "task_id": "T-ci-fail",
+    "pr": 42,
+    "status": "failed",
+    "created_at": "2026-05-01T03:00:00Z"
+  },
+  {
+    "key": "pending:T-pending-stale:pending_decision",
+    "kind": "pending_decision",
+    "severity": "urgent",
+    "title": "Pending decision",
+    "body": "T-pending-stale is waiting for human judgment.",
+    "source": "pending_decisions",
+    "task_id": "T-pending-stale",
+    "summary": "Need approval to expand scope to migration cleanup.",
+    "created_at": "2026-01-01T00:00:00Z"
+  },
+  {
+    "key": "pending:T-relay-gap:user_reply_not_forwarded",
+    "kind": "user_reply_not_forwarded",
+    "severity": "urgent",
+    "title": "User reply not forwarded",
+    "body": "T-relay-gap: user reply has not been relayed to the worker.",
+    "source": "pending_decisions",
+    "task_id": "T-relay-gap",
+    "summary": "Codex review round 3 done; OK to merge?",
+    "created_at": "2026-01-02T00:00:00Z"
+  }
+]

--- a/tests/fixtures/attention/pending_decisions.json
+++ b/tests/fixtures/attention/pending_decisions.json
@@ -1,0 +1,21 @@
+[
+  {
+    "task_id": "T-pending-stale",
+    "received_at": "2026-01-01T00:00:00Z",
+    "raw_message": "Need approval to expand scope to migration cleanup.",
+    "status": "pending"
+  },
+  {
+    "task_id": "T-relay-gap",
+    "received_at": "2026-01-01T00:30:00Z",
+    "raw_message": "Codex review round 3 done; OK to merge?",
+    "status": "escalated",
+    "user_replied_at": "2026-01-02T00:00:00Z"
+  },
+  {
+    "task_id": "T-future-dated",
+    "received_at": "2099-01-01T00:00:00Z",
+    "raw_message": "Below threshold (received_at far in the future so _minutes_since stays negative regardless of wall clock).",
+    "status": "pending"
+  }
+]

--- a/tests/fixtures/attention/state_events.json
+++ b/tests/fixtures/attention/state_events.json
@@ -1,0 +1,67 @@
+[
+  {
+    "kind": "heartbeat",
+    "occurred_at": "2026-05-01T00:00:00Z",
+    "actor": null,
+    "payload": {}
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T01:00:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "approval_blocked",
+      "task_id": "T-approval",
+      "worker": "worker-T-approval"
+    }
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:00:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "heartbeat_ping",
+      "task_id": "T-ignored"
+    }
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:30:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "relay_gap_suspected",
+      "task_id": "T-relay-suspected",
+      "worker": "worker-T-relay-suspected"
+    }
+  },
+  {
+    "kind": "notify_sent",
+    "occurred_at": "2026-05-01T02:45:00Z",
+    "actor": null,
+    "payload": {
+      "kind": "pane_output_without_peer_msg",
+      "task_id": "T-silent",
+      "worker": "worker-T-silent"
+    }
+  },
+  {
+    "kind": "ci_completed",
+    "occurred_at": "2026-05-01T03:00:00Z",
+    "actor": null,
+    "payload": {
+      "status": "failed",
+      "pr": 42,
+      "task_id": "T-ci-fail"
+    }
+  },
+  {
+    "kind": "ci_completed",
+    "occurred_at": "2026-05-01T03:30:00Z",
+    "actor": null,
+    "payload": {
+      "status": "success",
+      "pr": 43,
+      "task_id": "T-ci-ok"
+    }
+  }
+]

--- a/tests/test_attention_runtime_integration.py
+++ b/tests/test_attention_runtime_integration.py
@@ -1,0 +1,267 @@
+"""Layer 4 integration test for ``claude-org-runtime attention scan``.
+
+Feeds a hand-curated fixture (``tests/fixtures/attention/``) into the
+runtime CLI and asserts that the ``--dry-run --json`` output matches a
+checked-in golden file. This is the drift-detection seam between ja's
+``.state`` shape and the runtime classifier: if the runtime adds or
+renames an urgent kind ja could plausibly emit, this test fails and
+forces a deliberate vocabulary reconciliation on the ja side.
+
+Design source: ``docs/design/attention-notification.md`` §8 (companion
+to runtime PRs #19 + #20 — attention scan/watch CLI and template
+overrides). The runtime CLI ships in ``claude-org-runtime>=0.1.10``;
+on older runtimes that don't expose the ``attention`` subcommand the
+test skips with a clear message instead of failing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "attention"
+STATE_EVENTS_JSON = FIXTURE_DIR / "state_events.json"
+PENDING_JSON = FIXTURE_DIR / "pending_decisions.json"
+GOLDEN_JSON = FIXTURE_DIR / "expected_scan.json"
+
+# Mirrors the attention-relevant columns of tools/state_db/schema.sql.
+# Projecting only what the runtime reader touches keeps a non-attention
+# schema migration from breaking this test.
+_EVENTS_SCHEMA = """
+CREATE TABLE events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at  TEXT NOT NULL DEFAULT '2026-05-01T00:00:00Z',
+  actor        TEXT,
+  kind         TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+# Dispatch metadata depends on the host OS notification backend
+# (notify-send vs stdout vs PowerShell). The integration contract under
+# test is the classifier output, not the delivery channel, so these
+# fields are stripped before comparing against the golden.
+_DISPATCH_ONLY_KEYS = frozenset({
+    "desktop_dispatched", "bell_dispatched", "delivered",
+})
+
+# Drift canary: the set of urgent attention kinds the fixture is
+# expected to surface. Mirrors the urgent rows of
+# docs/design/attention-notification.md §5 — if the runtime stops
+# classifying any of these as urgent, the assertion in
+# test_all_expected_urgent_kinds_are_recognized fails and points at
+# the gap.
+_EXPECTED_URGENT_KINDS = frozenset({
+    "approval_blocked",
+    "relay_gap_suspected",
+    "silent_worker_output",
+    "ci_failed",
+    "pending_decision",
+    "user_reply_not_forwarded",
+})
+
+
+def _build_state_db(db_path: Path, events: list[dict]) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_EVENTS_SCHEMA)
+        for ev in events:
+            conn.execute(
+                "INSERT INTO events (occurred_at, actor, kind, payload_json)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    ev["occurred_at"],
+                    ev.get("actor"),
+                    ev["kind"],
+                    json.dumps(ev.get("payload", {})),
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _normalize(events: list[dict]) -> list[dict]:
+    """Strip env-dependent dispatch keys and sort by stable ``key``.
+
+    The CLI emits events in a deterministic order (DB events by id ASC,
+    then pending decisions in file order), but sorting both sides keeps
+    the assertion message readable when only one event drifts.
+    """
+    return sorted(
+        ({k: v for k, v in ev.items() if k not in _DISPATCH_ONLY_KEYS}
+         for ev in events),
+        key=lambda ev: ev["key"],
+    )
+
+
+def _runtime_has_attention() -> bool:
+    """Probe for the ``attention`` subcommand on the installed runtime."""
+    exe = shutil.which("claude-org-runtime")
+    if exe is None:
+        return False
+    proc = subprocess.run(
+        [exe, "attention", "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return proc.returncode == 0
+
+
+class AttentionRuntimeIntegrationTests(unittest.TestCase):
+    """End-to-end check: ja fixture → runtime CLI → golden output."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _runtime_has_attention():
+            raise unittest.SkipTest(
+                "claude-org-runtime CLI without 'attention' subcommand; "
+                "install claude-org-runtime>=0.1.10 to run this test"
+            )
+        cls.events_spec = json.loads(
+            STATE_EVENTS_JSON.read_text(encoding="utf-8"),
+        )
+        cls.pending = json.loads(
+            PENDING_JSON.read_text(encoding="utf-8"),
+        )
+        cls.golden = json.loads(
+            GOLDEN_JSON.read_text(encoding="utf-8"),
+        )
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.state_dir = Path(self._tmpdir.name) / ".state"
+        self.state_dir.mkdir()
+        _build_state_db(self.state_dir / "state.db", self.events_spec)
+        (self.state_dir / "pending_decisions.json").write_text(
+            json.dumps(self.pending, indent=2), encoding="utf-8",
+        )
+
+    def _run_scan(self) -> list[dict]:
+        result = subprocess.run(
+            [
+                "claude-org-runtime", "attention", "scan",
+                "--state-dir", str(self.state_dir),
+                "--dry-run", "--json",
+            ],
+            check=False, capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"attention scan exited with {result.returncode}; "
+            f"stderr={result.stderr!r}",
+        )
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"attention scan stdout was not JSON: {exc}; "
+                f"stdout={result.stdout!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # (1) Whole-fixture comparison against the golden.
+    # ------------------------------------------------------------------
+    def test_scan_output_matches_golden(self) -> None:
+        events = self._run_scan()
+        self.assertEqual(_normalize(events), _normalize(self.golden))
+
+    # ------------------------------------------------------------------
+    # (2) Each individual acceptance case from design §8 is present.
+    # ------------------------------------------------------------------
+    def test_notify_sent_approval_blocked_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:2")
+        self.assertEqual(ev["kind"], "approval_blocked")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-approval")
+
+    def test_notify_sent_relay_gap_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:4")
+        self.assertEqual(ev["kind"], "relay_gap_suspected")
+        self.assertEqual(ev["severity"], "urgent")
+
+    def test_notify_sent_silent_output_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:5")
+        self.assertEqual(ev["kind"], "silent_worker_output")
+        self.assertEqual(ev["severity"], "urgent")
+
+    def test_ci_completed_failed_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:6")
+        self.assertEqual(ev["kind"], "ci_failed")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["pr"], 42)
+        self.assertEqual(ev["status"], "failed")
+
+    def test_stale_pending_decision_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-pending-stale:pending_decision",
+        )
+        self.assertEqual(ev["kind"], "pending_decision")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-pending-stale")
+
+    def test_user_reply_not_forwarded_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-relay-gap:user_reply_not_forwarded",
+        )
+        self.assertEqual(ev["kind"], "user_reply_not_forwarded")
+        self.assertEqual(ev["severity"], "urgent")
+
+    # ------------------------------------------------------------------
+    # (3) Progress-only and below-threshold cases are dropped.
+    # ------------------------------------------------------------------
+    def test_progress_only_events_are_filtered(self) -> None:
+        keys = {ev["key"] for ev in self._run_scan()}
+        # heartbeat (filtered by reader)
+        self.assertNotIn("event:1", keys)
+        # notify_sent with unrecognized subkind (filtered by classifier)
+        self.assertNotIn("event:3", keys)
+        # ci_completed status=success (filtered by classifier)
+        self.assertNotIn("event:7", keys)
+        # pending decision whose received_at is far in the future —
+        # _minutes_since returns negative so the entry stays below the
+        # urgent threshold; this exercises the negative-delta branch
+        # of the staleness check.
+        self.assertNotIn(
+            "pending:T-future-dated:pending_decision", keys,
+        )
+
+    # ------------------------------------------------------------------
+    # (4) Drift canary — the runtime must still classify every kind the
+    # ja fixture is built around as urgent.
+    # ------------------------------------------------------------------
+    def test_all_expected_urgent_kinds_are_recognized(self) -> None:
+        urgent_kinds = {
+            ev["kind"] for ev in self._run_scan()
+            if ev.get("severity") == "urgent"
+        }
+        missing = _EXPECTED_URGENT_KINDS - urgent_kinds
+        self.assertEqual(
+            missing, set(),
+            "runtime is no longer classifying "
+            f"{sorted(missing)} as urgent; either the runtime vocabulary "
+            "drifted or the ja fixture is stale — reconcile before merging."
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers.
+    # ------------------------------------------------------------------
+    def _find_event(self, events: list[dict], *, key: str) -> dict:
+        for ev in events:
+            if ev.get("key") == key:
+                return ev
+        self.fail(
+            f"event with key={key!r} not found in scan output; "
+            f"got keys={[ev.get('key') for ev in events]!r}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#453](https://github.com/suisya-systems/claude-org-ja/pull/453)

Merge SHA: `de50cb2a2fc9b4b7034abaf5fb2f214a92f9c49e`

Source: ja PR [#453](https://github.com/suisya-systems/claude-org-ja/pull/453)
Merge SHA: `de50cb2a2fc9b4b7034abaf5fb2f214a92f9c49e`

| class | count |
|---|---|
| runtime | 4 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tests/fixtures/attention/expected_scan.json`
- `tests/fixtures/attention/pending_decisions.json`
- `tests/fixtures/attention/state_events.json`
- `tests/test_attention_runtime_integration.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
