### PR TITLE
auto-mirror: ja#458 fix(claude): reconcile attention integration tests with runtime v0.1.11 defaults

### DIFF
--- a/tests/fixtures/attention/expected_scan.json
+++ b/tests/fixtures/attention/expected_scan.json
@@ -1,0 +1,69 @@
+[
+  {
+    "key": "event:2",
+    "kind": "approval_blocked",
+    "severity": "urgent",
+    "title": "Worker approval required",
+    "body": "worker-T-approval is waiting for approval.",
+    "source": "state.db.events",
+    "task_id": "T-approval",
+    "worker": "worker-T-approval",
+    "created_at": "2026-05-01T01:00:00Z"
+  },
+  {
+    "key": "event:4",
+    "kind": "relay_gap_suspected",
+    "severity": "normal",
+    "title": "Secretary relay gap suspected",
+    "body": "Relay gap detected for T-relay-suspected.",
+    "source": "state.db.events",
+    "task_id": "T-relay-suspected",
+    "worker": "worker-T-relay-suspected",
+    "created_at": "2026-05-01T02:30:00Z"
+  },
+  {
+    "key": "event:5",
+    "kind": "silent_worker_output",
+    "severity": "normal",
+    "title": "Silent worker output",
+    "body": "worker-T-silent produced output without a peer message.",
+    "source": "state.db.events",
+    "task_id": "T-silent",
+    "worker": "worker-T-silent",
+    "created_at": "2026-05-01T02:45:00Z"
+  },
+  {
+    "key": "event:6",
+    "kind": "ci_failed",
+    "severity": "urgent",
+    "title": "CI failed",
+    "body": "PR #42 finished with failed.",
+    "source": "state.db.events",
+    "task_id": "T-ci-fail",
+    "pr": 42,
+    "status": "failed",
+    "created_at": "2026-05-01T03:00:00Z"
+  },
+  {
+    "key": "pending:T-pending-stale:pending_decision",
+    "kind": "pending_decision",
+    "severity": "urgent",
+    "title": "Pending decision",
+    "body": "T-pending-stale is waiting for human judgment.",
+    "source": "pending_decisions",
+    "task_id": "T-pending-stale",
+    "summary": "Need approval to expand scope to migration cleanup.",
+    "created_at": "__DYNAMIC__"
+  },
+  {
+    "key": "pending:T-relay-gap:user_reply_not_forwarded",
+    "kind": "user_reply_not_forwarded",
+    "severity": "urgent",
+    "title": "User reply not forwarded",
+    "body": "T-relay-gap: user reply has not been relayed to the worker.",
+    "source": "pending_decisions",
+    "task_id": "T-relay-gap",
+    "summary": "Codex review round 3 done; OK to merge?",
+    "created_at": "__DYNAMIC__"
+  }
+]

