### PR TITLE
chore: sync runtime pins with ja main (Closes #191, Closes #210)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.1,<0.2",
+    "claude-org-runtime>=0.1.9,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-claude-org-runtime>=0.1.1,<0.2
+claude-org-runtime>=0.1.9,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## Summary

Sync `requirements.txt` and `pyproject.toml` runtime pins to match claude-org-ja main. The en mirror's project identity (`name = "claude-org"`) and the `discover.py` canary comment block are preserved.

Closes #191.
Closes #210.

## Test plan

- [ ] CI green (runtime drift check)
- [ ] Spot-check that `pyproject.toml` still has `name = "claude-org"` and the canary comment block from PR #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)