### PR TITLE
fix: add effort/allowed-tools frontmatter to 12 SKILL.md (Closes #246)

### DIFF
--- a/.claude/skills/org-curate/SKILL.md
+++ b/.claude/skills/org-curate/SKILL.md
@@ -4,6 +4,16 @@ description: >
   Consolidate and reorganize accumulated raw learnings (knowledge/raw/).
   Periodically called from the Curator Claude's /loop.
   Also fires manually when asked to "organize the knowledge".
+effort: medium
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(mkdir -p knowledge/raw/archive/)
+  - Bash(mv knowledge/raw/*)
+  - Bash(grep:*)
+  - Bash(find knowledge/*)
+  - mcp__renga-peers__send_message
 ---
 
 # org-curate: knowledge curation

--- a/.claude/skills/org-dashboard/SKILL.md
+++ b/.claude/skills/org-dashboard/SKILL.md
@@ -4,6 +4,14 @@ description: >
   Refresh the org dashboard and open it in a browser.
   Triggers: "show me the dashboard", "visualize the situation",
   "show me the project list", "show me the big picture", etc.
+effort: low
+allowed-tools:
+  - Bash(cat .state/dashboard.pid)
+  - Bash(kill -0 *)
+  - Bash(python3 dashboard/server.py *)
+  - Bash(py -3 dashboard/server.py *)
+  - Bash(open http://localhost:8099)
+  - Bash(start http://localhost:8099)
 ---
 
 # org-dashboard: open the dashboard

--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -5,6 +5,23 @@ description: >
   command node, and hands off hands-on execution to Workers by default.
   Trigger this when a user request requires file edits, implementation, research,
   or other execution work.
+effort: medium
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(python tools/gen_delegate_payload.py:*)
+  - Bash(py -3 tools/gen_delegate_payload.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - Bash(git fetch:*)
+  - Bash(git log:*)
+  - Bash(gh issue create:*)
+  - mcp__renga-peers__send_message
+  - mcp__renga-peers__inspect_pane
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__list_panes
 ---
 
 # org-delegate: Worker Dispatch

--- a/.claude/skills/org-escalation/SKILL.md
+++ b/.claude/skills/org-escalation/SKILL.md
@@ -10,6 +10,14 @@ description: >
   Normal progress / completion reports are handled by org-delegate
   Step 5 (1) / (2a). This skill owns the canonical "do not approve
   on your own; update the registers" flow.
+effort: medium
+allowed-tools:
+  - Read
+  - Edit
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(python tools/pending_decisions.py:*)
+  - Bash(py -3 tools/pending_decisions.py:*)
+  - mcp__renga-peers__send_message
 ---
 
 # org-escalation: judgment-escalation / scope-expansion / blocker escalation

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -7,6 +7,28 @@ description: >
   (2) when review feedback or a CI failure arrives on a GitHub PR and the Lead sends a follow-up fix request back to the Worker,
   (3) when the PR is merged and the final close-out condition is satisfied.
   The initial action of simply "asking a Worker to do work" belongs to org-delegate, not this skill.
+effort: medium
+allowed-tools:
+  - Read
+  - Bash(git push:*)
+  - Bash(git -C * worktree remove:*)
+  - Bash(git worktree remove:*)
+  - Bash(gh pr create:*)
+  - Bash(gh pr view:*)
+  - Bash(gh pr checks:*)
+  - Bash(gh issue create:*)
+  - Bash(gh issue edit:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python tools/set_run_pr_open.py:*)
+  - Bash(py -3 tools/set_run_pr_open.py:*)
+  - Bash(python tools/run_complete_on_merge.py:*)
+  - Bash(py -3 tools/run_complete_on_merge.py:*)
+  - Bash(bash tools/pr-watch.sh:*)
+  - Bash(pwsh tools/pr-watch.ps1:*)
+  - Bash(powershell tools/pr-watch.ps1:*)
+  - mcp__renga-peers__send_message
+  - mcp__renga-peers__check_messages
 ---
 
 # org-pull-request: PR Creation, Review, and Post-Merge Close-Out

--- a/.claude/skills/org-resume/SKILL.md
+++ b/.claude/skills/org-resume/SKILL.md
@@ -4,6 +4,16 @@ description: >
   Resume a suspended org. Use when `.state/org-state.md` exists with
   Status: SUSPENDED and the user says "resume", "continue from where we left off",
   "where did we get to last time?". Also covers the auto-briefing on startup.
+effort: low
+allowed-tools:
+  - Read
+  - Bash(git status)
+  - Bash(git log:*)
+  - Bash(py -3 tools/state_migrate.py)
+  - Bash(python3 tools/state_migrate.py)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(python -m tools.state_db.importer:*)
 ---
 
 # org-resume: resume the org

--- a/.claude/skills/org-retro/SKILL.md
+++ b/.claude/skills/org-retro/SKILL.md
@@ -7,6 +7,12 @@ description: >
   task's pattern should be promoted to a work-skill.
   Technical retrospectives on the actual work are done by the worker
   automatically and are not handled here.
+effort: medium
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - mcp__renga-peers__send_message
 ---
 
 # org-retro: delegation-process retrospective

--- a/.claude/skills/org-setup/SKILL.md
+++ b/.claude/skills/org-setup/SKILL.md
@@ -6,6 +6,15 @@ description: |
   Curator / Worker), in one go.
   Triggers: "set up", "update permissions", "do the setup",
   "permissions config", "org-setup", etc.
+effort: low
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(python tools/org_setup_prune.py:*)
+  - Bash(py -3 tools/org_setup_prune.py:*)
+  - Bash(python tools/check_role_configs.py:*)
+  - Bash(py -3 tools/check_role_configs.py:*)
 ---
 
 # org-setup: place all the org's permission settings

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -4,6 +4,15 @@ description: >
   Start the organization. Load the previous state and brief it,
   then start the Dispatcher and Curator panes. Run once immediately after starting ClaudeCode.
   Also triggers on phrases like "start", "boot", or "begin".
+effort: low
+allowed-tools:
+  - Read
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - Bash(py -3 dashboard/org_state_converter.py:*)
+  - Bash(python3 dashboard/org_state_converter.py:*)
+  - mcp__renga-peers__*
 ---
 
 # org-start: Start the Organization

--- a/.claude/skills/org-suspend/SKILL.md
+++ b/.claude/skills/org-suspend/SKILL.md
@@ -4,6 +4,13 @@ description: >
   Suspend the org and persist all state to disk. Use when the user says
   "suspend", "save and exit", "I want to close", "let's stop for now",
   "done for today".
+effort: low
+allowed-tools:
+  - Read
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(python -m tools.state_db.importer:*)
+  - mcp__renga-peers__*
 ---
 
 # org-suspend: suspend the org

--- a/.claude/skills/skill-audit/SKILL.md
+++ b/.claude/skills/skill-audit/SKILL.md
@@ -7,6 +7,13 @@ description: >
   OR when the work-skill count under .claude/skills/ (excluding org-*)
   reaches 20 or more. Not started by a time-based /loop (avoids
   polluting raw logs on quiet days).
+effort: medium
+allowed-tools:
+  - Read
+  - Bash(grep:*)
+  - Bash(find:*)
+  - Bash(wc:*)
+  - mcp__renga-peers__send_message
 ---
 
 # skill-audit: skill inventory pass

--- a/.claude/skills/skill-eligibility-check/SKILL.md
+++ b/.claude/skills/skill-eligibility-check/SKILL.md
@@ -8,6 +8,11 @@ description: >
   Does not auto-create skills. A "recommend" appends to
   knowledge/skill-candidates.md, and the Lead later batch-asks the
   human once the queue accumulates — a two-stage handoff.
+effort: low
+allowed-tools:
+  - Read
+  - Edit
+  - Write
 ---
 
 # skill-eligibility-check: skill-promotion judgment


### PR DESCRIPTION
## Summary

Mirror the frontmatter additions from ja#463 (commit `96293f4`) to this en mirror's `.claude/skills/*/SKILL.md` files. ja#463 added `effort` and `allowed-tools` keys to the frontmatter of 14 SKILL.md files; both values are language-agnostic, so they are applied directly without translation.

12 of the 14 files in ja#463 exist in this en mirror and have been updated:

- `org-curate`, `org-dashboard`, `org-delegate`, `org-escalation`, `org-pull-request`, `org-resume`, `org-retro`, `org-setup`, `org-start`, `org-suspend`, `skill-audit`, `skill-eligibility-check`

The remaining 2 — `secretary-handover/SKILL.md` and `secretary-resume/SKILL.md` — are not yet present in this en mirror. Those skills have not been ported through the translation pipeline yet; they will be added in a separate change rather than carried here.

SKILL.md bodies remain in their current (still-Japanese) state in this PR. Body translation is out of scope for this issue.

Closes #246.

## Test plan

- [ ] CI green
- [ ] Spot-check 1-2 SKILL.md files: confirm frontmatter contains the new `effort` / `allowed-tools` keys and that the body is byte-identical to the previous en mirror version

🤖 Generated with [Claude Code](https://claude.com/claude-code)