--- a/tests/test_attention_runtime_integration.py
+++ b/tests/test_attention_runtime_integration.py
@@ -1,0 +1,312 @@
+"""Layer 4 integration test for ``claude-org-runtime attention scan``.
+
+Feeds a hand-curated fixture (``tests/fixtures/attention/``) into the
+runtime CLI and asserts that the ``--dry-run --json`` output matches a
+checked-in golden file. This is the drift-detection seam between ja's
+``.state`` shape and the runtime classifier: if the runtime adds or
+renames an urgent kind ja could plausibly emit, this test fails and
+forces a deliberate vocabulary reconciliation on the ja side.
+
+Design source: ``docs/design/attention-notification.md`` §8 (companion
+to runtime PRs #19 + #20 — attention scan/watch CLI and template
+overrides). The runtime CLI ships in ``claude-org-runtime>=0.1.10``;
+on older runtimes that don't expose the ``attention`` subcommand the
+test skips with a clear message instead of failing.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "attention"
+STATE_EVENTS_JSON = FIXTURE_DIR / "state_events.json"
+PENDING_JSON = FIXTURE_DIR / "pending_decisions.json"
+GOLDEN_JSON = FIXTURE_DIR / "expected_scan.json"
+
+# Mirrors the attention-relevant columns of tools/state_db/schema.sql.
+# Projecting only what the runtime reader touches keeps a non-attention
+# schema migration from breaking this test.
+_EVENTS_SCHEMA = """
+CREATE TABLE events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  occurred_at  TEXT NOT NULL DEFAULT '2026-05-01T00:00:00Z',
+  actor        TEXT,
+  kind         TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+# Dispatch metadata depends on the host OS notification backend
+# (notify-send vs stdout vs PowerShell). The integration contract under
+# test is the classifier output, not the delivery channel, so these
+# fields are stripped before comparing against the golden.
+_DISPATCH_ONLY_KEYS = frozenset({
+    "desktop_dispatched", "bell_dispatched", "delivered",
+})
+
+# Drift canary: the set of urgent attention kinds the fixture is
+# expected to surface at the claude-org-runtime v0.1.11 defaults.
+# Issue #26 demoted relay_gap_suspected / silent_worker_output /
+# pane_silent / worker_stalled / worker_not_reported / worker_error
+# from urgent to normal (anomaly signals are best-effort early
+# warnings, not user-action-required), and introduced the TTL ladder
+# that keeps pending_decision / user_reply_not_forwarded urgent only
+# inside the min..max window. The fixture refreshes the latter pair's
+# timestamps in setUp() so they fall inside that window.
+_EXPECTED_URGENT_KINDS = frozenset({
+    "approval_blocked",
+    "ci_failed",
+    "pending_decision",
+    "user_reply_not_forwarded",
+})
+
+# Placeholder ``created_at`` value used in the golden file for events
+# whose timestamps the test rewrites in :meth:`setUp` so they land in
+# the urgent TTL window. The comparison in
+# :meth:`test_scan_output_matches_golden` swaps the placeholder for
+# the actual rewritten ISO timestamp before asserting equality.
+_DYNAMIC_CREATED_AT = "__DYNAMIC__"
+
+
+def _build_state_db(db_path: Path, events: list[dict]) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(_EVENTS_SCHEMA)
+        for ev in events:
+            conn.execute(
+                "INSERT INTO events (occurred_at, actor, kind, payload_json)"
+                " VALUES (?, ?, ?, ?)",
+                (
+                    ev["occurred_at"],
+                    ev.get("actor"),
+                    ev["kind"],
+                    json.dumps(ev.get("payload", {})),
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _normalize(events: list[dict]) -> list[dict]:
+    """Strip env-dependent dispatch keys and sort by stable ``key``.
+
+    The CLI emits events in a deterministic order (DB events by id ASC,
+    then pending decisions in file order), but sorting both sides keeps
+    the assertion message readable when only one event drifts.
+    """
+    return sorted(
+        ({k: v for k, v in ev.items() if k not in _DISPATCH_ONLY_KEYS}
+         for ev in events),
+        key=lambda ev: ev["key"],
+    )
+
+
+def _runtime_has_attention() -> bool:
+    """Probe for the ``attention`` subcommand on the installed runtime."""
+    exe = shutil.which("claude-org-runtime")
+    if exe is None:
+        return False
+    proc = subprocess.run(
+        [exe, "attention", "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    return proc.returncode == 0
+
+
+class AttentionRuntimeIntegrationTests(unittest.TestCase):
+    """End-to-end check: ja fixture → runtime CLI → golden output."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not _runtime_has_attention():
+            raise unittest.SkipTest(
+                "claude-org-runtime CLI without 'attention' subcommand; "
+                "install claude-org-runtime>=0.1.10 to run this test"
+            )
+        cls.events_spec = json.loads(
+            STATE_EVENTS_JSON.read_text(encoding="utf-8"),
+        )
+        cls.pending = json.loads(
+            PENDING_JSON.read_text(encoding="utf-8"),
+        )
+        cls.golden = json.loads(
+            GOLDEN_JSON.read_text(encoding="utf-8"),
+        )
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.state_dir = Path(self._tmpdir.name) / ".state"
+        self.state_dir.mkdir()
+        _build_state_db(self.state_dir / "state.db", self.events_spec)
+
+        # claude-org-runtime v0.1.11 enforces a TTL ladder on
+        # pending_decision / user_reply_not_forwarded rows: only the
+        # ``pending_decision_min`` (15 min) ≤ age < ``pending_decision_max``
+        # (24h) window keeps the design-default ``urgent`` severity.
+        # Anything older is demoted (or, past the 7d drop, suppressed).
+        # The checked-in fixture timestamps would always fall past that
+        # window at wall-clock test time, so refresh the entries whose
+        # urgent path the test exercises to "30 minutes ago" before
+        # handing the fixture to the runtime. ``T-future-dated`` keeps
+        # its far-future timestamp because
+        # :meth:`test_progress_only_events_are_filtered` asserts it
+        # stays below the urgent threshold.
+        fresh_iso = (
+            datetime.now(timezone.utc) - timedelta(minutes=30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        pending = [dict(entry) for entry in self.pending]
+        self._fresh_created_at: dict[str, str] = {}
+        for entry in pending:
+            tid = entry.get("task_id")
+            if tid == "T-pending-stale":
+                entry["received_at"] = fresh_iso
+                self._fresh_created_at[
+                    f"pending:{tid}:pending_decision"
+                ] = fresh_iso
+            elif tid == "T-relay-gap":
+                entry["user_replied_at"] = fresh_iso
+                self._fresh_created_at[
+                    f"pending:{tid}:user_reply_not_forwarded"
+                ] = fresh_iso
+        (self.state_dir / "pending_decisions.json").write_text(
+            json.dumps(pending, indent=2), encoding="utf-8",
+        )
+
+    def _run_scan(self) -> list[dict]:
+        result = subprocess.run(
+            [
+                "claude-org-runtime", "attention", "scan",
+                "--state-dir", str(self.state_dir),
+                "--dry-run", "--json",
+            ],
+            check=False, capture_output=True, text=True, timeout=30,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"attention scan exited with {result.returncode}; "
+            f"stderr={result.stderr!r}",
+        )
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(
+                f"attention scan stdout was not JSON: {exc}; "
+                f"stdout={result.stdout!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # (1) Whole-fixture comparison against the golden.
+    # ------------------------------------------------------------------
+    def test_scan_output_matches_golden(self) -> None:
+        events = self._run_scan()
+        expected = [dict(ev) for ev in self.golden]
+        for ev in expected:
+            actual_ts = self._fresh_created_at.get(ev.get("key", ""))
+            if actual_ts is not None and ev.get("created_at") == _DYNAMIC_CREATED_AT:
+                ev["created_at"] = actual_ts
+        self.assertEqual(_normalize(events), _normalize(expected))
+
+    # ------------------------------------------------------------------
+    # (2) Each individual acceptance case from design §8 is present.
+    # ------------------------------------------------------------------
+    def test_notify_sent_approval_blocked_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:2")
+        self.assertEqual(ev["kind"], "approval_blocked")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-approval")
+
+    def test_notify_sent_relay_gap_is_normal(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:4")
+        self.assertEqual(ev["kind"], "relay_gap_suspected")
+        self.assertEqual(ev["severity"], "normal")
+
+    def test_notify_sent_silent_output_is_normal(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:5")
+        self.assertEqual(ev["kind"], "silent_worker_output")
+        self.assertEqual(ev["severity"], "normal")
+
+    def test_ci_completed_failed_is_urgent(self) -> None:
+        ev = self._find_event(self._run_scan(), key="event:6")
+        self.assertEqual(ev["kind"], "ci_failed")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["pr"], 42)
+        self.assertEqual(ev["status"], "failed")
+
+    def test_pending_decision_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-pending-stale:pending_decision",
+        )
+        self.assertEqual(ev["kind"], "pending_decision")
+        self.assertEqual(ev["severity"], "urgent")
+        self.assertEqual(ev["task_id"], "T-pending-stale")
+
+    def test_user_reply_not_forwarded_is_urgent(self) -> None:
+        ev = self._find_event(
+            self._run_scan(),
+            key="pending:T-relay-gap:user_reply_not_forwarded",
+        )
+        self.assertEqual(ev["kind"], "user_reply_not_forwarded")
+        self.assertEqual(ev["severity"], "urgent")
+
+    # ------------------------------------------------------------------
+    # (3) Progress-only and below-threshold cases are dropped.
+    # ------------------------------------------------------------------
+    def test_progress_only_events_are_filtered(self) -> None:
+        keys = {ev["key"] for ev in self._run_scan()}
+        # heartbeat (filtered by reader)
+        self.assertNotIn("event:1", keys)
+        # notify_sent with unrecognized subkind (filtered by classifier)
+        self.assertNotIn("event:3", keys)
+        # ci_completed status=success (filtered by classifier)
+        self.assertNotIn("event:7", keys)
+        # pending decision whose received_at is far in the future —
+        # _minutes_since returns negative so the entry stays below the
+        # urgent threshold; this exercises the negative-delta branch
+        # of the staleness check.
+        self.assertNotIn(
+            "pending:T-future-dated:pending_decision", keys,
+        )
+
+    # ------------------------------------------------------------------
+    # (4) Drift canary — the runtime must still classify every kind the
+    # ja fixture is built around as urgent.
+    # ------------------------------------------------------------------
+    def test_all_expected_urgent_kinds_are_recognized(self) -> None:
+        urgent_kinds = {
+            ev["kind"] for ev in self._run_scan()
+            if ev.get("severity") == "urgent"
+        }
+        missing = _EXPECTED_URGENT_KINDS - urgent_kinds
+        self.assertEqual(
+            missing, set(),
+            "runtime is no longer surfacing "
+            f"{sorted(missing)} as urgent against this fixture; either "
+            "the runtime defaults drifted or the fixture aged out of "
+            "the TTL urgent window — reconcile before merging."
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers.
+    # ------------------------------------------------------------------
+    def _find_event(self, events: list[dict], *, key: str) -> dict:
+        for ev in events:
+            if ev.get("key") == key:
+                return ev
+        self.fail(
+            f"event with key={key!r} not found in scan output; "
+            f"got keys={[ev.get('key') for ev in events]!r}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/org_extension_schema.json
+++ b/tools/org_extension_schema.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Source of truth for per-role settings.local.json shape. Both tools/check_role_configs.py and docs/skills/org-setup/references/permissions.md project from this schema. See Issue #85.",
+  "$comment": "Source of truth for per-role settings.local.json shape (Layer 2 audit constraints in `roles[*]`, concrete worker templates in `worker_roles[*]`, Phase 1 PR3 also Layer 3 sandbox bodies in `roles.{secretary,dispatcher,curator}.sandbox`). Consumers: tools/check_role_configs.py validates emitted `.claude/settings.local.json` files against `roles[*]` audit constraints; docs/skills/org-setup/references/permissions.md projects the per-role shape; tools/check_runtime_schema_drift.py byte-compares this file against the schema bundled with `claude-org-runtime` (skipped outside the pin window) and `--semantic` runs the semantic golden drift check against tests/fixtures/runtime_schema_drift/sandbox_intent/ — which now includes role_secretary.json / role_dispatcher.json / role_curator.json fixtures that load this file via `schema_source: \"shipped\"`. See Issue #85 for the original schema-as-SoT decision and Refs claude-org-ja#378 #376 for the Phase 1 sandbox surface.",
   "version": 1,
   "global": {
     "forbidden_allow_exact": [
@@ -26,6 +26,7 @@
     "check-worker-boundary.sh",
     "block-dispatcher-out-of-scope.sh"
   ],
+  "$comment_roles_sandbox": "Phase 1 schema surface: each entry under `roles.<role>` may also include an optional `sandbox` object using the same shape and structured-anchor entry form documented under `worker_roles.$comment_sandbox` / `worker_roles.$comment_sandbox_anchor`. This lets secretary / dispatcher / curator declare Layer 3 sandbox intent alongside the existing Layer 2 `required_allow` / `required_deny` audit constraints. Roles without `sandbox` are treated as sandbox-disabled (backward compatible). Phase 1 PR3 (Refs claude-org-ja#378 #376) lands concrete bodies for `roles.secretary` / `roles.dispatcher` / `roles.curator`; each role's per-`sandbox` `$comment_sandbox` field documents the contract sections it is driven from and which prescriptions are deferred (e.g. curator knowledge/raw move-only is operation-semantic and not mechanizable here). `worker_roles.*` concrete bodies are NOT landed in PR3 — they need a `sandbox_by_pattern` schema decision (deferred to PR4). See `docs/contracts/role-pattern-sandbox-contract.md` for the contract that all bodies must satisfy.",
   "roles": {
     "repo_shared": {
       "description": "Repo-shared settings (.claude/settings.json) — tracked in git; hosts repo-wide safety hooks (block-no-verify, block-dangerous-git).",
@@ -85,6 +86,7 @@
     "secretary": {
       "description": "Secretary (窓口) — repo .claude/settings.local.json.",
       "docs_section": "窓口",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the secretary role. Read scope = secretary's worker_dir (= live repo at claude_org_path) plus the workers_dir at <claude_org_path>/../workers (per docs/contracts/role-pattern-sandbox-contract.md §3.1.1 prescribed read surface). Layer 3 denyRead covers credential paths named in §3.1.1 — worker_dir-anchored .env / .env.* / **/credentials* / **/*.pem, plus home-anchored ~/.config/gh/hosts.yml / ~/.aws/** / ~/.ssh/** with §1.3 adaptive suppression. The home-anchored entries carry a `layer2Fallback` string each; per worker_roles.$comment_sandbox_anchor that string is intended as the Layer-2 permissions.deny mirror emitted when the Layer-3 entry is suppressed (e.g. on WSL). NOTE: claude-org-runtime up to and including the version pinned in pyproject.toml does NOT yet auto-mirror `layer2Fallback` into permissions.deny — the schema declares the intent but the runtime evaluator only preserves the field on the suppression record's entry. So today these strings are forward-looking documentation; effective Layer 2 deny for credentials still needs to be declared via roles.secretary.required_deny. Settings.local.json paths under workers/ are NOT mirrored here — the existing roles.secretary.required_deny rules enforce those at Layer 2 (Edit/Write tool path) and Layer 3 cannot reach the worker dirs anyway. Knowledge/raw and curated/ scrub policies remain convention-only per knowledge-curation-contract.md and are NOT mechanized here. ~/.claude/plans/ from §3.1.1 read surface is NOT in additionalDirectories because the substitution mapping has no {home} placeholder (only worker_dir / claude_org_path / Pattern B context); a runtime-side substitution extension is the natural fix and is tracked as a follow-up.",
       "settings_paths": [".claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -146,7 +148,9 @@
         "Write(*/workers/*/.claude/settings.local.json)",
         "Edit(*/workers/*/.claude/settings.local.json)",
         "Write(*/workers/*/.worktrees/*/.claude/settings.local.json)",
-        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)"
+        "Edit(*/workers/*/.worktrees/*/.claude/settings.local.json)",
+        "Write(*/.worktrees/*/.claude/settings.local.json)",
+        "Edit(*/.worktrees/*/.claude/settings.local.json)"
       ],
       "required_hooks": [
         {
@@ -158,11 +162,65 @@
       "disallow_allow_regex": [
         "^Bash\\(\\*\\)$",
         "^Bash$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}/../workers"
+          ],
+          "denyRead": [
+            {
+              "anchor": "worker_dir",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/credentials*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/*.pem)"
+            },
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.aws/*)"
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.ssh/*)"
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "dispatcher": {
       "description": "Dispatcher — .dispatcher/.claude/settings.local.json. Runs in bypassPermissions mode (Sonnet constraint), so permissions.allow / deny are no-ops; PreToolUse hooks are the only enforcement layer.",
       "docs_section": "ディスパッチャー",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the dispatcher role. Layer 3 is the primary enforcement vector here because permission_mode=bypassPermissions makes Layer 2 a no-op (docs/contracts/role-pattern-sandbox-contract.md §3.2 line 270-272 / §3.2.3 line 325). Therefore the structured-anchor entries deliberately omit `layer2Fallback` (Major 1 from the Codex pre-design review): a Layer 2 mirror would be discarded under bypassPermissions and giving operators the impression that a fallback is in place would mis-state the protection level. Read scope = worker_dir (.dispatcher/) + claude_org_path (broad, per §3.2.1 read surface enumeration: .state/, knowledge/raw/, registry/, tools/). denyRead covers credential paths (home-anchored ~/.aws/** / ~/.ssh/** / ~/.config/gh/hosts.yml plus claude_org_path-anchored .env / .env.* / **/credentials* / **/*.pem) so Bash-mediated reads via cat/head/etc. are caught at the syscall layer. denyWrite covers paths the dispatcher must NOT modify (tools/ dashboard/ tests/ .claude/skills/ docs/ registry/ — derived from §3.2.2 Denied writes) so Bash redirect (echo > tools/foo) is caught at Layer 3 — closing the §3.2.4 carve-out where .hooks/block-dispatcher-out-of-scope.sh only matches Edit/Write. workers_dir is intentionally NOT in denyWrite at Layer 3: it falls outside read_roots so a denyWrite entry would be suppressed; that surface is protected at Layer 4 by .hooks/block-dispatcher-out-of-scope.sh + .hooks/block-workers-delete.sh. Residual risk: if the sandbox is unavailable (failIfUnavailable=false fall-open), Layer 2 is no-op AND Layer 3 is absent, leaving only Layer 4 hooks for credentials / Bash-redirect — see PR body for the deferred follow-up.",
       "settings_paths": [".dispatcher/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [
@@ -202,11 +260,90 @@
         "^Bash\\(\\*\\)$",
         "^Bash$",
         "^Bash\\(git \\*\\)$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}"
+          ],
+          "denyRead": [
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true
+            }
+          ],
+          "denyWrite": [
+            {
+              "anchor": "claude_org_path",
+              "path": "tools",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "dashboard",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "tests",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".claude/skills",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "docs",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "registry",
+              "suppressOnSymlinkEscape": true
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "curator": {
       "description": "Curator — .curator/.claude/settings.local.json (narrow / empty by design).",
       "docs_section": "キュレーター",
+      "$comment_sandbox": "Phase 1 PR3 (Refs claude-org-ja#378 #376): concrete sandbox body for the curator role. Read scope = worker_dir (.curator/) + {claude_org_path}/knowledge — narrow per docs/contracts/role-pattern-sandbox-contract.md §3.3.1 (curator reads knowledge/raw/, knowledge/curated/, knowledge/skill-candidates.md only) and §3.3.3 Phase 1 prescription (additionalDirectories = [knowledge, .curator]). denyRead covers credential paths (worker_dir-anchored .env / .env.* / **/credentials* / **/*.pem, plus home-anchored ~/.config/gh/hosts.yml / ~/.aws/** / ~/.ssh/** with §1.3 adaptive suppression). The credential entries carry a `layer2Fallback` string each, intended as the Layer-2 permissions.deny mirror per worker_roles.$comment_sandbox_anchor — same forward-looking caveat as roles.secretary: claude-org-runtime up to and including the version pinned in pyproject.toml does NOT yet auto-mirror `layer2Fallback`, so today these strings are documentation. denyWrite enumerates the org-internal paths the curator must NOT modify (.state/ registry/ tools/ dashboard/ .claude/skills/ workers_dir/**, from §3.3.2 / §3.3.3 prescription). With the narrow read scope these denyWrite entries fall outside read_roots and are SUPPRESSED at Layer 3 — by design: the entries document intent and would activate if read scope were ever widened, while at runtime the same paths are protected by absence-of-mount (a path that is not in the bwrap mount namespace cannot be written to from inside the sandbox). Major 2 from the Codex pre-design review: knowledge/raw/ deletion-vs-move discipline is operation-semantic (rm vs mv), NOT path-based — Layer 3 cannot express 'move-only' via path globs (denyWrite knowledge/raw/** would break legitimate move-to-archive; allow knowledge/raw/** would not stop rm). That row is therefore deferred as a Bash-matcher hook follow-up and is intentionally NOT mechanized in this body.",
       "settings_paths": [".curator/.claude/settings.local.json"],
       "closed_world": true,
       "required_allow": [],
@@ -218,7 +355,92 @@
         "^Bash$",
         "^Bash\\(git .*\\)$",
         "^Bash\\(git:\\*\\)$"
-      ]
+      ],
+      "sandbox": {
+        "enabled": true,
+        "filesystem": {
+          "additionalDirectories": [
+            "{claude_org_path}/knowledge"
+          ],
+          "denyRead": [
+            {
+              "anchor": "worker_dir",
+              "path": ".env",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": ".env.*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(.env.*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/credentials*",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/credentials*)"
+            },
+            {
+              "anchor": "worker_dir",
+              "path": "**/*.pem",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(**/*.pem)"
+            },
+            {
+              "anchor": "home",
+              "path": ".config/gh/hosts.yml",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.config/gh/hosts.yml)"
+            },
+            {
+              "anchor": "home",
+              "path": ".aws/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.aws/*)"
+            },
+            {
+              "anchor": "home",
+              "path": ".ssh/**",
+              "suppressOnSymlinkEscape": true,
+              "layer2Fallback": "Read(~/.ssh/*)"
+            }
+          ],
+          "denyWrite": [
+            {
+              "anchor": "claude_org_path",
+              "path": ".state",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "registry",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "tools",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": "dashboard",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "claude_org_path",
+              "path": ".claude/skills",
+              "suppressOnSymlinkEscape": true
+            },
+            {
+              "anchor": "absolute",
+              "path": "{claude_org_path}/../workers/**",
+              "suppressOnSymlinkEscape": true
+            }
+          ]
+        },
+        "failIfUnavailable": false
+      }
     },
     "worker": {
       "description": "Worker (dynamic template, audit constraints) — <worker_dir>/.claude/settings.local.json. See also top-level worker_roles section for the concrete templates that generate_worker_settings.py emits.",
@@ -234,14 +456,36 @@
         "Bash(git branch:*)",
         "Bash(git checkout:*)",
         "Bash(git switch:*)",
-        "Bash(git worktree:*)",
         "Bash(git stash:*)",
+        "Bash(git fetch:*)",
+        "Bash(git merge:*)",
         "Bash(sleep:*)"
       ],
       "allowed_allow_regex": [],
       "required_deny": [
         "Bash(git push *)",
         "Bash(git push)",
+        "Bash(git worktree)",
+        "Bash(git worktree *)",
+        "Bash(git pull)",
+        "Bash(git pull *)",
+        "Bash(git submodule)",
+        "Bash(git submodule *)",
+        "Bash(git lfs)",
+        "Bash(git lfs *)",
+        "Bash(git gc)",
+        "Bash(git gc *)",
+        "Bash(git filter-branch)",
+        "Bash(git filter-branch *)",
+        "Bash(git filter-repo)",
+        "Bash(git filter-repo *)",
+        "Bash(git replace)",
+        "Bash(git replace *)",
+        "Bash(git update-ref)",
+        "Bash(git update-ref *)",
+        "Bash(git config --global *)",
+        "Bash(git config --local *)",
+        "Bash(git config --worktree *)",
         "Bash(rm -rf *)",
         "Bash(rm -r *)"
       ],
@@ -264,20 +508,95 @@
         {
           "event": "PreToolUse",
           "matcher_contains": "Bash",
+          "command_contains": "block-dangerous-git.sh"
+        },
+        {
+          "event": "PreToolUse",
+          "matcher_contains": "Bash",
+          "command_contains": "block-no-verify.sh"
+        },
+        {
+          "event": "PreToolUse",
+          "matcher_contains": "Bash",
           "command_contains": "block-org-structure.sh"
         }
       ],
       "disallow_allow_regex": [
         "^Bash\\(\\*\\)$",
         "^Bash$",
-        "^Bash\\(git push.*\\)$"
+        "^Bash\\(git push.*\\)$",
+        "^Bash\\(git worktree.*\\)$"
       ]
     }
   },
   "worker_roles": {
-    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time.",
+    "$comment": "Concrete templates historically emitted by tools/generate_worker_settings.py. Phase 4 (Issue #129) moved generation into the claude-org-runtime package (run `claude-org-runtime settings generate ...`). This section is kept here for the audit constraints in roles.worker — drift tooling (tools/check_role_configs.py) validates emitted files against them. Placeholders {worker_dir} and {claude_org_path} are substituted at generation time; Pattern B context placeholders are documented under `$comment_sandbox_anchor`.",
+    "$comment_sandbox": "Phase 1 schema surface: each `worker_roles.<role>` may include an optional `sandbox` object of the form {enabled: bool, filesystem: {denyRead: [entry], denyWrite: [entry], additionalDirectories: [string]}, failIfUnavailable: bool, default false}. The sandbox object is forwarded as-is to the rendered settings.local.json (consumed by claude-org-ja's bwrap launcher). At render time the generator applies Layer 3 suppression: each filesystem.denyRead / denyWrite entry whose realpath escapes the sandbox read roots (worker_dir + additionalDirectories) is dropped from the rendered sandbox object because the sandbox cannot reach the path anyway. This is common on WSL (where /home/<user>/... may be a /mnt/c/... symlink) and devcontainers (/workspaces symlinks). Layer 2 `permissions.deny` `Read(...)` / `Write(...)` entries are NEVER suppressed. Suppression metadata is exposed via `claude-org-runtime settings show --explain`. Roles without `sandbox` are treated as sandbox-disabled (backward compatible).",
+    "$comment_sandbox_by_pattern": "Phase 1 PR4 (Refs claude-org-ja#378 #376): a worker role may declare `sandbox_by_pattern` instead of the single `sandbox` field. Shape: `{A?: <sandbox-object>, B?: <sandbox-object>, C?: <sandbox-object>}` keyed by dispatch pattern (the pattern keys are exactly 'A' / 'B' / 'C' matching the resolver / delegate payload normalization). `sandbox` and `sandbox_by_pattern` are MUTUALLY EXCLUSIVE on worker roles; the runtime errors if both are declared. Org roles (`roles.{secretary,dispatcher,curator}`) keep the single `sandbox` shape and may NOT declare `sandbox_by_pattern`. At render time the generator picks `sandbox_by_pattern[--pattern]` and treats it as the role's sandbox; missing pattern keys for the requested pattern are an authoring error (not a silent fallthrough), so Pattern B's distinct additionalDirectories / base_clone surface is never replaced by an A/C surface. Pattern B's command-isolation layer (Bash(git worktree *) deny + .hooks/block-dangerous-git.sh attachment) is intentionally NOT modeled here — runtime sandbox_by_pattern is path-isolation only; command isolation lives in `worker_roles.<role>.permissions.deny` / `.hooks` and is the responsibility of Phase 2 #379 (NOT this PR). Pattern C sub-modes (ephemeral vs gitignored_repo_root) share a single `C` body — the sub-mode-specific surface (worker_dir = host repo root for `gitignored_repo_root`) is captured at dispatch time via `--worker-dir`. Concrete bodies are driven by docs/contracts/role-pattern-sandbox-contract.md §4 (per-role per-pattern read/write surface) and worker-git-guardrails-design.md §2 (Pattern B Git metadata boundary categories B1–B5). Cross-cutting design constraints landed by Codex pre-design review: (a) Pattern B refs scope is THIS-branch only — `<base_clone>/.git/refs/heads/{branch_ref}` carve-out, NEVER `<base_clone>/.git/refs/heads` whole, so cross-branch ref isolation (§4.2.1 row 'refs/heads/<other_branch>': read allowed, write denied) holds; (b) for `claude-org-self-edit` Pattern B (`live_repo_worktree`), additionalDirectories MUST scope to `{worker_dir}` (auto-mounted) + `<base_clone>/.git/...` carve-outs only — adding `<base_clone>` root or `{claude_org_path}` root would make the live repo's working tree writable and break check-worker-boundary.sh's WORKER_DIR boundary (Phase 0 §3.4 / §4.4). Knowledge/raw raw-write carve-out for self-edit Pattern B is a residual gap deferred to Phase 2 #379 — adding `{claude_org_path}/knowledge/raw` here would re-introduce a writable subtree of the live repo's working tree from inside a worktree that is not the live repo, conflicting with (b); the default-role Pattern B carve-out is unaffected because its base_clone is the registered project's clone, not claude_org_path.",
+    "$comment_sandbox_anchor": "Phase 1 schema surface: `denyRead` / `denyWrite` entries may now be either (a) a legacy raw string (anchored at worker_dir for relative paths, treated literally for absolute paths) or (b) a structured object {anchor: 'home'|'worker_dir'|'claude_org_path'|'base_clone'|'absolute', path: string, suppressOnSymlinkEscape: bool default true, layer2Fallback: optional Layer-2 permissions.deny mirror entry}. The structured form fixes the legacy ambiguity where '~/.aws/**'-style entries were misjudged as worker_dir-relative. 'home' resolves to the current user's home directory, 'absolute' is treated literally, 'worker_dir' / 'claude_org_path' / 'base_clone' use the corresponding generator-context substitutions. When `suppressOnSymlinkEscape` is false the entry is preserved even if its realpath escapes the sandbox read roots (useful for entries the operator wants in the rendered output regardless of reachability). When `layer2Fallback` is set, the value is the Layer-2 `permissions.deny` mirror string INTENDED to be emitted whenever the Layer-3 entry is suppressed; the field is forward-looking — `claude-org-runtime` versions up to and including the one pinned by `tools/check_runtime_schema_drift.py` do NOT auto-mirror it into `permissions.deny`, the runtime evaluator only preserves the field on the suppression record's `entry`. Effective Layer 2 deny for credentials therefore still has to be declared via `roles.<role>.required_deny` / `worker_roles.<role>.permissions.deny` directly, not relied on via `layer2Fallback` alone. Pattern B context placeholders ({base_clone}, {task_id}, {branch_ref}, {pattern}) are recognized substitution variables in addition to the legacy {worker_dir} / {claude_org_path}; they are substituted in entry.path and additionalDirectories before realpath evaluation when supplied via the generator API. Backward compat: legacy raw-string entries continue to parse via the runtime adapter and need not be migrated when this schema surface is adopted.",
     "default": {
       "description": "Standard worker template — git read/write within the worktree, no push, no recursive delete. Mirrors the historical org-delegate Step 3 inline JSON.",
+      "$comment_sandbox": "Phase 1 PR4 (Refs claude-org-ja#378 #376): concrete sandbox_by_pattern body for worker_roles.default. The Layer 3 surface is keyed by dispatch pattern per docs/contracts/role-pattern-sandbox-contract.md §4.1 (Pattern A) / §4.2 (Pattern B default variant) / §4.3 (Pattern C ephemeral and gitignored_repo_root). Pattern A and Pattern C add only the knowledge/raw carve-out (§5.1: full-mode workers may write `<claude_org_path>/knowledge/raw/YYYY-MM-DD-<topic>.md`); the worker_dir itself is auto-mounted and does not need to be re-listed. Pattern B union per §4.2.1 / worker-git-guardrails-design.md §2 categories B1+B2 (this worktree's metadata + shared object store + this branch's ref + packed-refs) is `<base_clone>/.git/worktrees/<task_id>`, `<base_clone>/.git/objects`, `<base_clone>/.git/refs/heads/<branch_ref>`, `<base_clone>/.git/packed-refs`. Refs scope is THIS-branch only by design (§4.2.1 cross-task isolation): listing `<base_clone>/.git/refs/heads` whole would let the worker rewrite a sibling worktree's branch ref. `<base_clone>/.git/packed-refs` is added because git itself rewrites this file as part of normal commit / pack-refs operations (§4.2.1 row); without it Pattern B workers would fail any operation that touches packed refs. denyRead carries the standard credential set with `layer2Fallback` strings for forward compatibility (current runtime preserves the field but does not auto-mirror it into permissions.deny — see $comment_sandbox_anchor); the corresponding Layer 2 mirrors live in `worker_roles.default.permissions.deny` directly so secret reads remain blocked even when Layer 3 is suppressed on WSL. denyWrite is empty: by virtue of additionalDirectories not including `<base_clone>` root / sibling worktrees / `.git/HEAD` / `.git/config`, those paths are already not writable; explicit denyWrite on subpaths inside additionalDirectories would just add suppression noise on platforms with realpath escapes. Layer 4 hooks (.hooks/block-org-structure.sh, .hooks/check-worker-boundary.sh) handle org-structure / out-of-WORKER_DIR write boundaries inside the mounted writable surface. Pattern A's branch ref deny for `<base_clone>/.git/HEAD` etc. (§4.1 / §5.2 worker × Pattern A row) is implicit: Pattern A workers operate in their own clone, no base_clone is supplied at dispatch (--base-clone null), and `{base_clone}` placeholders therefore never substitute into A's body. RESIDUAL GAP (Phase 2): the knowledge/raw mount is whole-directory; the §5.1 filename / depth carve-out (`YYYY-MM-DD-<kebab-topic>.md` and full-mode-only) is enforced ONLY at Layer 4 by .hooks/check-worker-boundary.sh allow path 3, NOT at Layer 3. Layer 3 cannot express the kebab-case filename rule, and the schema cannot express the verification-depth conditional. Phase 2 may add a Bash-matcher hook for tighter knowledge/raw discipline if drift is observed.",
+      "sandbox_by_pattern": {
+        "A": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{claude_org_path}/knowledge/raw"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ]
+          },
+          "failIfUnavailable": false
+        },
+        "B": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{base_clone}/.git/worktrees/{task_id}",
+              "{base_clone}/.git/objects",
+              "{base_clone}/.git/refs/heads/{branch_ref}",
+              "{base_clone}/.git/packed-refs",
+              "{claude_org_path}/knowledge/raw"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ]
+          },
+          "failIfUnavailable": false
+        },
+        "C": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{claude_org_path}/knowledge/raw"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ]
+          },
+          "failIfUnavailable": false
+        }
+      },
       "permissions": {
         "allow": [
           "Bash(git add:*)",
@@ -288,15 +607,75 @@
           "Bash(git branch:*)",
           "Bash(git checkout:*)",
           "Bash(git switch:*)",
-          "Bash(git worktree:*)",
           "Bash(git stash:*)",
+          "Bash(git fetch:*)",
+          "Bash(git merge:*)",
           "Bash(sleep:*)"
         ],
         "deny": [
           "Bash(git push *)",
           "Bash(git push)",
+          "Bash(git worktree)",
+          "Bash(git worktree *)",
+          "Bash(git -C * worktree)",
+          "Bash(git -C * worktree *)",
+          "Bash(git -C * fetch)",
+          "Bash(git -C * fetch *)",
+          "Bash(git pull)",
+          "Bash(git pull *)",
+          "Bash(git -C * pull)",
+          "Bash(git -C * pull *)",
+          "Bash(git remote add *)",
+          "Bash(git remote set-url *)",
+          "Bash(git remote remove *)",
+          "Bash(git remote rm *)",
+          "Bash(git -C * remote add *)",
+          "Bash(git -C * remote set-url *)",
+          "Bash(git -C * remote remove *)",
+          "Bash(git -C * remote rm *)",
+          "Bash(git submodule)",
+          "Bash(git submodule *)",
+          "Bash(git -C * submodule)",
+          "Bash(git -C * submodule *)",
+          "Bash(git lfs)",
+          "Bash(git lfs *)",
+          "Bash(git -C * lfs)",
+          "Bash(git -C * lfs *)",
+          "Bash(git gc)",
+          "Bash(git gc *)",
+          "Bash(git -C * gc)",
+          "Bash(git -C * gc *)",
+          "Bash(git filter-branch)",
+          "Bash(git filter-branch *)",
+          "Bash(git filter-repo)",
+          "Bash(git filter-repo *)",
+          "Bash(git -C * filter-branch *)",
+          "Bash(git -C * filter-repo *)",
+          "Bash(git replace)",
+          "Bash(git replace *)",
+          "Bash(git -C * replace *)",
+          "Bash(git update-ref)",
+          "Bash(git update-ref *)",
+          "Bash(git -C * update-ref *)",
+          "Bash(git config --global *)",
+          "Bash(git config --local *)",
+          "Bash(git config --worktree *)",
+          "Bash(git -C * config --global *)",
+          "Bash(git -C * config --local *)",
+          "Bash(git -C * config --worktree *)",
+          "Bash(git reflog expire *)",
+          "Bash(git reflog delete *)",
+          "Bash(git -C * reflog expire *)",
+          "Bash(git -C * reflog delete *)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)",
+          "Read(~/.aws/*)",
+          "Read(~/.ssh/*)"
         ]
       },
       "hooks": {
@@ -320,6 +699,14 @@
               {
                 "type": "command",
                 "command": "bash \"{claude_org_path}/.hooks/block-git-push.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-dangerous-git.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-no-verify.sh\""
               },
               {
                 "type": "command",
@@ -336,6 +723,46 @@
     },
     "claude-org-self-edit": {
       "description": "Worker that edits the claude-org repo itself (e.g. tools/, .claude/skills/). Drops block-org-structure.sh hooks because by definition this role must touch org structure paths. check-worker-boundary.sh remains the boundary check.",
+      "$comment_sandbox": "Phase 1 PR4 (Refs claude-org-ja#378 #376): concrete sandbox_by_pattern body for worker_roles.claude-org-self-edit. Pattern A is INTENTIONALLY OMITTED — the resolver (`tools/resolve_worker_layout.py:643`) refuses `pattern=A` for this role because Pattern A would land the worker inside `<workers_dir>/claude-org-ja/` (a separate clone) and break the live-repo single-`.git` invariant from Issue #289. Including a Pattern A key here would silently sanction a layout the resolver rejects. Pattern B handles the canonical `live_repo_worktree` variant: worker_dir = `<claude_org_path>/.worktrees/<task_id>/`, base_clone = claude_org_path. additionalDirectories covers the per-worktree `.git/worktrees/<task_id>/` admin dir + shared object store + this branch's ref only — the cross-row constraint from worker-git-guardrails-design.md §2 (B1+B2 categories writable; B3 `<base_clone>/.git/HEAD`/`config` / other branch refs read-only; B4 sibling worktrees denied). CRITICAL: additionalDirectories MUST NOT include `<base_clone>` root or `{claude_org_path}` root — both resolve to the live repo and would expose the secretary's working tree as writable, breaking check-worker-boundary.sh's WORKER_DIR boundary (Phase 0 §3.4 `claude-org-self-edit Pattern B` row / §4.4.4 attribution table). The refs scope is THIS-branch only (`<base_clone>/.git/refs/heads/<branch_ref>`), NOT `<base_clone>/.git/refs/heads` whole, to preserve cross-task isolation. Pattern C covers the `gitignored_repo_root` sub-mode only (worker_dir = the existing repo's root, no worktree, no base_clone). additionalDirectories is empty for C: worker_dir is auto-mounted and there is no shared base. RESIDUAL GAP for Pattern B: knowledge/raw raw-write carve-out (`<claude_org_path>/knowledge/raw/YYYY-MM-DD-<topic>.md`, allowed by check-worker-boundary.sh allow path 3) is NOT mounted writable here — adding `{claude_org_path}/knowledge/raw` would re-introduce a writable subtree of the live repo's working tree, conflicting with the live-repo-mount prohibition above. Self-edit Pattern B retro notes therefore land via the worktree-local `<worker_dir>/knowledge/raw/...` path; the live-repo write convention codified in §4.4.5 / §5.1 is deferred to Phase 2 #379 (will need either a worktree-to-livepath mover hook or a more granular sandbox surface than the current runtime placeholder set supports).",
+      "sandbox_by_pattern": {
+        "B": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{base_clone}/.git/worktrees/{task_id}",
+              "{base_clone}/.git/objects",
+              "{base_clone}/.git/refs/heads/{branch_ref}",
+              "{base_clone}/.git/packed-refs"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ]
+          },
+          "failIfUnavailable": false
+        },
+        "C": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ]
+          },
+          "failIfUnavailable": false
+        }
+      },
       "permissions": {
         "allow": [
           "Bash(git add:*)",
@@ -346,15 +773,75 @@
           "Bash(git branch:*)",
           "Bash(git checkout:*)",
           "Bash(git switch:*)",
-          "Bash(git worktree:*)",
           "Bash(git stash:*)",
+          "Bash(git fetch:*)",
+          "Bash(git merge:*)",
           "Bash(sleep:*)"
         ],
         "deny": [
           "Bash(git push *)",
           "Bash(git push)",
+          "Bash(git worktree)",
+          "Bash(git worktree *)",
+          "Bash(git -C * worktree)",
+          "Bash(git -C * worktree *)",
+          "Bash(git -C * fetch)",
+          "Bash(git -C * fetch *)",
+          "Bash(git pull)",
+          "Bash(git pull *)",
+          "Bash(git -C * pull)",
+          "Bash(git -C * pull *)",
+          "Bash(git remote add *)",
+          "Bash(git remote set-url *)",
+          "Bash(git remote remove *)",
+          "Bash(git remote rm *)",
+          "Bash(git -C * remote add *)",
+          "Bash(git -C * remote set-url *)",
+          "Bash(git -C * remote remove *)",
+          "Bash(git -C * remote rm *)",
+          "Bash(git submodule)",
+          "Bash(git submodule *)",
+          "Bash(git -C * submodule)",
+          "Bash(git -C * submodule *)",
+          "Bash(git lfs)",
+          "Bash(git lfs *)",
+          "Bash(git -C * lfs)",
+          "Bash(git -C * lfs *)",
+          "Bash(git gc)",
+          "Bash(git gc *)",
+          "Bash(git -C * gc)",
+          "Bash(git -C * gc *)",
+          "Bash(git filter-branch)",
+          "Bash(git filter-branch *)",
+          "Bash(git filter-repo)",
+          "Bash(git filter-repo *)",
+          "Bash(git -C * filter-branch *)",
+          "Bash(git -C * filter-repo *)",
+          "Bash(git replace)",
+          "Bash(git replace *)",
+          "Bash(git -C * replace *)",
+          "Bash(git update-ref)",
+          "Bash(git update-ref *)",
+          "Bash(git -C * update-ref *)",
+          "Bash(git config --global *)",
+          "Bash(git config --local *)",
+          "Bash(git config --worktree *)",
+          "Bash(git -C * config --global *)",
+          "Bash(git -C * config --local *)",
+          "Bash(git -C * config --worktree *)",
+          "Bash(git reflog expire *)",
+          "Bash(git reflog delete *)",
+          "Bash(git -C * reflog expire *)",
+          "Bash(git -C * reflog delete *)",
           "Bash(rm -rf *)",
-          "Bash(rm -r *)"
+          "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)",
+          "Read(~/.aws/*)",
+          "Read(~/.ssh/*)"
         ]
       },
       "hooks": {
@@ -374,6 +861,14 @@
               {
                 "type": "command",
                 "command": "bash \"{claude_org_path}/.hooks/block-git-push.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-dangerous-git.sh\""
+              },
+              {
+                "type": "command",
+                "command": "bash \"{claude_org_path}/.hooks/block-no-verify.sh\""
               }
             ]
           }
@@ -386,6 +881,80 @@
     },
     "doc-audit": {
       "description": "Read-only investigation worker — no Write/Edit allow, no commit/branch mutation. Suitable for survey / audit / reporting tasks where the worker should not modify the worktree.",
+      "$comment_sandbox": "Phase 1 PR4 (Refs claude-org-ja#378 #376): concrete sandbox_by_pattern body for worker_roles.doc-audit. Per docs/contracts/role-pattern-sandbox-contract.md §3.5 / §4.6 the doc-audit role's WRITE surface is pattern-orthogonal (the read-only audit constraint dominates) but the READ surface inherits from the underlying pattern (§4.6.1: 'Identical to the underlying pattern'). Pattern A / Pattern C only need worker_dir + Plan-mode carve-out; Pattern B additionally needs base_clone Git metadata (§4.2.1 categories B1+B2: this worktree's admin dir, shared object store, this branch's ref, packed-refs) so doc-audit's allowed Bash commands (`git status:*` / `git diff:*` / `git log:*`) can resolve `<worker_dir>/.git` (the gitdir pointer file) into the base_clone's Git metadata. Layer 3 closes the §4.6.2 write gap that Layer 2 + Layer 4 alone cannot: `{anchor: 'worker_dir', path: '**', suppressOnSymlinkEscape: false}` denies any write inside the worktree at the syscall level — including Bash redirects (`git diff > /tmp/x`, `git log > log`, `tee`), tool-generated temp files, and any other write channel that bypasses the `Edit` / `Write` Layer 2 deny. `suppressOnSymlinkEscape: false` is intentional: even on platforms where `<worker_dir>` would be suppressed off (handcraft profile-tightened style), we want the deny to stay in the rendered surface so the audit role's read-only invariant is not platform-dependent. Pattern B additionally denyWrites the base_clone Git metadata carve-outs (worktrees/<task_id>, objects, refs/heads/<branch_ref>, packed-refs) so the additional read mounts cannot be exploited as a write channel — read-only by intent on top of additionalDirectories. denyRead carries the standard credential set with `layer2Fallback` strings (forward-compat); the corresponding Layer 2 mirrors live in `worker_roles.doc-audit.permissions.deny`. Plan-mode carve-out (§4.6.2 lines 919-921 mark `~/.claude/plans/**` and `<worker_dir>/.claude/plans/**` as 'NOT denied'): `<worker_dir>/.claude/plans` is added to additionalDirectories so the contract surface is encoded. PRECEDENCE ASSUMPTION (residual gap): bwrap evaluates additionalDirectories AFTER denyWrite globs — the more-specific `<worker_dir>/.claude/plans` write-mount overrides the parent `<worker_dir>/**` deny because the additionalDirectories bind is the last mount applied at that path. This assumption is launcher-implementation-dependent and is NOT empirically verified in this PR. Operators relying on Plan-mode persistence in doc-audit should treat it as best-effort; the redundant Layer 2 `Edit` / `Write` deny means Plan files written via Claude tools are blocked regardless of L3 outcome. The home-anchored Plan path (`~/.claude/plans/**`) is a RESIDUAL GAP: the runtime's additionalDirectories is a flat string list (no per-entry anchor), and a raw '~/...' string would be misinterpreted as worker_dir-relative by `_normalize_sandbox_entry`. Encoding the home-anchored carve-out requires either (a) a runtime extension to support anchor='home' in additionalDirectories, or (b) the launcher tilde-expanding additionalDirectories paths; both are deferred to Phase 2.",
+      "sandbox_by_pattern": {
+        "A": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{worker_dir}/.claude/plans"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ],
+            "denyWrite": [
+              {"anchor": "worker_dir", "path": "**", "suppressOnSymlinkEscape": false}
+            ]
+          },
+          "failIfUnavailable": false
+        },
+        "B": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{worker_dir}/.claude/plans",
+              "{base_clone}/.git/worktrees/{task_id}",
+              "{base_clone}/.git/objects",
+              "{base_clone}/.git/refs/heads/{branch_ref}",
+              "{base_clone}/.git/packed-refs"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ],
+            "denyWrite": [
+              {"anchor": "worker_dir", "path": "**", "suppressOnSymlinkEscape": false},
+              {"anchor": "base_clone", "path": ".git/worktrees/{task_id}/**", "suppressOnSymlinkEscape": false},
+              {"anchor": "base_clone", "path": ".git/objects/**", "suppressOnSymlinkEscape": false},
+              {"anchor": "base_clone", "path": ".git/refs/heads/{branch_ref}", "suppressOnSymlinkEscape": false},
+              {"anchor": "base_clone", "path": ".git/packed-refs", "suppressOnSymlinkEscape": false}
+            ]
+          },
+          "failIfUnavailable": false
+        },
+        "C": {
+          "enabled": true,
+          "filesystem": {
+            "additionalDirectories": [
+              "{worker_dir}/.claude/plans"
+            ],
+            "denyRead": [
+              {"anchor": "worker_dir", "path": ".env", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env)"},
+              {"anchor": "worker_dir", "path": ".env.*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(.env.*)"},
+              {"anchor": "worker_dir", "path": "**/credentials*", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/credentials*)"},
+              {"anchor": "worker_dir", "path": "**/*.pem", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(**/*.pem)"},
+              {"anchor": "home", "path": ".config/gh/hosts.yml", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.config/gh/hosts.yml)"},
+              {"anchor": "home", "path": ".aws/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.aws/*)"},
+              {"anchor": "home", "path": ".ssh/**", "suppressOnSymlinkEscape": true, "layer2Fallback": "Read(~/.ssh/*)"}
+            ],
+            "denyWrite": [
+              {"anchor": "worker_dir", "path": "**", "suppressOnSymlinkEscape": false}
+            ]
+          },
+          "failIfUnavailable": false
+        }
+      },
       "permissions": {
         "allow": [
           "Bash(git status:*)",
@@ -404,6 +973,13 @@
           "Bash(git switch *)",
           "Bash(rm -rf *)",
           "Bash(rm -r *)",
+          "Read(.env)",
+          "Read(.env.*)",
+          "Read(**/credentials*)",
+          "Read(**/*.pem)",
+          "Read(~/.config/gh/hosts.yml)",
+          "Read(~/.aws/*)",
+          "Read(~/.ssh/*)",
           "Edit",
           "Write",
           "MultiEdit",


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#458](https://github.com/suisya-systems/claude-org-ja/pull/458)

Merge SHA: `fae87e7abdfbc52b38e8771d768b8729014232f6`

Source: ja PR [#458](https://github.com/suisya-systems/claude-org-ja/pull/458)
Merge SHA: `fae87e7abdfbc52b38e8771d768b8729014232f6`

| class | count |
|---|---|
| runtime | 3 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tests/fixtures/attention/expected_scan.json`
- `tests/test_attention_runtime_integration.py`
- `tools/org_extension_schema.json`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-setup/references/permissions.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
