### PR TITLE
docs: add English translation of attention notification design and operations docs (Closes #241)

### DIFF
--- a/docs/design/attention-notification.md
+++ b/docs/design/attention-notification.md
@@ -1,0 +1,580 @@
+# Attention notification design
+
+> Status: **design only**. This document defines the implementation direction and Issue split. The actual implementation is done in separate Issues / PRs on the `claude-org-runtime` side and the `claude-org-ja` side.
+> Scope: an attention layer that uses desktop notifications / sound to alert the moment an AI worker needs a human response.
+> Conclusion: the implementation body goes in **Layer 2 = `claude-org-runtime`**. `claude-org-ja` owns the Japanese default settings, onboarding paths, and documentation. `core-harness` and `renga` are not touched in the initial implementation.
+
+---
+
+## 1. Background
+
+`claude-org-ja` already has mechanisms to detect and record worker approval waits, judgment waits, CI failures, silent deadlocks, and so on.
+
+- The dispatcher uses `inspect_pane` / `check_messages` / `poll_events` to detect `APPROVAL_BLOCKED`, `ERROR_DETECTED`, `relay_gap_suspected`, `pane_output_without_peer_msg`, and similar conditions.
+- The Secretary records worker escalations in `.state/pending_decisions.json`.
+- `tools/pr_watch.py` records CI results as `ci_completed` events and also best-effort notifies the renga peer.
+- `state.db` is the post-M4 SoT, holding events / runs / worker_dirs / sessions.
+
+However, current notifications are mostly limited to renga-peers channel messages and rendering inside the Secretary pane. When the human is not looking at the terminal, the following genuinely important states are easy to miss.
+
+- A worker stalled waiting for tool approval.
+- A worker asked for a judgment but the human did not notice.
+- The human already replied but the Secretary has not relayed it to the worker.
+- CI failed.
+- A worker completed and is waiting for review.
+- The pane has output but no peer message has been sent.
+
+The value here is stronger as an attention notification that "calls the human back" than as a dashboard the human has to "go look at." Therefore the main feature is designed not as a dashboard but as a **watcher that alerts the moments a human response is required, via OS notification / sound / fallback bell**.
+
+---
+
+## 2. Goal
+
+Add `claude-org-runtime attention watch` that monitors `.state/state.db` and `.state/pending_decisions.json` and notifies via desktop notification / sound / terminal bell whenever a human response is needed.
+
+Expected command shapes:
+
+```bash
+claude-org-runtime attention scan --state-dir .state --dry-run
+claude-org-runtime attention watch --state-dir .state
+claude-org-runtime attention watch --state-dir .state --config .state/attention.json
+```
+
+`scan` evaluates once and exits. `watch` keeps monitoring by polling.
+
+---
+
+## 3. Layer decision
+
+### 3.1 Why this lives in Layer 2 `claude-org-runtime`
+
+The substance of attention notification is not the OS notification itself but **how to interpret claude-org's execution state**.
+
+The runtime is already responsible for:
+
+- the dispatcher CLI,
+- worker settings generation,
+- bundling the role schema,
+- deterministic operations close to worker startup and state recording,
+- operational logic carved out of Layer 4.
+
+The inputs the attention watcher reads are close to the runtime's responsibilities.
+
+- `.state/state.db`
+- `.state/pending_decisions.json`
+- `notify_sent`
+- `ci_completed`
+- `worker_completed`
+- `pr_merged`
+- `relay_gap_suspected`
+- `pane_output_without_peer_msg`
+
+These are not `core-harness` safety primitives; they are claude-org runtime semantics. So the implementation body belongs in `claude-org-runtime`.
+
+### 3.2 What remains in Layer 4 `claude-org-ja`
+
+`claude-org-ja`, as the consumer / reference distribution, holds:
+
+- Japanese notification templates,
+- default config,
+- README / getting-started / verification onboarding paths,
+- documentation that guides starting the attention watcher from `/org-start`,
+- ja-specific troubleshooting.
+
+### 3.3 Why this does not go into `core-harness`
+
+`core-harness` is the low-level safety / audit foundation of the Claude Code harness: permission schema, validator, hook framework, dangerous git/no-verify block, audit primitives, and so on.
+
+Desktop notification / sound / operator attention is closer to UX / runtime operation, not core safety primitives. Putting it here would stretch `core-harness`'s responsibility too far.
+
+We only consider a constrained Layer 1 extraction in the future if multiple harnesses end up needing a shared `AttentionEvent` envelope or dedup/cooldown primitive.
+
+### 3.4 Why this does not go into `renga`
+
+`renga` is a terminal multiplexer + MCP server — a Layer 3 component that provides pane control / peer messaging / screen inspection / event polling.
+
+The attention watcher's input is not renga's live event stream; the persisted `state.db` / `pending_decisions.json` from claude-org is enough. OS notification is not the responsibility of a backend terminal multiplexer.
+
+If a TUI-integrated notification primitive like `renga notify` is needed in the future, that becomes a separate Issue.
+
+---
+
+## 4. Non-goals
+
+- Do not implement OS notifications inside renga itself.
+- Do not have the Secretary / Dispatcher prompts directly issue OS notifications.
+- Do not make a dashboard the primary UI.
+- Do not require external notifications (Slack / Discord / ntfy / Pushover, etc.) in the initial scope.
+- Do not notify on every progress event.
+- Do not include secrets, diffs, full commands, or long logs in notification bodies.
+- Do not stretch `core-harness`'s responsibility into UX / OS integration.
+
+---
+
+## 5. Runtime Issue: attention scan/watch CLI
+
+### Issue title
+
+`claude-org-runtime`: add attention scan/watch CLI for human-required events
+
+### Implementation target
+
+Add the following to `claude-org-runtime`.
+
+```text
+claude_org_runtime/attention/
+  __init__.py
+  cli.py
+  config.py
+  classifier.py
+  readers.py
+  dedup.py
+  notify.py
+  platform.py
+```
+
+CLI:
+
+```bash
+claude-org-runtime attention scan --state-dir .state --dry-run
+claude-org-runtime attention watch --state-dir .state --config .state/attention.json
+```
+
+### Inputs
+
+- `.state/state.db`
+- `.state/pending_decisions.json`
+- optional config JSON (`.state/attention.json`)
+
+### Outputs
+
+- desktop notification
+- urgent sound
+- terminal bell fallback
+- stdout log
+- dedup state file (`.state/attention_notified.json`)
+
+### Attention event model
+
+Internally the runtime converts inputs into the following normalized event.
+
+```python
+@dataclass(frozen=True)
+class AttentionEvent:
+    key: str
+    kind: str
+    severity: Literal["urgent", "normal"]
+    title: str
+    body: str
+    source: str
+    task_id: str | None = None
+    worker: str | None = None
+    created_at: str | None = None
+```
+
+`key` is a stable ID used for dedup.
+
+- From a DB event: `event:<events.id>`
+- From a pending decision: `pending:<task_id>:<kind>`
+
+### Classification rules
+
+| Input | Condition | Attention kind | Severity |
+|---|---|---|---|
+| `events` | `event='notify_sent'` and `kind='approval_blocked'` | `approval_blocked` | urgent |
+| `events` | `event='notify_sent'` and `kind='relay_gap_suspected'` | `relay_gap_suspected` | urgent |
+| `events` | `event='notify_sent'` and `kind='pane_output_without_peer_msg'` | `silent_worker_output` | urgent |
+| `events` | `event='ci_completed'` and `status in ('failed','canceled','incomplete')` | `ci_failed` | urgent |
+| `events` | `event='worker_completed'` | `worker_completed` | normal |
+| `events` | `event='pr_merged'` | `pr_merged` | normal |
+| `pending_decisions.json` | pending older than threshold | `pending_decision` | urgent |
+| `pending_decisions.json` | user replied but not forwarded older than threshold | `user_reply_not_forwarded` | urgent |
+
+Not notified:
+
+- progress-only events
+- `heartbeat`
+- raw `anomaly_observed` without a notification path
+- duplicate `notify_sent`
+- normal worker reports
+
+### Notification backend
+
+Implement without additional dependencies. Subprocess invocations carry a timeout.
+
+| Environment | Desktop | Sound |
+|---|---|---|
+| macOS | `osascript display notification` | `afplay` if configured, otherwise bell |
+| Linux | `notify-send` | `paplay` / `canberra-gtk-play` / bell |
+| Windows native | PowerShell `Write-Host` (a defect remained at implementation time: no visible UI. Conversion to real toasts is tracked as a separate follow-up Issue) | PowerShell `[console]::beep` |
+| WSL (with `wsl-notify-send.exe`, recommended) | `wsl-notify-send.exe --category <title> <body>` produces a real toast in the Windows notification center | A separate PowerShell `[console]::beep` subprocess (terminal bell is suppressed when the toast succeeds) |
+| WSL (only `powershell.exe`, fallback) | PowerShell `Write-Host` (no visible UI, the legacy path uncovered by Issue #25) | PowerShell `[console]::beep` |
+| fallback | stdout | terminal bell `\a` |
+
+If no desktop notification backend is available, `watch` still does not crash. It falls back to stdout + bell.
+
+**Implementation reality note (design ↔ implementation drift)**: the initial design described the WSL backend in a single line as "PowerShell via the Windows host," but at implementation time Issue #25 revealed that the `Write-Host` path does not reach the Windows notification center. `claude-org-runtime` PR #27 ([suisya-systems/claude-org-runtime#27](https://github.com/suisya-systems/claude-org-runtime/pull/27)) split it into a 3-step priority chain `wsl-notify-send.exe` → `powershell.exe` → stdout. The Windows native backend carries the same defect and is not fixed by PR #27 (tracked in a separate follow-up Issue). For the operational onboarding path and install instructions, see [`docs/operations/attention-watch.md`](../operations/attention-watch.md) §3.1.
+
+### Config
+
+The runtime owns the config schema and defaults.
+
+```json
+{
+  "desktop": true,
+  "sound": "urgent-only",
+  "cooldown_sec": 300,
+  "poll_interval_sec": 10,
+  "pending_decision_min": 15,
+  "user_replied_min": 15,
+  "max_title_chars": 80,
+  "max_body_chars": 240,
+  "notify": {
+    "approval_blocked": "urgent",
+    "relay_gap_suspected": "urgent",
+    "silent_worker_output": "urgent",
+    "ci_failed": "urgent",
+    "pending_decision": "urgent",
+    "user_reply_not_forwarded": "urgent",
+    "worker_completed": "normal",
+    "pr_merged": "normal"
+  }
+}
+```
+
+Possible values for `sound`:
+
+- `"off"`
+- `"urgent-only"`
+- `"all"`
+
+### Dedup / cooldown
+
+The runtime manages `.state/attention_notified.json`.
+
+```json
+{
+  "events": {
+    "event:123": "2026-05-12T10:00:00Z"
+  },
+  "pending": {
+    "pending:issue-123:user_reply_not_forwarded": "2026-05-12T10:00:00Z"
+  }
+}
+```
+
+Requirements:
+
+- The same DB event id is notified only once.
+- Cooldown applies to pending decisions by `(task_id, kind)`.
+- Broken JSON emits a warning and is regenerated.
+- Writes to the dedup state are an atomic replace.
+
+### Secret-safe formatting
+
+Notification bodies are short and secret-safe.
+
+- Do not include the full command.
+- Do not include diffs / logs / stack traces.
+- Do not emit arbitrary fields of `payload_json` directly into the body.
+- Keep contents at task id / worker id / PR number / status level.
+- Truncate the body at `max_body_chars`.
+
+### Runtime acceptance criteria
+
+- `claude-org-runtime attention scan --state-dir <fixture> --dry-run` emits attention events from a fake state.
+- `notify_sent kind=approval_blocked` is classified as urgent.
+- `ci_completed status=failed` is classified as urgent.
+- `worker_completed` is classified as normal.
+- Progress-only events are ignored.
+- Stale pending decisions are classified as urgent.
+- User replied but not forwarded is classified as urgent.
+- Event id dedup works.
+- Pending decision cooldown works.
+- When no desktop backend is available, it falls back to stdout + bell.
+- macOS / Linux / Windows / WSL backend selection is unit tested.
+- `--dry-run` does not invoke OS notification subprocesses.
+- Recovery from a broken `.state/attention_notified.json` works.
+
+---
+
+## 6. Runtime Issue: locale/template override
+
+### Issue title
+
+`claude-org-runtime`: support attention notification templates and locale overrides
+
+### Background
+
+The runtime owns the implementation body, but we do not want to hard-code notification text to `claude-org-ja`, the Japanese distribution. The runtime carries neutral default titles/bodies, and Layer 4 needs to override them via a locale config.
+
+### Implementation direction
+
+Add `templates` to the runtime config.
+
+```json
+{
+  "templates": {
+    "approval_blocked": {
+      "title": "Worker approval required",
+      "body": "{worker} is waiting for approval."
+    },
+    "ci_failed": {
+      "title": "CI failed",
+      "body": "PR #{pr} finished with {status}."
+    }
+  }
+}
+```
+
+Template placeholders are allowlisted.
+
+Allowed placeholders:
+
+- `{task_id}`
+- `{worker}`
+- `{kind}`
+- `{status}`
+- `{pr}`
+- `{summary}`
+
+Unknown placeholders are either left as literals (not raised as errors) or trigger a warning + fallback template. The fallback template is recommended for the initial implementation.
+
+### Acceptance criteria
+
+- Template overrides in the config are reflected in title/body.
+- The watcher does not crash on unknown placeholders.
+- Template-derived bodies are also truncated at `max_title_chars` / `max_body_chars`.
+- The ja-side config can supply Japanese text.
+
+---
+
+## 7. ja Issue: default config and documentation
+
+### Issue title
+
+`claude-org-ja`: add attention watcher config, docs, and README positioning
+
+### Implementation target
+
+Add / update the following on the `claude-org-ja` side.
+
+```text
+.state/attention.example.json
+docs/operations/attention-watch.md
+docs/verification.md
+README.md
+.claude/skills/org-start/SKILL.md
+```
+
+Because `.state/` is gitignored, the example should live at a tracked path. Candidates:
+
+```text
+tools/templates/attention.example.json
+```
+
+or:
+
+```text
+docs/operations/attention.example.json
+```
+
+Following the existing template placement, `tools/templates/attention.example.json` is recommended.
+
+### README positioning
+
+Do not pitch the README's value proposition solely on "AI organization operation." Lean into the following pains.
+
+- Be able to come back the moment a Claude worker is waiting on a human.
+- Do not miss approval / judgment / CI failure / silent stop.
+- No need to keep watching multiple workers all the time.
+
+That said, do not remove the existing 4-layer architecture or Secretary/Dispatcher/Curator/Worker description. Move the front-door pitch toward attention / ops and place the organizational structure as a mechanism in a later section.
+
+### org-start guidance
+
+Add startup guidance for the attention watcher to the `/org-start` procedure.
+
+Example:
+
+```bash
+claude-org-runtime attention watch --state-dir .state --config .state/attention.json
+```
+
+That said, do not make auto-start mandatory in the first iteration. OS notifications are environment-dependent, so the user should be able to enable them explicitly.
+
+### ja default template
+
+The ja config ships with short Japanese text.
+
+Example:
+
+```json
+{
+  "templates": {
+    "approval_blocked": {
+      "title": "ワーカーが承認待ちです",
+      "body": "{worker} が承認待ちで停止しています。"
+    },
+    "ci_failed": {
+      "title": "CI が失敗しました",
+      "body": "PR #{pr} の CI が {status} で完了しました。"
+    },
+    "pending_decision": {
+      "title": "判断待ちがあります",
+      "body": "{task_id} が人間の判断を待っています。"
+    },
+    "user_reply_not_forwarded": {
+      "title": "返答の転送待ちです",
+      "body": "{task_id} でユーザー返答が worker に未転送です。"
+    }
+  }
+}
+```
+
+### ja acceptance criteria
+
+- The README documents the value of the attention watcher and a startup example.
+- `docs/operations/attention-watch.md` covers OS-specific fallback and troubleshooting.
+- `docs/verification.md` covers the `scan --dry-run` verification procedure.
+- `tools/templates/attention.example.json` carries the ja default config.
+- The `/org-start` docs include watcher startup guidance.
+
+---
+
+## 8. ja Issue: integration verification fixtures
+
+### Issue title
+
+`claude-org-ja`: add fixtures for attention watcher integration verification
+
+### Background
+
+Unit tests on the runtime side alone make it hard to notice when ja's event vocabulary drifts from the real `.state` shape. We also place semantic fixtures on the `claude-org-ja` side and verify integration with the runtime CLI.
+
+### Implementation target
+
+```text
+tests/fixtures/attention/
+  state.db
+  pending_decisions.json
+  expected_scan.json
+tests/test_attention_runtime_integration.py
+```
+
+Whether the `state.db` fixture is held as a binary or generated from schema inside the test is decided at implementation time. The test-generation approach has higher maintainability.
+
+### Acceptance criteria
+
+- The fixture's `notify_sent approval_blocked` produces the expected urgent event.
+- The fixture's `ci_completed failed` produces the expected urgent event.
+- The fixture's stale `pending_decisions.json` produces the expected urgent event.
+- The output of `claude-org-runtime attention scan --dry-run --json` matches a golden file.
+
+---
+
+## 9. Future Issue: optional external notification sinks
+
+### Issue title
+
+`claude-org-runtime`: optional external attention sinks for Slack/Discord/ntfy
+
+### Background
+
+The initial implementation is confined to local notification. External notification carries secret / privacy / network configuration concerns, so it is not made mandatory.
+
+### Direction
+
+Add external sinks as optional only after local notification has stabilized.
+
+Candidates:
+
+- Slack webhook
+- Discord webhook
+- ntfy.sh
+- Gotify
+- Pushover
+
+External sinks are always opt-in. Their notification bodies are even shorter than local notifications, and they share the secret-safe formatting.
+
+---
+
+## 10. Overall acceptance criteria
+
+- The runtime ships `claude-org-runtime attention scan/watch`.
+- `claude-org-runtime attention scan --state-dir .state --dry-run` can be run from the ja repo.
+- approval blocked / relay gap / silent worker output / CI failed / pending decision become urgent notifications.
+- worker completed / pr merged become normal notifications.
+- Progress-style events are not notified.
+- Even in environments where OS notifications are unavailable, it falls back to stdout + terminal bell.
+- With urgent-only sound, only urgent events make a sound.
+- Dedup / cooldown prevent the same event from sounding repeatedly.
+- Notification bodies are secret-safe and short.
+- The ja side has Japanese config and operational procedures.
+- core-harness / renga are not modified.
+
+---
+
+## 11. Open questions
+
+1. Should `watch` auto-start from `/org-start`, or remain an explicit start?
+   - Explicit start is recommended for the first iteration. OS notifications are environment-dependent, and sound going off without consent is easily unpleasant.
+2. Should `worker_completed` be included in normal desktop notifications?
+   - Included in the initial defaults. But sound does not fire.
+3. The default for `pending_decision_min`.
+   - Match the existing dispatcher monitoring's 15 minutes.
+4. How to tolerate `notify_sent` event payload schema drift?
+   - The runtime classifier tolerates missing fields and reconstructs from at least `event` / `kind` / `payload_json`.
+5. Behavior on first launch when `state.db` does not exist.
+   - No-op, not a warning. `scan` / `watch` do not crash.
+
+---
+
+## 12. Severity taxonomy and TTL ladder
+
+> **Implementation reality note (design ↔ implementation drift, Part B)**: the Config example in §5 preserves the design snapshot from the initial version of this document. The real runtime defaults were updated by Issue #26 / `claude-org-runtime` PR #29 ([suisya-systems/claude-org-runtime#29](https://github.com/suisya-systems/claude-org-runtime/pull/29)): (a) the severity of 6 anomaly kinds was demoted from `urgent` to `normal`, and (b) two new TTL keys `pending_decision_max` / `pending_decision_drop` were added. This section is the SoT describing the rationale and taxonomy for that update. For the Layer 4 ja distribution's reflected defaults, see [`tools/templates/attention.example.json`](../../tools/templates/attention.example.json); for the operations-perspective table and tuning advice, see [`docs/operations/attention-watch.md`](../operations/attention-watch.md) §4.1 / §4.2.
+
+### 12.1 Anomaly / precursor vs action-required dichotomy
+
+attention events split into two by **"whether recovery is possible via a path other than the user."** This is also the basis for revisiting the severity defaults in Issue #26 Part B.
+
+- **action-required moments (urgent default)** — events where the user is the only recovery path. The runtime / dispatcher / Secretary can only detect and notify; releasing the state requires human intervention.
+  - `approval_blocked`: tool approval / sensitive op approval — cannot proceed without the user's reply
+  - `ci_failed`: CI failure — the decision to re-push / fix is up to the user
+  - `pending_decision`: a worker asks for a judgment — the Secretary is a relay, and the human is the judgment layer (CLAUDE.md § "judgment escalations go to the human")
+  - `user_reply_not_forwarded`: the user replied but the worker has not received it — visibility into a Secretary operational gap
+  - `pane_crashed`: a pane terminated unexpectedly — the decision to restart is up to the user
+
+- **anomaly / precursor signals (normal default)** — best-effort detections, events that may self-recover on the worker / dispatcher / runtime side. To avoid urgent muting (where the alarm rings every day and ends up being uniformly ignored), all 6 of these were demoted to normal in Part B.
+  - `relay_gap_suspected`: dispatcher's SECRETARY_RELAY_GAP_SUSPECTED precursor detection. Often transient on the Secretary side in the short term
+  - `silent_worker_output`: pane has output but no peer message has arrived — may be flushed on the worker side
+  - `pane_silent`: pane is unresponsive, including silence during tool execution. Not necessarily a full stall
+  - `worker_stalled`: heuristic estimate that worker progress has stagnated — may self-recover
+  - `worker_not_reported`: no report has arrived from the worker — may just be a delay in the short term
+  - `worker_error`: an error report from the worker — may be retried / recovered internally
+
+`worker_completed` / `pr_merged` are treated as **progress events**: normal default, but taxonomically a third independent category (no immediate action required, yet a trigger for review / cleanup).
+
+### 12.2 4-step TTL ladder for pending_decisions
+
+If a judgment escalation stays "urgent forever once urgent," in operations where unresolved items pile up, the watcher itself ends up muted (noise → uniformly ignored), a failure mode. To avoid this, runtime PR #29 introduced a ladder that decays the elapsed time of a pending decision through 4 stages.
+
+| Elapsed time | Stage | Behavior |
+|---|---|---|
+| `t < pending_decision_min` | grace | No event fired. A grace window on the assumption that the Secretary can relay to a human within a short time |
+| `pending_decision_min ≤ t < pending_decision_max` | urgent | desktop notification + urgent sound + terminal bell |
+| `pending_decision_max ≤ t < pending_decision_drop` | normal / visual-only | The desktop notification fires but no urgent sound. A visual remnant marking long-unresolved items |
+| `t ≥ pending_decision_drop` | suppressed | Both desktop and sound are suppressed; only `attention scan --json` output retains it |
+
+The design aim is **"the decay curve preserves the signal while suppressing dead state":**
+
+- The **first 24 hours (default)** of a new pending is the urgent window — guaranteed audiovisual notice.
+- After 24h, it does not disappear from the dashboard / `--json` output but remains as normal/visual. A state in which **the fact that the long-term backlog is non-zero** stays visible.
+- Past 7 days, the dead state is suppressed from notification surfaces and only accessible via audit/dashboard paths. This prevents noise from growing linearly.
+
+Consistency conditions (validated in the runtime `attention/config.py`):
+
+- `pending_decision_min < pending_decision_max < pending_decision_drop`
+- `user_replied_min < pending_decision_max`
+
+These are returned as validation errors at load time, so typos in Layer 4 / user overlays are caught early.

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -1,0 +1,209 @@
+# attention-watch operations guide
+
+`claude-org-runtime attention scan` / `attention watch` is a watcher that monitors `.state/state.db` and `.state/pending_decisions.json` and notifies — via desktop notification + sound + terminal bell fallback — states that require a human response (waiting for approval / waiting for a judgment / CI failed / silent stop, etc.). This document covers operational procedures on the Layer 4 (`claude-org-ja`) side. For the design premises, classification rules, and dedup spec, see [`docs/design/attention-notification.md`](../design/attention-notification.md).
+
+## 1. Role, inputs, outputs
+
+- **Inputs**:
+  - The `events` table in `.state/state.db` (`notify_sent` / `ci_completed` / `worker_completed` / `pr_merged`, etc.)
+  - `.state/pending_decisions.json` (the register of human-judgment escalations)
+  - optional config: `.state/attention.json` (use `tools/templates/attention.example.json` as a template)
+- **Outputs**:
+  - desktop notification (OS-specific backends — see §3)
+  - sound (one of `urgent-only` / `all` / `off` — see §4)
+  - terminal bell fallback (`\a`)
+  - structured stdout log
+  - dedup state: `.state/attention_notified.json` (managed automatically by the runtime)
+
+## 2. Enable / disable
+
+### 2.1 Placing the config file
+
+`tools/templates/attention.example.json` is a tracked example containing the ja default template set. In real use, copy it to `.state/attention.json` (since `.state/` is gitignored, it does not exist in a fresh clone or before `/org-start`):
+
+```bash
+mkdir -p .state
+cp tools/templates/attention.example.json .state/attention.json
+```
+
+To change OS-notification or sound behavior, edit `.state/attention.json` (override template strings, switch `sound`, adjust `cooldown_sec`, etc.). The template placeholder allowlist is the 6 placeholders `{task_id}` / `{worker}` / `{kind}` / `{status}` / `{pr}` / `{summary}`; unknown placeholders are either left as literals or filled by the runtime's fallback template (see design §6).
+
+### 2.2 One-shot verification (`scan`)
+
+Before keeping `watch` resident, confirm that attention events are extracted from the current `.state/` as expected:
+
+```bash
+claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json
+```
+
+Always pass `--config .state/attention.json` (without it, the runtime-neutral English defaults appear in title/body, and you cannot tell whether the ja templates are actually taking effect). `--dry-run` does not invoke OS-notification subprocesses, so it is safe in CI environments or during quiet hours. The output is in the form `{ "events": [{ "key": ..., "kind": ..., "severity": ..., "title": ..., "body": ...}, ...] }` (for details, see [the attention scan verification block in `docs/verification.md`](../verification.md)).
+
+### 2.3 Resident mode (`watch`)
+
+```bash
+claude-org-runtime attention watch --state-dir .state --config .state/attention.json
+```
+
+Start it in another terminal or in the background. It does not auto-start from `/org-start` (since it is strongly environment-dependent, explicit start is recommended; see design §11 Q1 / §7 "org-start guidance"). Stopping is the usual Ctrl-C (the dedup state is written via atomic replace, so even a forced kill can be recovered on next startup — see §5).
+
+### 2.4 Disabling
+
+To stop it permanently, just terminate the `watch` process. There is no need to delete the config file (`.state/attention.json`). To temporarily suppress notifications, set `"desktop": false` / `"sound": "off"` in `.state/attention.json`, or demote individual-kind severities from `"urgent"` to `"normal"` (the value of `notify.<kind>` only accepts `"urgent"` / `"normal"`; there is no per-kind `off`. To stop completely, use the global `desktop: false`).
+
+## 3. OS-specific notification backend behavior
+
+The runtime invokes OS-standard commands via subprocess (with timeouts) without adding dependencies. Unusable backends fall back to stdout + terminal bell, and the watcher itself does not crash. **The current runtime (0.1.x) does not have an audio-file playback path; when `sound` is effective, it rings the terminal bell (`\a`) immediately after the OS notification** (on Windows / WSL only, it uses `[console]::beep` for a simple beep). Sound-playback commands such as `afplay` / `paplay` / `canberra-gtk-play` are not currently used and are only described as future enhancements.
+
+| OS / environment | desktop backend | sound backend | notes |
+|---|---|---|---|
+| macOS | `osascript -e 'display notification ...'` | terminal bell `\a` | macOS shows desktop notifications by default. When `sound` is effective, a bell rings right after the notification |
+| Linux | `notify-send <title> <body>` | terminal bell `\a` | `notify-send` is from the `libnotify-bin` package. Works on GNOME / KDE. If DBus is absent, `notify-send` silently fails, but the watcher does not crash and falls back to stdout |
+| Windows native | PowerShell `Write-Host` (in reality produces no visible UI) | PowerShell `[console]::beep` (urgent only) | **Currently has no visible notification surface.** Only the urgent-severity beep is audible; nothing reaches the Windows notification center. Conversion to a real toast via BurntToast / WinRT is split out as a separate follow-up Issue on the runtime side (not addressed in PR #27) |
+| WSL (with `wsl-notify-send.exe`, **recommended**) | `wsl-notify-send.exe --category <title> <body>` produces a real toast in the Windows notification center | PowerShell `[console]::beep` (urgent only, separate subprocess) | If `wsl-notify-send.exe` is on `$PATH` inside WSL, the runtime selects this path automatically. See §3.1 for install steps. On a successful toast, the terminal bell is suppressed to avoid a double beep |
+| WSL (only `powershell.exe`, fallback) | PowerShell `Write-Host` (no visible UI) | PowerShell `[console]::beep` (urgent only) | A legacy path used when `wsl-notify-send.exe` is not installed and only `powershell.exe` is on PATH. **No visible UI; only the urgent beep is audible**. To reach the Windows notification center, follow the install steps in §3.1 |
+| fallback (none of the above / containers, etc.) | structured stdout log | terminal bell `\a` | The watcher does not crash |
+
+During `--dry-run`, no OS subprocess is invoked in any environment — stdout only.
+
+WSL backend selection follows a 3-step priority `wsl-notify-send.exe` → `powershell.exe` → stdout, switching automatically based on PATH presence. The design intentionally does not provide a way to name the backend explicitly in the runtime config — behavior is determined by tuning the environment (i.e., installing or not installing `wsl-notify-send.exe`).
+
+### 3.1 Installing wsl-notify-send.exe (WSL recommended)
+
+To get real toasts in the Windows notification center from WSL, install [`stuartleeks/wsl-notify-send`](https://github.com/stuartleeks/wsl-notify-send). The runtime selects automatically based on whether the exe is on WSL's `$PATH`, so no config changes (such as `.state/attention.json`) are needed.
+
+```bash
+mkdir -p ~/.local/bin
+curl -L -o ~/.local/bin/wsl-notify-send.exe \
+  https://github.com/stuartleeks/wsl-notify-send/releases/latest/download/wsl-notify-send.exe
+chmod +x ~/.local/bin/wsl-notify-send.exe
+wsl-notify-send.exe 'test'
+```
+
+- If `~/.local/bin` is not on `$PATH`, add it in `.bashrc` / `.zshrc` (`export PATH="$HOME/.local/bin:$PATH"`).
+- If the verification step `wsl-notify-send.exe 'test'` shows 'test' in the Windows notification center, the install succeeded.
+- Upstream (`stuartleeks/wsl-notify-send`) is MIT-licensed and written in Go. The last release is from 2021; it is stable but upstream is dormant (no plans for new features).
+- After installing, re-running `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json` does not change the JSON output (dry-run does not invoke OS subprocesses). To verify an actual toast, drop `--dry-run` and trigger a single urgent-severity event.
+
+#### How title/body are rendered
+
+The `wsl-notify-send.exe --category <title> <body>` call maps to the Windows toast as follows:
+
+- The notification's **title line** (top) ← the runtime template `title` passed via `--category`
+- The notification's **body** (bottom) ← the runtime template `body` passed as a positional argument
+
+`--category` is originally intended as a "notification category" flag, but upstream `wsl-notify-send` renders it as the title string, so claude-org-runtime puts the title on `--category` (design judgment from the PR #27 worker, following upstream `main.go` documentation). The `templates.<kind>.title` / `body` values in `.state/attention.json` can be read directly as the toast's 2-line display.
+
+### 3.2 Why no toast on Windows native / WSL fallback? — history
+
+Before Issue #25 / PR #27, both WSL and Windows native were described as "produces a toast via PowerShell `Write-Host`," but the implementation just wrote `Write-Host` to the subprocess's captured stdout and discarded it — nothing reached the Windows notification center (only the urgent `[console]::beep` was an audible signal).
+
+- PR #27 ([suisya-systems/claude-org-runtime#27](https://github.com/suisya-systems/claude-org-runtime/pull/27)) split the WSL backend into the 3-step `wsl-notify-send.exe → powershell.exe → stdout`, with the top-priority `wsl-notify-send.exe` path now producing real toasts.
+- The Windows native backend carries the same defect and is not fixed by PR #27. Work to produce real toasts via BurntToast / WinRT is split out as a separate Issue on the runtime side.
+- Impact on existing users: WSL users who have not installed `wsl-notify-send.exe` remain on the same legacy path as before PR #27 (Write-Host + beep). There is no breaking change; only users who follow `§3.1`'s install steps automatically receive real toasts.
+
+## 4. Key config keys (operational view)
+
+For the detailed schema, see [`docs/design/attention-notification.md`](../design/attention-notification.md) §5 / §6; the SoT is the runtime config schema. Here we list only the keys frequently touched in ja operations.
+
+| Key | Default | Role |
+|---|---|---|
+| `desktop` | `true` | Whether to fire desktop notifications. `false` keeps stdout + bell only |
+| `sound` | `"urgent-only"` | `"off"` / `"urgent-only"` / `"all"`. urgent-only makes sound only for urgent-severity events |
+| `cooldown_sec` | `300` | Minimum interval (seconds) for re-notifying the same dedup key |
+| `poll_interval_sec` | `10` | Polling period of `watch` |
+| `pending_decision_min` | `15` | Elapsed minutes after which a `pending_decisions.json` pending becomes urgent (the entry of the 4-step ladder — see §4.1) |
+| `pending_decision_max` | `1440` | Upper bound (minutes) of the urgent period. Pendings past this drop to normal (24h) |
+| `pending_decision_drop` | `10080` | End of normal notifications (minutes). Pendings past this are suppressed from notification and remain only in `--json` output (7d) |
+| `user_replied_min` | `15` | Elapsed minutes after which "user replied but worker not yet forwarded" becomes urgent |
+| `max_title_chars` / `max_body_chars` | `80` / `240` | Truncation upper bounds of template output (part of secret-safe formatting) |
+| `notify.<kind>` | see §4.1 | Per-event-kind severity (only the values `urgent` / `normal`; `off` is not allowed. To stop completely, use the global `desktop: false`) |
+| `templates.<kind>.{title,body}` | ja default text | Placeholder allowlist: `{task_id} {worker} {kind} {status} {pr} {summary}` |
+
+### 4.1 Default severity classification
+
+The default severities for each kind in the `notify` map of `tools/templates/attention.example.json` are listed below. **urgent roughly corresponds to "action-required moments where only the user can recover," and normal to "anomaly / precursor signals that may self-recover"** (for the taxonomy rationale, see [`docs/design/attention-notification.md`](../design/attention-notification.md) §12).
+
+| event kind | Default severity | Category | Notes |
+|---|---|---|---|
+| `approval_blocked` | urgent | action-required | The worker is fully stopped on tool approval, etc. Cannot be unblocked except via the user |
+| `ci_failed` | urgent | action-required | CI failure. The user is needed to decide on re-push / fix |
+| `pending_decision` | urgent | action-required | Worker asks for a judgment. The Secretary is responsible for escalating to the human (see CLAUDE.md) |
+| `user_reply_not_forwarded` | urgent | action-required | The user already replied but it has not reached the worker. A Secretary operational gap |
+| `pane_crashed` | urgent | action-required | A pane terminated unexpectedly. The user is needed to decide on restart |
+| `relay_gap_suspected` | normal | anomaly / precursor | Dispatcher-monitoring precursor detection. Often self-recovers, and was the primary cause of urgent muting, so demoted |
+| `silent_worker_output` | normal | anomaly / precursor | Pane has output but no peer message arrived. Same as above |
+| `pane_silent` | normal | anomaly / precursor | Pane is unresponsive. May self-recover on the dispatcher side |
+| `worker_stalled` | normal | anomaly / precursor | Heuristic estimate of worker progress stagnation. Short term may self-recover |
+| `worker_not_reported` | normal | anomaly / precursor | No report has arrived from the worker. Short term may just be a delay |
+| `worker_error` | normal | anomaly / precursor | Error report from the worker. May recover inside the worker |
+| `worker_completed` | normal | progress | Completion. No immediate action required, but waiting for review |
+| `pr_merged` | normal | progress | Merged. A trigger for post-merge cleanup |
+
+**※ Local overrides**: in `.state/attention.json` you can override per-kind severity. The ja distribution's template defaults and the user's individual `.state/attention.json` overlay are separate layers (templates are tracked; the overlay is gitignored). For example, a user who wants to "see it immediately" for `worker_completed` can raise it to urgent in their `.state/attention.json`, while the template default (normal) is maintained independently.
+
+### 4.2 4-step TTL ladder for pending_decisions
+
+The three thresholds `pending_decision_min` / `pending_decision_max` / `pending_decision_drop` create a **4-step notification decay** based on the elapsed time since a judgment escalation was registered. This is designed to avoid the failure pattern where "ringing urgent forever on unresolved judgments" causes the watcher itself to be muted (noise → uniformly ignored) — see the rationale in [`docs/design/attention-notification.md`](../design/attention-notification.md) §12.
+
+| Elapsed time | Stage | Behavior |
+|---|---|---|
+| `< pending_decision_min` (default less than 15 min) | grace | No attention event fired. A grace window on the assumption that the Secretary can relay to a human within a short time |
+| `pending_decision_min ≤ t < pending_decision_max` (default 15 min — 24h) | urgent | desktop notification + urgent sound + terminal bell. First-response window |
+| `pending_decision_max ≤ t < pending_decision_drop` (default 24h — 7d) | normal / visual-only | The desktop notification fires but no urgent sound. A visual remnant marking long-unresolved cases |
+| `≥ pending_decision_drop` (default 7d or more) | suppressed | Both desktop and sound are suppressed. Only the `attention scan --json` output retains it, viewable via audit / dashboard paths |
+
+**Runtime-side consistency conditions**: configs that do not satisfy `pending_decision_min < pending_decision_max < pending_decision_drop` cause the runtime's `attention/config.py` to return a validation error at load time (`user_replied_min < pending_decision_max` is also checked).
+
+**Tuning advice**:
+
+- **Tighten the urgent window in noisier workflows**: lower `pending_decision_max` (e.g., 24h → 4h). Demotes urgent → normal earlier, distinguishing the high-urgency newer pendings
+- **Keep a longer audit trail**: raise `pending_decision_drop` (e.g., 7d → 30d). Extends the grace before full suppression, making long-running backlogs auditable via `attention scan --json`
+- **Judgment escalations are frequent and the 15-minute grace feels short**: lengthen `pending_decision_min` (e.g., 15 → 60). For operations that want headroom for the Secretary's relay and want to suppress urgent over-firing
+- Aligning `pending_decision_drop = pending_decision_max` removes the normal/visual stage, so excess immediately becomes suppressed. For short-lifecycle teams that do not need a "while-demoting" display
+
+## 5. Troubleshooting
+
+### 5.1 Desktop notification does not appear
+
+1. Confirm that attention events appear on stdout with `--dry-run`:
+   ```bash
+   claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json
+   ```
+   If no event appears, the cause is upstream of the classifier (event injection into `.state/state.db` or the state of `.state/pending_decisions.json`). Trace `tools/journal_append.sh` / `tools/pending_decisions.py` paths instead of the watcher side.
+2. If events appear but only OS notifications are absent, the backend was judged unavailable, or a backend without a visible UI was selected:
+   - **macOS**: confirm that the notification-center settings allow notifications to your terminal / iTerm
+   - **Linux**: run `which notify-send`; if missing, install via `sudo apt install libnotify-bin` or similar
+   - **WSL**: verify install with `which wsl-notify-send.exe`. If not installed, it falls back to PowerShell `Write-Host` and nothing reaches the Windows notification center (only the urgent beep is audible). Install `~/.local/bin/wsl-notify-send.exe` via the steps in §3.1
+   - **Windows native**: currently no visible notification surface implemented (see the §3 table). Only the urgent beep is audible. Real toast is planned in a separate follow-up Issue
+3. If stdout contains a log similar to "fallback to terminal bell," the backend has explicitly fallen back. Check the items above.
+
+### 5.2 Sound does not ring
+
+- Check `sound` in `.state/attention.json` (not `"off"`? if `"urgent-only"`, is the target event classified as `urgent`?)
+- The current runtime does not invoke sound-playback commands (`afplay` / `paplay`, etc.); when `sound` is effective, it rings the terminal bell `\a`. Check whether your terminal config has suppressed the bell (iTerm / Windows Terminal / GNOME Terminal each have visual bell / silent bell options)
+- On Windows / WSL, `powershell.exe -NoProfile -Command "[console]::beep(...)"` runs as a separate subprocess (the beep goes through the same PowerShell even when the WSL `wsl-notify-send.exe` path is chosen). Check host-side sound settings (system volume / stereo-mixer muting)
+- On the WSL real-toast path (§3.1), when the toast succeeds, the terminal bell is suppressed (to avoid double-beep with the PowerShell beep). If toasts appear but beeps do not, check in order: `sound` setting / whether the event severity is classified as urgent / system volume
+
+### 5.3 The same event keeps ringing / does not ring
+
+The dedup state is managed by the runtime in `.state/attention_notified.json`.
+
+- **The same event keeps ringing despite cooldown** → `.state/attention_notified.json` may be broken JSON. The runtime emits a warning and regenerates when corruption is detected, but to force a reset, delete it manually:
+  ```bash
+  rm .state/attention_notified.json
+  ```
+  It will be regenerated on the next scan / watch (atomic replace).
+- **An event you want to hear does not ring** → it may be suppressed inside cooldown. Temporarily shorten `cooldown_sec`, or manually remove the key from `.state/attention_notified.json` and rescan.
+
+### 5.4 Notification body is unexpected / garbled
+
+- Placeholders appear as literals → if you wrote anything outside the design §6 allowlist (`{task_id} {worker} {kind} {status} {pr} {summary}`) into the template, the runtime keeps it as a literal or uses the fallback template. Rewrite within the allowlist
+- Body is cut off → being truncated at `max_title_chars` / `max_body_chars`. This is part of secret-safe formatting, so it is preferable to shorten the summary rather than lengthen the body
+- Japanese characters become `?` / garbled → on Linux, `notify-send` can corrupt them when locale is `C`. Export `LANG=ja_JP.UTF-8` or similar before starting `watch`
+
+## 6. Related
+
+- Design: [`docs/design/attention-notification.md`](../design/attention-notification.md)
+- Verification procedure: the `attention scan --dry-run` verification block in [`docs/verification.md`](../verification.md)
+- Startup guidance from `/org-start`: [`.claude/skills/org-start/SKILL.md`](../../.claude/skills/org-start/SKILL.md)
+- External sinks (Slack / Discord / ntfy) are out of the initial scope (design §9, future opt-in)


### PR DESCRIPTION
## Summary

Translate and add two new English docs from ja#455:

- `docs/design/attention-notification.md` (580 lines, design doc for the attention notification layer)
- `docs/operations/attention-watch.md` (209 lines, operations runbook for `claude-org-runtime attention watch`)

Both files did not exist in this en mirror; their ja counterparts were merged in ja#455 (commit `be499522`). The runtime portion of ja#455 (`tools/templates/attention.example.json`) is already in en main via the auto-mirror bulk sync (PR #247).

Code blocks, command examples, file paths, configuration values, and internal links keep their original form; only Japanese prose is rendered into English.

Closes #241.

## Test plan

- [ ] CI green
- [ ] Spot-check that both docs are fully in English (no untranslated Japanese paragraphs remain) and that headings / lists / tables mirror the ja structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)