### PR TITLE
auto-mirror: ja#455 docs(claude): paired ja sync for runtime PR #29 (Refs #26)

### DIFF
--- a/tools/templates/attention.example.json
+++ b/tools/templates/attention.example.json
@@ -1,0 +1,81 @@
+{
+  "desktop": true,
+  "sound": "urgent-only",
+  "cooldown_sec": 300,
+  "poll_interval_sec": 10,
+  "pending_decision_min": 15,
+  "pending_decision_max": 1440,
+  "pending_decision_drop": 10080,
+  "user_replied_min": 15,
+  "max_title_chars": 80,
+  "max_body_chars": 240,
+  "notify": {
+    "approval_blocked": "urgent",
+    "relay_gap_suspected": "normal",
+    "silent_worker_output": "normal",
+    "ci_failed": "urgent",
+    "pending_decision": "urgent",
+    "user_reply_not_forwarded": "urgent",
+    "pane_silent": "normal",
+    "pane_crashed": "urgent",
+    "worker_stalled": "normal",
+    "worker_not_reported": "normal",
+    "worker_error": "normal",
+    "worker_completed": "normal",
+    "pr_merged": "normal"
+  },
+  "templates": {
+    "approval_blocked": {
+      "title": "ワーカーが承認待ちです",
+      "body": "{worker} が承認待ちで停止しています。"
+    },
+    "ci_failed": {
+      "title": "CI が失敗しました",
+      "body": "PR #{pr} の CI が {status} で完了しました。"
+    },
+    "pending_decision": {
+      "title": "判断待ちがあります",
+      "body": "{task_id} が人間の判断を待っています。"
+    },
+    "user_reply_not_forwarded": {
+      "title": "返答の転送待ちです",
+      "body": "{task_id} でユーザー返答が worker に未転送です。"
+    },
+    "relay_gap_suspected": {
+      "title": "ワーカー宛 relay が滞っています",
+      "body": "{task_id} の {worker} 宛て転送が遅延している可能性があります。"
+    },
+    "silent_worker_output": {
+      "title": "ワーカーが無言で出力しています",
+      "body": "{worker} ペインに出力がありますが peer message が届いていません。"
+    },
+    "pane_silent": {
+      "title": "ワーカーペインが無反応です",
+      "body": "{worker} のペインに動きがありません。"
+    },
+    "pane_crashed": {
+      "title": "ワーカーペインが異常終了しました",
+      "body": "{worker} のペインが予期せず終了しました。"
+    },
+    "worker_stalled": {
+      "title": "ワーカーが停滞しています",
+      "body": "{worker} は進捗が見られず停滞しているようです。"
+    },
+    "worker_not_reported": {
+      "title": "ワーカーから報告がありません",
+      "body": "{worker} から窓口への報告がまだ届いていません。"
+    },
+    "worker_error": {
+      "title": "ワーカーがエラーを報告しました",
+      "body": "{worker} がエラーを報告しています。"
+    },
+    "worker_completed": {
+      "title": "ワーカーが完了しました",
+      "body": "{task_id} の作業が完了し、レビュー待ちです。"
+    },
+    "pr_merged": {
+      "title": "PR がマージされました",
+      "body": "PR #{pr} がマージされました。"
+    }
+  }
+}


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#455](https://github.com/suisya-systems/claude-org-ja/pull/455)

Merge SHA: `be499522794f1852a2626c46daa07b84f476b726`

Source: ja PR [#455](https://github.com/suisya-systems/claude-org-ja/pull/455)
Merge SHA: `be499522794f1852a2626c46daa07b84f476b726`

| class | count |
|---|---|
| runtime | 1 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (1)</summary>

- `tools/templates/attention.example.json`

</details>
<details><summary>translation (2)</summary>

- `docs/design/attention-notification.md`
- `docs/operations/attention-watch.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
