### PR TITLE
docs: translate .claude/skills/** to English (Closes #180 #187 #205 #230 #232)

### DIFF
--- a/.claude/skills/org-delegate/SKILL.md
+++ b/.claude/skills/org-delegate/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: org-delegate
 description: >
-  Dispatch Worker Claude instances and delegate work to them. The Lead acts as the
-  command node, and hands off hands-on execution to Workers by default.
-  Trigger this when a user request requires file edits, implementation, research,
-  or other execution work.
+  Dispatch a Worker Claude to delegate work. The Lead is the command tower;
+  hands-on execution is, in principle, left to Workers.
+  Fires when a user request involves actual hands-on work such as
+  file edits, implementation, or investigation.
 effort: medium
 allowed-tools:
   - Read
@@ -24,226 +24,237 @@ allowed-tools:
   - mcp__renga-peers__list_panes
 ---
 
-# org-delegate: Worker Dispatch
+# org-delegate: Worker dispatch
 
-Delegate work to Worker Claude instances. The Lead only decomposes the task and generates the dispatch payload, then hands pane launch and instruction delivery to the Dispatcher. This minimizes the Lead's lock time.
+Delegate work to a Worker Claude. The Lead performs only task decomposition and dispatch-payload generation; pane spawning and instruction delivery are delegated to the Dispatcher. This minimizes the time the Lead is locked.
 
-> **Scope of this SKILL**: Only the initial dispatch phase: task identification → dispatch payload generation → handing off `DELEGATE` to the Dispatcher → greeting after Worker launch → ack on progress/completion reports and transition to REVIEW. The following are split into other skills / references:
-> - **Worker launch, instruction delivery, and state recording procedure** → [`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md) (Dispatcher-only)
-> - **Push / PR / CI watch / review-fix loop / post-merge close after user approval** → [`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md)
-> - **Worker requests for judgment, scope expansion, and blocker escalation** → [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md)
-> - **Minimum three ack elements and message-type-specific examples** → [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md) (single SoT)
+> **Scope of this SKILL**: Only the "initial leg" of dispatch (task identification → dispatch-payload generation → handoff of DELEGATE to the Dispatcher → greeting after the Worker is started → ack and REVIEW transition when progress / completion reports come in). The following are separated into other skills / references:
+> - **Worker spawning, instruction sending, and state recording procedures** → [`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md) (Dispatcher-exclusive)
+> - **Post-user-approval push / PR / CI watch / review-comment loop / post-merge close** → [`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md)
+> - **Escalation of judgment requests / scope expansion / blockers from Workers** → [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md)
+> - **Minimum 3 elements of an ack message and per-kind example texts** → [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md) (single SoT)
 
-> **state-db cutover (M4, Issue #267 / #284)**: Structured section writes must go **through `StateWriter.transaction()`**. The post-commit hook automatically regenerates `.state/org-state.md` / `.state/org-state.json` from the DB, and `update_run_status('<task_id>', 'completed')` automatically moves `.state/workers/worker-<task_id>.md` to `.state/workers/archive/`. Direct markdown edits are detected by `drift_check`. For events, the DB `events` table is the SoT (`tools/journal_append.sh` / `.py` already route to the DB). If the DB is missing, build it with `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
+> **state-db cutover (M4, Issue #267 / #284)**: All writes to structured sections **must go through `StateWriter.transaction()`**. A post-commit hook auto-regenerates `.state/org-state.md` / `.state/org-state.json` from the DB, and calling `update_run_status('<task_id>', 'completed')` automatically moves `.state/workers/worker-<task_id>.md` to `.state/workers/archive/`. Direct markdown edits are detected by drift_check. The SoT for events is the DB `events` table (`tools/journal_append.sh` / `.py` already route to the DB). When the DB is missing, build it with `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
 
-## Lead and Dispatcher Responsibilities
+## Lead / Dispatcher division of roles
 
-| Stage | Owner |
+| Step | Owner |
 |---|---|
 | Project name resolution | **Lead** |
 | work-skill search | **Lead** |
-| Task decomposition / dispatch payload generation | **Lead** (`gen_delegate_payload.py`) |
-| `DELEGATE` send | **Lead** (the Lead is released here) |
-| Pane launch, peer wait, instruction delivery, state recording | **Dispatcher** ([`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md)) |
-| Dispatch completion report to the Lead | **Dispatcher** |
-| Receive progress / completion / escalation reports from Workers | **Lead** |
-| Pane close on Worker completion | **Dispatcher** (`CLOSE_PANE` requested by the Lead) |
+| Task decomposition / dispatch-payload generation | **Lead** (`gen_delegate_payload.py`) |
+| DELEGATE send | **Lead** (the Lead is released at this point) |
+| Pane spawn / peer wait / instruction send / state recording | **Dispatcher** ([`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md)) |
+| Dispatch-complete report back to the Lead | **Dispatcher** |
+| Receiving progress / completion / escalation reports from Workers | **Lead** |
+| Pane close on Worker completion | **Dispatcher** (on `CLOSE_PANE` request from the Lead) |
 
-## Pre-delegation Checklist (run by the Lead)
+## Pre-delegation checklist (executed by the Lead)
 
-Before task decomposition, check the request from the following angles. Ask the user to clarify when applicable.
+Before entering task decomposition, check the request from the following angles. If any apply, ask the user back.
 
-| Check item | Situation to confirm | Example |
+| Check item | Situations to confirm | Example |
 |---|---|---|
-| **Ambiguous terms / abbreviations** | A tool name, service name, or abbreviation may have multiple meanings | `gog` → Google OAuth? `gog` CLI? |
-| **OS-specific prerequisites** | The output differs by OS and default assumptions must be explicit | Mac=`zsh`, Windows=`py -3`, path separators |
+| **Ambiguous terms / abbreviations** | When a tool name, service name, or abbreviation could mean multiple things | "gog" → Google OAuth? gog CLI? |
+| **OS-specific preconditions** | When producing OS-specific deliverables, default settings must be made explicit | Mac=zsh, Windows=py -3, path separator |
 
-- If there is ambiguous terminology: ask the user, "Does `○○` mean `△△`?" before proceeding.
-- For OS-specific tasks: include OS-specific prerequisites in the Worker instructions when generating the payload.
+- When there is an ambiguous term: ask the user "Do you mean XX by YY?" before proceeding
+- For OS-specific tasks: include OS-specific preconditions in the Worker instructions when generating the payload
 
-## Step 0: Project Name Resolution (run by the Lead)
+### Initial-step checklist for incorporation / sync tasks
 
-Identify the project from the user request:
+For incorporation / sync tasks that bring a source (review results / another branch / state of another repository) into a destination, **when the source commit is more than N commits ahead of the destination's current state, consider selective merge (cherry-pick / apply only the necessary hunks) as the initial move**. A byte-identical cp risks mechanically overwriting Codex iterative review fixes.
+
+| Angle | Check | Action |
+|---|---|---|
+| Divergence between source and destination | Verify both directions with `git log <source>..<destination>` / `git log <destination>..<source>` | If both directions have diverged, prohibit cp and adopt selective merge |
+| Additional fixes on the destination side | Whether Codex review fixes / Blocker fixes are stacked on the destination branch | If they are, do not mechanically overwrite with cp (cherry-pick or hunk-level apply) |
+
+Background: There have been past incidents where cp mechanically reverted destination-side fixes (a destination-side credential-exposure Blocker fix nearly got reverted). Require the Worker brief to specify "no cp as the initial step / state the incorporation strategy explicitly".
+
+## Step 0: Project name resolution (executed by the Lead)
+
+Identify the project from the user's request:
 
 1. Read `registry/projects.md`
-2. Identify the matching project from keywords in the request (match against alias, project name, and description)
+2. Identify the matching project from keywords in the request (match against alias / project name / description)
 3. If identified, use that path
-4. If not identified, show the list of registered project aliases and let the user choose
+4. If not identifiable, present the list of registered project aliases and let the user choose
 5. For a new project:
    - Confirm the path with the user
-   - Infer the alias, description, and common work examples, then append them to `registry/projects.md` after user confirmation
+   - Estimate alias / description / typical work examples, confirm with the user, then append to `registry/projects.md`
 
-## Step 0.5: work-skill Search (run by the Lead)
+## Step 0.5: work-skill search (executed by the Lead)
 
-Before task decomposition, search for existing related work-skills. Include matched work-skills in Worker instructions as reference material.
+Before task decomposition, search for any related existing work-skills. Matched work-skills are included as reference information in the Worker instructions.
 
-1. Enumerate all `SKILL.md` files under `.claude/skills/`
-2. Match each `SKILL.md` frontmatter (`type` / `description` / `triggers`) against the task. Exclude the `org-` prefix because those are org-operation skills
-3. Include relevant candidates when applicable. Exact match is not required; if multiple match, include all in relevance order
+1. Enumerate all SKILL.md files under `.claude/skills/`
+2. Compare each SKILL.md's frontmatter (`type` / `description` / `triggers`) against the task content. The `org-` prefix denotes org-operation skills and is excluded from the search
+3. Include any relevant candidates (exact match not required; for multiple matches, include all in relevance order)
 
-**If matched:**
-- Notify the human: `Found a related work-skill: {skill-name} — I will include it as reference material`
-- Pass the work-skill `SKILL.md` path to the `gen_delegate_payload.py` call via the `--knowledge` flag. The Stage 2 brief renderer embeds that path into `CLAUDE.md` / `CLAUDE.local.md` as `[references].knowledge`. For multiple matches, repeat as `--knowledge <path1> --knowledge <path2>`
-- Explicitly note the presence of the reference skill in the Worker instructions (`instruction-template`)
+**When matches are found:**
+- Notify the human: "Found a related work-skill: `{skill-name}` — including as reference information"
+- Pass the work-skill's SKILL.md path to `gen_delegate_payload.py` via the `--knowledge` flag. The Stage 2 brief renderer embeds that path into CLAUDE.md / CLAUDE.local.md as `[references].knowledge`. For multiple matches, repeat: `--knowledge <path1> --knowledge <path2>`
+- Also note the presence of the reference skill in the Worker instructions (instruction-template)
 
-Do not copy a work-skill procedure verbatim. Present it as reference material and let the Worker decide.
+Do not copy the work-skill's procedure verbatim. Present it as reference information and let the Worker decide.
 
-## Step 0.6: Pre-fetch for release-class tasks (run by the Lead)
+## Step 0.6: Pre-fetch for release-class tasks (executed by the Lead)
 
-Tasks that cut a `release/*` branch assume the Worker branches from the **latest `main` of the target project**. Since the Phase 2 Worker git guardrails, the Worker-side `.claude/settings.json` `permissions.deny` list includes `Bash(git fetch)` / `Bash(git pull)` / `Bash(git remote update)`. Dispatching a Worker while local `origin/main` is stale therefore fires a "git fetch deny" BLOCKER within 5 minutes of start, causing a 10+ minute round-trip with the Lead (claude-org-runtime v0.1.10 incident).
+Tasks that cut a `release/*` branch assume the worker branches from **the target project's latest `main`**. Since Phase 2 worker git guardrails, the worker-side `.claude/settings.json` `permissions.deny` includes `Bash(git fetch)` / `Bash(git pull)` / `Bash(git remote update)`. If you dispatch a worker while local `origin/main` is stale, a "git fetch deny" BLOCKER fires within 5 minutes of work, costing over 10 minutes of Lead round-trip (claude-org-runtime v0.1.10 case).
 
-For this reason, **only for release-class tasks**, the Lead performs the fetch on the Worker's behalf before `gen_delegate_payload.py preview` / `apply`:
+For this reason, **only for release-class tasks**, the Lead performs the fetch on its side before `gen_delegate_payload.py preview` / `apply`:
 
 ```bash
-# Local root of the target project (the repo where the release will be cut)
+# Local root of the target project (the repository where the release is cut)
 cd <target project root>
 
-# Pick up the latest origin/main and ff-update local main
+# Pull in the latest origin/main and fast-forward local main
 git fetch origin
 git pull --ff-only origin main
 ```
 
-### Applicability
+### Trigger conditions
 
-Trigger only when one of the following applies:
+Fire only when one of the following applies:
 
-- The task description / commit-prefix / planned branch contains a release-promotion term such as `release`, `release/`, `vX.Y.Z`
-- The target files include release-promotion work such as a `CHANGELOG.md` promotion or a `version` bump in `__about__.__version__` / `pyproject.toml`
-- The `task_id` contains `release` (example: `runtime-0-1-10-release`)
+- The task description / commit-prefix / planned branch contains words signaling a release promotion such as `release`, `release/`, `vX.Y.Z`
+- The target files include release-promotion work such as promoting `CHANGELOG.md`, bumping `__about__.__version__` / `pyproject.toml`'s `version`
+- The task_id contains `release` (e.g., `runtime-0-1-10-release`)
 
-Do not run this for ordinary feature / fix / docs tasks. Worker permissions deny is an intentional design choice that "the Worker does not pull mainline history and completes work inside the sandbox"; only releases are the exception that requires "branching from the latest main".
+Do not execute for ordinary feature / fix / docs tasks. The worker permissions deny is an intentional design that "the worker does not pull in mainline history and self-contains within its sandbox"; only release is the exception flow that requires "branching from the latest main".
 
 ### Background
 
-For the detailed background (the measured 5-minute Worker BLOCKER → 10-minute extra round-trip, comparison of four response options, and the permissions-side root cause), see the section "On release-branch creation, the Lead performs `git fetch` on the Worker's behalf" in [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md).
+For the detailed history (measured 5-minute-in BLOCKER → 10-minute additional loss for workers, comparison of 4 response options, permissions-side root cause), refer to the "When creating a release branch, the Lead performs `git fetch` on its side" section of [`knowledge/curated/release-process.md`](../../../knowledge/curated/release-process.md).
 
-## Step 0.7 / 1 / 1.5 / 2: Generate the Dispatch Payload with One Command (Issue #283)
+## Step 0.7 / 1 / 1.5 / 2: Generate the dispatch payload in 1 command (Issue #283)
 
-Step 0.7 (pre-check for `.gitignore`) / Step 1 (Pattern decision) / Step 1.5 (Worker directory preparation + role decision + settings generation) / Step 2 (`DELEGATE` body assembly) are handled **in one pass by `tools/gen_delegate_payload.py`**. The Lead is only responsible for task identification (Step 0), work-skill search (Step 0.5), target file extraction, and depth selection.
+Step 0.7 (gitignore pre-check) / Step 1 (Pattern determination) / Step 1.5 (Worker directory preparation + role decision + settings generation) / Step 2 (DELEGATE body assembly) are **all handled by `tools/gen_delegate_payload.py`**. The Lead's responsibility is only task identification (Step 0), work-skill search (Step 0.5), target-file extraction, and depth judgment.
 
 ### Standard flow (recommended)
 
 ```bash
-# 1. preview: fully non-destructive. Only check the DELEGATE body and the list of files to be created
+# 1. preview: completely non-destructive. Only confirms the DELEGATE body and the list of files to be created
 python tools/gen_delegate_payload.py preview \
     --task-id <task-id> --project-slug <slug> \
     --target <path>... --description "<desc>" \
     --verification-depth full
 
-# 1.5. Step 1.7 gate: evaluate Codex design-review trigger conditions against the preview output.
-#      Only when applicable, run a design review with `codex exec` and pass the summary to apply
-#      via --impl-guidance or --knowledge (see Step 1.7 below).
+# 1.5. Step 1.7 gate: evaluate the Codex design review trigger conditions on the preview output
+#      Only when applicable, run a design review with codex exec and pass the summary
+#      to apply via --impl-guidance or --knowledge (see Step 1.7 below)
 
-# 2. apply: reserve state.db with runs.status='queued' + place CLAUDE.md/CLAUDE.local.md
-#    + run claude-org-runtime settings generate + output send_plan.json
+# 2. apply: reserve in state.db with runs.status='queued' + place CLAUDE.md/CLAUDE.local.md
+#    + run claude-org-runtime settings generate + emit send_plan.json
 python tools/gen_delegate_payload.py apply \
     --task-id <task-id> --project-slug <slug> \
     --target <path>... --description "<desc>" \
     --verification-depth full
 
-# 3. Copy the send_plan.json emitted by apply into the MCP call
+# 3. Copy-paste the send_plan.json from the apply output into the MCP call
 #    cat <worker_dir>/send_plan.json
 #    → mcp__renga-peers__send_message(to_id="dispatcher", message=<message>)
 ```
 
-`apply` performs **T1 reservation only** (`runs.status='queued'`). Activation into Active Work Items is Dispatcher T2 ([`docs/contracts/delegation-lifecycle-contract.md`](../../../docs/contracts/delegation-lifecycle-contract.md)), so this skill does not touch it. On failure, leave the queued entry in place and ask the Lead for judgment.
+`apply` performs **only T1 reservation** (`runs.status='queued'`). Activation into Active Work Items is the Dispatcher's T2 ([`docs/contracts/delegation-lifecycle-contract.md`](../../../docs/contracts/delegation-lifecycle-contract.md)), so this skill does not touch it. On failure, leave the queue as is and escalate to the Secretary for judgment.
 
-### Common flags
+### Frequently used flags
 
-- `--mode edit|audit` (default `edit`): explicitly use `--mode audit` for **read-only** audit tasks on `claude-org`
-- `--branch <name>`: override `planned_branch`. Default is `feat/<task-id>` (`fix/<task-id>` when the description contains `fix` / `bug` / `修正`)
-- `--commit-prefix "<prefix>"`: if omitted, infer from the head of `project_slug` (example: `claude-org` → `feat(claude):`)
-- `--closes-issue N` / `--refs-issues N1 N2`: embed `Closes #N` / `Refs #N1 #N2` into the brief
+- `--mode edit|audit` (default `edit`): For **read-only** audit tasks on claude-org, explicitly specify `--mode audit`
+- `--branch <name>`: Override planned_branch. Default is `feat/<task-id>` (becomes `fix/<task-id>` if the description contains "fix" / "bug" / "修正")
+- `--commit-prefix "<prefix>"`: When omitted, inferred from the head of project_slug (e.g., `claude-org-ja` → `feat(claude):`)
+- `--closes-issue N` / `--refs-issues N1 N2`: Embeds "Closes #N" / "Refs #N1 #N2" into the brief
 - `--impl-target <path>` / `--impl-guidance "<text>"` / `--knowledge <path>`: optional `[implementation]` / `[references]` sections
-- `--skip-settings`: skip `claude-org-runtime settings generate` (for environments where the CLI is not installed)
-- `--from-toml <path>`: use an existing `worker_brief.toml` as input. CLI flags override the TOML
+- `--skip-settings`: Skip `claude-org-runtime settings generate` (for environments without the CLI)
+- `--from-toml <path>`: Take an existing `worker_brief.toml` as input. CLI flags override the TOML
 
-### Pattern / role / branch decision details
+### Details on Pattern / role / branch determination
 
-See [`.claude/skills/org-delegate/references/delegate-flow-details.md`](references/delegate-flow-details.md) for the decision logic (`Pattern A` vs `B` vs `C` / gitignored submodes / role table / `planned_branch` / required lines in the `DELEGATE` body). For the self-edit task special case (Issue #289, `pattern_variant='live_repo_worktree'`), see §3 of [`.claude/skills/org-delegate/references/claude-org-self-edit.md`](references/claude-org-self-edit.md).
+For the determination logic (Pattern A vs B vs C / gitignored sub-mode / role table / planned_branch / required lines in the DELEGATE body), see [`.claude/skills/org-delegate/references/delegate-flow-details.md`](references/delegate-flow-details.md). For the special case of self-edit tasks (Issue #289, `pattern_variant='live_repo_worktree'`), see [`.claude/skills/org-delegate/references/claude-org-self-edit.md`](references/claude-org-self-edit.md) §3.
 
-### Target file extraction
+### Target-file extraction
 
-The Lead extracts "target files" from the task description: paths explicitly named in the request text, Issue body, or user message. Do not determine them mechanically. For tasks where target files cannot be identified, such as pure research or new file creation with undecided paths, `--target` is not required.
+"Target files" are extracted by the Lead from the task description (paths explicitly stated in the request text, Issue body, or user utterances; no mechanical determination). For tasks whose target files cannot be identified (pure investigation, new-creation tasks with no fixed target path, etc.), `--target` need not be passed.
 
-### When the standard path returns unexpected output
+### When the standard route returns unexpected output
 
-If the standard path (`gen_delegate_payload.py apply`) returns unexpected output such as a wrong Pattern decision, resolver error, or brief inconsistency, the Lead must **not manually reproduce the same work**. File an Issue for the resolver bug and pause delegation for that task until the resolver is fixed. Manual fallback is out of scope for this skill. In environments without the CLI, only the `--skip-settings` flag is allowed. A museum copy of the historical handwritten path exists at `docs/legacy/hand-typed-delegate-path.md`, but it must not be referenced in standard operations.
+When the standard route (`gen_delegate_payload.py apply`) returns unexpected output (Pattern misjudgment / resolver error / brief inconsistency, etc.), the Secretary **must not manually reproduce the same work**. File an Issue as a resolver bug, and pause delegation of that task until the resolver is fixed. Manual fallback is out of scope for this skill. In environments without the CLI, limit yourself to the `--skip-settings` flag. A museum copy of the historic hand-typed route exists at `docs/legacy/hand-typed-delegate-path.md`, but it is prohibited from reference in standard operations.
 
-## Step 1.7: Codex Design-Review Trigger (run by the Lead, Issue #337)
+## Step 1.7: Codex design review trigger (executed by the Lead, Issue #337)
 
-Looking at the `preview` output (`description` / number of `--target` entries / referenced documents), if **at least one** of the following applies, run a Codex design review **before** `apply`. This gate is based on Curator session #18 retrospective (Issue #283 / session #12), where "an up-front Codex design review caught 2 Blocker + 5 Major findings in a single round."
+Looking at the `preview` output's `description` / `--target` count / referenced documents, if **at least one** of the following applies, run a Codex design review before `apply`. This gate is based on the track record from the Curator session #18 retrospective (Issue #283 / session #12) where "a pre-Codex design review caught 2 Blockers + 5 Majors in one round".
 
-| Trigger | How to evaluate |
+| Trigger | Determination method |
 |---|---|
-| Estimated effort ≥ 3h | Lead's judgment from the task description (user input / preview scale) |
-| Introduces a new module / new tool | The description contains "new", "new tool", "newly introduced", etc., or the planned files in preview are all new paths |
-| File changes ≥ 3 | Number of `--target` entries + edit targets enumerated in the preview brief |
-| References a contract document under `docs/contracts/` | The description / brief / `--knowledge` references something under `docs/contracts/` |
+| Estimated effort ≥ 3h | Lead judges from the task description (user input / scale sense of preview) |
+| Introduction of a new module / new tool | Description contains "新規" / "new tool" / "新ツール" / "新規導入" etc., or the files to be created in the preview are all on new paths |
+| File changes ≥ 3 | Count of `--target` + edit targets listed in the preview brief |
+| Reference to contract documents under `docs/contracts/` | Description / brief / `--knowledge` references `docs/contracts/` |
 
-**Procedure:**
+**Execution procedure:**
 
 ```bash
 codex exec --skip-git-repo-check "Design review for <task-id>.\
-  Task: <description>.\
+  Task description: <description>.\
   Target files: <target paths>.\
   Related contracts / references: <docs paths>.\
-  Classify pre-implementation findings as Blocker / Major / Minor / Nit, and for each finding include the target file:line and the rationale, in concise English."
+  Classify pre-design findings as Blocker / Major / Minor / Nit. For each finding, cite the target file:line and the rationale. Be concise."
 ```
 
-Do not use the `codex:rescue` skill (forbidden by `CLAUDE.local.md`). Use `codex exec` directly only.
+Do not use the `codex:rescue` skill (prohibited per CLAUDE.local.md). Only direct `codex exec` invocation.
 
-**Embedding the review summary:**
+**Incorporating the review summary:**
 
-- Save the summary at `tmp/codex-review-{task-id}.md`
-- When calling `apply`, pass **`--impl-guidance "<summary body>"`**. This expands the summary body into `[implementation].guidance` in the brief, so the Worker can read it directly
-- As a supplement, add `--knowledge tmp/codex-review-{task-id}.md` so the brief's `[references].knowledge` enumerates the path and the Worker can refer to the full text on demand (`gen_worker_brief.py` only enumerates paths and does not embed bodies). Reliably delivering the body to the Worker is the responsibility of `--impl-guidance`
-- If a Blocker / Major is reported, escalate to the user and confirm whether the approach should change before proceeding to apply
+- Save the summary to `tmp/codex-review-{task-id}.md`
+- When calling `apply`, pass **`--impl-guidance "<summary body>"`**. This expands the summary body into the brief's `[implementation].guidance` so the Worker can read it directly
+- As a supplement, adding `--knowledge tmp/codex-review-{task-id}.md` lists the path under the brief's `[references].knowledge`, letting the Worker refer to the full text as needed (`gen_worker_brief.py` only lists the path, it does not embed the body). The responsibility for reliably delivering the body to the Worker lies on the `--impl-guidance` side
+- If a Blocker / Major is flagged, escalate to the user to confirm direction-change possibility before proceeding to apply
 
-**Helper script:** marked optional in the Issue #337 acceptance and not implemented in this PR. The Lead evaluates the table above manually.
+**helper script:** Optional per the Issue #337 acceptance, not implemented in this PR. The Secretary judges the above table manually.
 
-## Step 1.8: Dogfood Follow-up Issue Protocol (Lead + org-pull-request, Issue #338)
+## Step 1.8: dogfood follow-up issue protocol (Lead + org-pull-request coordination, Issue #338)
 
-For PRs that introduce a new tool / runtime / workflow, create a "dogfood follow-up" issue paired with the implementation PR, and explicitly earmark the next delegation that actually uses the new tool as a **dogfood pass**. This protocol is based on the Curator session #18 retrospective, where "PR #288 surfaced 4 categories of defects only on first real use" (also reproduced in session #11).
+For PRs that introduce a new tool / runtime / workflow, create a "dogfood follow-up" issue paired with the implementation PR, and explicitly earmark the next delegation that actually uses that new tool as a **dogfood pass**. This protocol is based on the phenomenon in the Curator session #18 retrospective where "PR #288 only surfaced 4 categories of defects on first real use" (also reproduced in session #11).
 
-### Applicability
+### Trigger conditions
 
-Triggered when the task is one of the following:
+Fires when the task is one of the following:
 
-- Adds a new CLI tool / script (`tools/*.py`, `tools/*.sh`, `tools/*.ps1`, etc.)
-- Introduces a new runtime / new workflow / new protocol
-- A breaking redesign of an existing tool
+- Adding a new CLI tool / script (`tools/*.py`, `tools/*.sh`, `tools/*.ps1`, etc.)
+- Introducing a new runtime / new workflow / new protocol
+- Re-design of an existing tool that involves a breaking change
 
-### Lead (org-delegate) responsibilities
+### The Lead's (org-delegate) responsibilities
 
-The dogfood protocol spans **two delegations**: (A) the **implementation delegation** that introduces the new tool, and (B) the **dogfood pass delegation** that actually uses that tool afterward. The Lead reads/writes `registry/dogfood_pending.md` in both.
+The dogfood protocol spans **2 delegations**: (A) the **implementation delegation** that introduces the new tool, and (B) the subsequent **dogfood pass delegation** that actually uses that tool. The Lead reads and writes `registry/dogfood_pending.md` in both.
 
-**(A) When opening the implementation delegation (same timing as Step 1.7 evaluation):**
+**(A) When filing the implementation delegation (same timing as Step 1.7 evaluation):**
 
-1. Determine that applicability is satisfied, and in parallel with preview, mark the task as a "dogfood target task"
-2. Append one new row to `registry/dogfood_pending.md` with `status=pending`, empty `dogfood_issue` / `dogfood_run_task_id`, and empty `impl_pr` (the PR number is filled in later). At this point the implementation PR itself does not yet exist
-3. The implementation Worker brief does not need to mention dogfood (neither the issue number nor the PR number is finalized at this point). The implementation Worker just builds the tool as usual
+1. Determine that the trigger conditions apply and, in parallel with preview, mark it as a "dogfood-target task"
+2. Append 1 new row to `registry/dogfood_pending.md` with `status=pending` / `dogfood_issue` / `dogfood_run_task_id` empty / `impl_pr` empty (PR number filled in later). At this point the implementation PR itself does not yet exist
+3. The brief for the implementation worker need not mention dogfood (neither issue number nor PR number is fixed at this point). The implementation worker simply builds the tool as usual
 
-**(B) When opening the dogfood pass delegation:**
+**(B) When filing the dogfood pass delegation:**
 
-4. Whenever opening a new delegation, check rows in `registry/dogfood_pending.md` whose `status=open` (= the paired follow-up issue is created and a dogfood pass has not yet been run)
-5. If the new task being opened actually uses the tool / surface in question, earmark that task as the dogfood pass:
+4. Whenever filing a new delegation, check `registry/dogfood_pending.md`'s `status=open` rows (= paired follow-up issue created / dogfood pass not yet performed) each time
+5. If the new task to be filed actually uses the target in the `tool / surface` column, earmark that task as a dogfood pass:
    - Add `--impl-guidance "Dogfood pass for paired follow-up issue #<N>. Report any defects to that issue using the format in references/dogfood-issue-template.md. Refs #<N>, do not Closes."` to the `apply` call
-   - Additionally pass `--knowledge .claude/skills/org-delegate/references/dogfood-issue-template.md` so the defect-reporting format is included in the brief
-6. Update the relevant row: fill in `dogfood_run_task_id=<new task_id>`, leave `status` at `open` (it transitions to `consumed` upon receipt of the dogfood Worker's completion report — see §register state transitions)
+   - Additionally pass `--knowledge .claude/skills/org-delegate/references/dogfood-issue-template.md` to include the defect-reporting format in the brief
+6. Update the relevant row: fill `dogfood_run_task_id=<new task_id>`, and leave `status` as `open` (transitions to `consumed` upon receipt of the completion report from the dogfood worker; see §Register state transitions)
 
-### org-pull-request responsibilities (cross-ref)
+### org-pull-request's responsibilities (cross-ref)
 
-At PR creation / merge time, the org-pull-request side does the following (detailed steps live there; Issue #338 only records the protocol in this SKILL):
+Done at the time of implementation PR creation / merge (detailed procedure is maintained separately on the org-pull-request side; Issue #338's scope is to record the protocol in this SKILL):
 
-1. Right after creating the implementation PR: find the row in `registry/dogfood_pending.md` with `status=pending`, fill in `impl_pr=#<NNN>`, and create the paired follow-up issue with `gh issue create --body-file <rendered template>` (template: [`references/dogfood-issue-template.md`](references/dogfood-issue-template.md))
-2. Fill the created issue number into `dogfood_issue=#<MMM>` on that row, and transition `status` from `pending → open`
+1. Immediately after implementation PR creation: find the matching `status=pending` row in `registry/dogfood_pending.md`, fill in `impl_pr=#<NNN>`, and create the paired follow-up issue via `gh issue create --body-file <rendered template>` (template: [`references/dogfood-issue-template.md`](references/dogfood-issue-template.md))
+2. Fill the created issue number into the row's `dogfood_issue=#<MMM>`, and transition `status` from `pending → open`
 3. Append `Paired dogfood issue: #<MMM>` to the bottom of the implementation PR body
-4. When the paired issue is closed, transition `status` from `consumed → closed` on that row
+4. When the paired issue is closed, transition the row's `status` from `consumed → closed`
 
-### `dogfood_pending` register format
+### dogfood_pending register format
 
-`registry/dogfood_pending.md` is **not append-only but a partial-update register**: appending rows is via append, and per-column updates (`impl_pr` / `dogfood_issue` / `dogfood_run_task_id` / `status`) are allowed. Logical deletion and row reordering are forbidden.
+`registry/dogfood_pending.md` is **a partial-update register, not append-only**: row additions are append; updates to each column (`impl_pr` / `dogfood_issue` / `dogfood_run_task_id` / `status`) are allowed. Logical deletion and row reordering are prohibited.
 
 ```
 | task_id | tool / surface | impl_pr | dogfood_issue | dogfood_run_task_id | status |
@@ -251,20 +262,20 @@ At PR creation / merge time, the org-pull-request side does the following (detai
 | issue-XXX-new-tool | tools/foo.py | #YYY | #ZZZ | issue-MMM-bar | open |
 ```
 
-### register state transitions
+### Register state transitions
 
 ```
-[Append row] (org-delegate Step 1.8 §A.2)
-  status = pending      ← issue not created yet / impl_pr also empty
+[Row added] (org-delegate Step 1.8 §A.2)
+  status = pending      ← issue not created / impl_pr also empty
        │
        │ Implementation PR created + paired issue created (org-pull-request §1-2)
        ▼
-  status = open         ← paired issue created / dogfood pass not yet run
+  status = open         ← paired issue created / dogfood pass not yet performed
        │
-       │ Earmarked by a follow-up delegation (org-delegate Step 1.8 §B.5-6)
-       │ Fill in dogfood_run_task_id. status stays open
+       │ Earmarked by a subsequent delegation (org-delegate Step 1.8 §B.5-6)
+       │ Fill dogfood_run_task_id. status stays open
        │
-       │ Dogfood pass Worker completion report received → defects already aggregated on the paired issue
+       │ Dogfood pass worker completion report received → defects aggregated into paired issue
        ▼
   status = consumed     ← defect monitoring period
        │
@@ -273,68 +284,72 @@ At PR creation / merge time, the org-pull-request side does the following (detai
   status = closed       ← terminal
 ```
 
-Each transition is a **single-column delta on a single row**. Updating multiple columns at once is allowed within the same row (e.g., `pending → open` updates `impl_pr` + `dogfood_issue` + `status` together).
+Each transition is a **single-column diff rewrite** on a single row of the table. Rewriting multiple columns simultaneously (e.g., pending → open is a batched update of `impl_pr`, `dogfood_issue`, and `status`) is allowed as long as it stays on the same row.
 
-### `consumed → closed` observation timing (Lead's register-hygiene responsibility)
+### consumed → closed observation timing (Lead's register hygiene responsibility)
 
-A paired follow-up issue may be closed outside the implementation PR's lifecycle (manual close / split into individual fix issues / cleanup after a long idle period), so detection cannot be guaranteed by org-pull-request triggers (PR creation / review / post-merge close) alone. The Lead runs the following hygiene check at **every moment it writes to `registry/dogfood_pending.md`** (= opening the implementation delegation / earmarking the dogfood pass / receiving the dogfood-pass completion report / state inspection):
+Because the paired follow-up issue can be closed outside the implementation PR's lifecycle (manual close / split into individual fix issues / cleanup after long idle), relying only on `org-pull-request`'s trigger events (PR creation / review / post-merge close) will cause detection gaps. The Lead performs the following hygiene check at **every opportunity it writes to `registry/dogfood_pending.md`** (= implementation delegation filing / dogfood pass earmarking / dogfood pass completion receipt / status check):
 
 ```bash
-# For each row with status=consumed, transition to closed if the paired dogfood_issue is closed
+# For status=consumed rows, transition to closed if the paired dogfood_issue is closed
 gh issue view <dogfood_issue> --json state -q .state
   # → if "CLOSED", rewrite status from consumed to closed
 ```
 
-In addition, the `/org-resume` startup briefing also scans rows with `status=consumed` once each and closes them (resume-time hygiene). This way, even if `consumed` rows linger in the register, they are reliably collected by the next register operation.
+In addition, the briefing at `/org-resume` startup also scans `status=consumed` rows once each and closes them (resume-time hygiene). This ensures that even if consumed lingers in the register, it is always reaped by the next register operation.
 
-## Step 3 / 4: Worker Launch, Instruction Delivery, State Recording (run by the Dispatcher)
+## Step 3 / 4: Worker spawn / instruction send / state recording (executed by the Dispatcher)
 
-For the detailed procedure (`3-1 balanced split` / `3-1c SPLIT_CAPACITY_EXCEEDED escalate` / `3-2 spawn` / `3-3 pane_started` / `3-3b channel approve` / `3-4 list_peers` / `3-5 instruction send` / `3-6 sequential launch` / Step 4 state recording / Worker Directory Registry), use **[`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md)** as the primary reference. The Lead does not touch this.
+For the detailed procedure (3-1 balanced split / 3-1c SPLIT_CAPACITY_EXCEEDED escalate / 3-2 spawn / 3-3 pane_started / 3-3b channel approve / 3-4 list_peers / 3-5 instruction send / 3-6 sequential spawn / Step 4 state recording / Worker Directory Registry), reference **[`.dispatcher/references/spawn-flow.md`](../../../.dispatcher/references/spawn-flow.md)** as the primary source. The Lead does not touch it.
 
-When dispatch completes, the Dispatcher returns `DELEGATE_COMPLETE` to the Lead.
+The Dispatcher returns `DELEGATE_COMPLETE` to the Lead upon dispatch completion.
 
-## Step 5: Progress Management (run by the Lead)
+## Step 5: Progress management (executed by the Lead)
 
-### On `DELEGATE_COMPLETE`
+### ⚠️ cwd caution: state.db touching tools
 
-After receiving the dispatch completion report from the Dispatcher, send a greeting message to each Worker:
+`tools/journal_append.sh` / `tools/journal_append.py` / `tools/set_run_pr_open.py` / `python -c "... StateWriter ..."` and the like — any tool that opens `state.db` via a relative path — assume ja-root-relative. If you launch them from a worker / worktree cwd, they will fail silently or crash with `no such table: runs` / `no such table: events`, and the downstream post-commit hook and snapshot regeneration will not run either. Always `cd <ja-root>` before executing. Issue #398 is tracking a root fix.
+
+### On DELEGATE_COMPLETE receipt
+
+When you receive a dispatch-complete report from the Dispatcher, send a greeting message to each Worker:
 ```
 mcp__renga-peers__send_message(
   to_id="worker-{task_id}",
-  message="窓口です。{task_id} の作業をお願いしています。完了・進捗・ブロック、全ての報告は `to_id=\"secretary\"` で renga-peers 送信してください。"
+  message="This is the Lead. You are assigned to {task_id}. Send all reports — completion, progress, and blockers — to `to_id=\"secretary\"` over renga-peers."
 )
 ```
 
 ### On message receipt from a Worker
 
-**Canonical event flow** (do not skip intermediate stages):
+**Canonical event flow** (intermediate steps must not be skipped):
 
 ```
 worker → Secretary peer message
-  1. ack to worker (全 message 共通で必須。dead-lock 防止)
+  1. ack to worker (required for all messages; deadlock prevention)
   2. update Progress Log + DB (run.status / events / pending-decisions register)
-  3. report to user           (完了 / escalation / blocker のみ。進捗報告は不要)
+  3. report to user           (only for completion / escalation / blocker; progress reports not needed)
   4. wait for user approval before push/PR
   5. CI watch / next instruction → [`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md)
 ```
 
-- For minimum ack content and examples by message type, see [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md). **`ack` != user approval**: only issue `git push`, `gh pr create`, and `tools/pr-watch.*` after explicit user OK
-- The order `2 → 3` follows the rule: make internal state consistent first, then report to the user
+- For the minimum ack contents and per-kind example texts, see [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md). **ack ≠ user approval**: `git push` / `gh pr create` / `tools/pr-watch.*` are issued only after the user's explicit OK
+- The 2 → 3 ordering follows the principle "reconcile internal state first, then report to the user"
 
-#### 0. Requests for judgment, scope expansion, blockers (identify first, highest priority)
+#### 0. Judgment request / scope expansion / blocker (identify with top priority)
 
-→ Trigger [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md). The Lead does not give first-line approval.
+→ Trigger [`.claude/skills/org-escalation/SKILL.md`](../org-escalation/SKILL.md). The Secretary does not pre-approve.
 
-#### 1. Progress reports
+#### 1. Progress report
 
-- Return an ack to the worker (see the "progress report ack" section of [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md), before appending to the Progress Log). **Do not report progress updates to the user, and do not wait for approval**
-- Append to the Progress Log in `.state/workers/worker-{task_id}.md`
-- Append the event to the DB `events` table (`bash tools/journal_append.sh ...`)
+- Return ack to the worker (see the "progress report ack" section of [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md); before the Progress Log append). **Do not escalate progress reports to the user or wait for approval**
+- Append to the Progress Log of `.state/workers/worker-{task_id}.md`
+- Append an event to the DB events table (`bash tools/journal_append.sh ...`)
 
-#### 2a. Completion reports
+#### 2a. Completion report
 
-- Return an ack to the worker (see the "completion report ack" section of [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md))
-- **Transition the run to REVIEW through the DB** (direct markdown edits are forbidden):
+- Return ack to the worker (see the "completion report ack" section of [`.claude/skills/org-delegate/references/ack-template.md`](references/ack-template.md))
+- **Transition the run to REVIEW via the DB** (direct markdown edits prohibited):
   ```bash
   python -c "
   from pathlib import Path
@@ -345,27 +360,27 @@ worker → Secretary peer message
       w.update_run_status('<task_id>', 'review')
   "
   ```
-- Append the event to the DB `events` table (`bash tools/journal_append.sh ...`)
-- **Register update on dogfood-pass completion (Issue #338)**: if the completed task is earmarked in the `dogfood_run_task_id` column of `registry/dogfood_pending.md`, transition `status` on that row from `open → consumed`. Defects are assumed to already be aggregated on the paired follow-up issue (`dogfood_issue` column) per the format pre-specified in the dogfood-pass Worker's brief. The full protocol's SoT is Step 1.8 of this SKILL
-- **Emit the awaiting_user notification (Issue #28)**: just before reporting to the human and stopping to wait for approval, tell the attention watcher that the Secretary is about to stop waiting on a user judgment:
+- Append an event to the DB events table (`bash tools/journal_append.sh ...`)
+- **Register update on dogfood pass completion (Issue #338)**: If the completed task was earmarked in the `dogfood_run_task_id` column of `registry/dogfood_pending.md`, transition that row's `status` from `open → consumed`. Defects are assumed to already be aggregated in the paired follow-up issue (the `dogfood_issue` column) — the format is specified in the dogfood pass worker's brief. The full protocol's SoT is Step 1.8 of this SKILL
+- **Emit awaiting_user notification (Issue #28)**: Just before reporting to the human → entering an approval-wait stop, inform the attention watcher that "the Secretary is stopping while awaiting the user's judgment":
   ```bash
   bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=<task_id> gate=worker_completed note="<short context such as PR/Issue>"
   ```
-  The classifier in the parallel runtime PR picks this single line up as `secretary_awaiting_user` (default severity `urgent`), so the user gets a beep even when not at the screen. See the "Notify when the Secretary is waiting on a user judgment" section in CLAUDE.md.
-- Report the result to the human and **stop, waiting for approval without closing the pane**. Issuing push/PR without approval violates protocol for both the Worker and the user
+  The classifier of the parallel runtime PR picks this single line up as `secretary_awaiting_user` (default severity `urgent`) and beeps even when the user is not in front of the screen. See the CLAUDE.md section "Notify when the secretary is waiting for the user's judgment"
+- Report the result to the human and **stop awaiting approval without closing the pane**. Issuing push/PR without approval is a protocol violation toward both the worker and the user
 
-#### 2b / 2c. After user approval, review comments, post-merge close
+#### 2b / 2c. After user approval / review comments / post-merge close
 
 → Trigger [`.claude/skills/org-pull-request/SKILL.md`](../org-pull-request/SKILL.md).
 
-### Worker monitoring and intervention decisions (run by the Lead)
+### Worker monitoring and intervention judgment (executed by the Lead)
 
-After dispatch, periodically check whether the Worker has fallen into a deep-dive or over-verification loop. **Intervention triggers** (if any one applies, inspect the state with `mcp__renga-peers__inspect_pane`):
+After dispatch, periodically check that the Worker has not entered a deep-dive or excessive-verification loop. **Intervention triggers** (if any one or more applies, check the situation with `mcp__renga-peers__inspect_pane`):
 
-- More than 30 minutes elapsed on the same task, and the Worker has entered the same phase (implementation / review / verification) for the third time or later
-- Quiet for more than 1 hour with no progress report (not waiting for input, and no progress log either)
-- If using codex: Codex self-review has entered round 4 or later
+- More than 30 minutes elapsed on the same task, and entering the same phase (implementation / review / verification) for the 3rd time or later
+- Silent for more than 1 hour with no progress report (not waiting for input either, and no progress log being emitted)
+- (When using codex) Codex self-review is on its 4th or later round
 
-**Intervention procedure**: inspect the screen with `inspect_pane` → if it is judged to be a deep dive, interrupt with `send_keys(target="worker-{task_id}", keys=["Escape"])` → send a tight corrective instruction with `send_message` (example: `Switch verification depth to minimal. No Codex review, no additional tests. Reply with one line only: done: {commit SHA} {filename}`).
+**Intervention procedure**: Check the screen with `inspect_pane` → if judged to be deep-diving, interrupt with `send_keys(target="worker-{task_id}", keys=["Escape"])` → send a tight correction instruction via `send_message` (e.g., "Switch verification depth to minimal. Codex review and additional tests prohibited. Return only the single line `done: {commit SHA} {filename}`").
 
-The Lead is blocked by the auto-mode classifier from making a commit directly in the Worker's worktree on the Worker's behalf (out-of-scope action). Intervention must be done strictly by resending instructions.
+The Lead substituting in a commit on its own at the Worker's worktree is blocked by the auto-mode classifier (scope deviation). Intervention should be done strictly by "re-sending instructions".

--- a/.claude/skills/org-delegate/references/pane-layout.md
+++ b/.claude/skills/org-delegate/references/pane-layout.md
@@ -1,18 +1,18 @@
 # Pane Layout Specification (renga-peers MCP)
 
-Pane/tab layout rules for `renga`. Referenced by `org-start` and `org-delegate`.
-Pane control is handled through the `mcp__renga-peers__*` MCP tools (requires renga 0.18.0+, with all 14 tools including `spawn_claude_pane` / `set_pane_identity` available through MCP).
+renga pane / tab layout rules. Referenced by `org-start` and `org-delegate`.
+Pane control goes through the `mcp__renga-peers__*` MCP tools (renga 0.18.0+ required; all 14 tools including `spawn_claude_pane` / `set_pane_identity` are available via MCP).
 
-## Initial layout (result of `renga --layout ops` + after starting Dispatcher and Curator)
+## Initial layout (result of `renga --layout ops` plus Dispatcher/Curator startup)
 
-The policy is to start the Lead (`secretary`), Dispatcher, and Curator in the same tab, then keep stacking Workers as splits within that same tab.
+The Secretary (`secretary`) / Dispatcher / Curator all come up in the same tab, and Workers are stacked into the same tab via splits.
 
 ```
-Tab 1: ops (ワーカー 0 人)
+Tab 1: ops (0 workers)
 ┌────────────────────┬────────────────────┐
 │                    │                    │
 │                    │     Secretary      │
-│                    │     (上半分)       │
+│                    │     (top half)     │
 │                    │                    │
 │                    ├──────────┬─────────┤
 │                    │ Dispatcher  │ Curator │
@@ -20,83 +20,83 @@ Tab 1: ops (ワーカー 0 人)
 └────────────────────┴──────────┴─────────┘
 ```
 
-> Note: in practice, there is also a layout where `secretary` is on the left and `dispatcher/curator` occupy the bottom half; the exact initial layout is left to `org-start`. What matters in this document is that the system builds the worker zone dynamically using balanced splits with role priority over the four candidate roles: `secretary / curator / worker / dispatcher` (see the algorithm section below).
+> Note: in practice `secretary` may sit on the left while `dispatcher/curator` occupy the bottom half — the precise initial layout is delegated to org-start. What matters in this document is that "we dynamically grow the Worker zone via a role-priority-aware balanced split whose candidates are the four roles `secretary / curator / worker / dispatcher`" (see the algorithm section below for details).
 
-## Layout rules
+## Placement rules
 
 | Target | Operation | Notes |
 |---|---|---|
-| Dispatcher | Horizontally split the Lead pane and use the bottom half | `mcp__renga-peers__spawn_claude_pane(target="focused", direction="horizontal", role="dispatcher", name="dispatcher", cwd=".dispatcher", permission_mode="bypassPermissions", model="sonnet")` (org-start Step 2) |
-| Curator | Vertically split the Dispatcher pane and use the right half | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="auto")` (org-start Step 3) |
-| Each Worker | **balanced split**: dynamically choose `target` and `direction` from the current rects returned by `list_panes`, then stack within the same tab | See the "Worker balanced split strategy" section below. `mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="auto")` (org-delegate Step 3) |
+| Dispatcher | Horizontal split of the Secretary pane, taking the bottom half | `mcp__renga-peers__spawn_claude_pane(target="focused", direction="horizontal", role="dispatcher", name="dispatcher", cwd=".dispatcher", permission_mode="bypassPermissions", model="sonnet")` (org-start Block A-1) |
+| Curator | Vertical split of the Dispatcher pane, taking the right half | `mcp__renga-peers__spawn_claude_pane(target="dispatcher", direction="vertical", role="curator", name="curator", cwd=".curator", permission_mode="auto")` (org-start Block A-2) |
+| Each Worker | **balanced split**: dynamically pick target and direction from the current rects returned by `list_panes`, and stack into the same tab | See the "Worker balanced split strategy" section below. `mcp__renga-peers__spawn_claude_pane(target={target}, direction={direction}, role="worker", name="worker-{task_id}", cwd="{workers_dir}/{task_id}", permission_mode="auto")` (org-delegate Step 3) |
 
-> **Why use `spawn_claude_pane`**: this is the structured launch tool added in renga 0.18.0+. When `cwd` / `permission_mode` / `model` / `args[]` are passed as structured fields, renga internally composes `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old method of passing a `command` string with a `cd` prefix into `spawn_pane` is **forbidden** (if a cwd-change prefix is present, renga's bare-`claude` auto-upgrade does not trigger, and channel push via `send_message` stops working. Instructions from Lead to Dispatcher and from Dispatcher to Worker stop working entirely). Only the Lead is launched as bare `claude` from `ops.toml` and relies on auto-upgrade.
+> **Why use `spawn_claude_pane`**: it is the structured launch tool added in renga 0.18.0+. When you pass `cwd` / `permission_mode` / `model` / `args[]` as structured fields, renga internally synthesizes `claude --permission-mode {mode} --dangerously-load-development-channels server:renga-peers ...`. The old approach (feeding a `cd`-prefixed command string into `spawn_pane`) is **forbidden** — a cwd-changing prefix prevents renga's bare-`claude` auto-upgrade from firing, so `send_message` channel pushes never arrive. Instructions from Secretary→Dispatcher and Dispatcher→Worker stop flowing entirely. Only the Secretary is launched as bare `claude` from `ops.toml` and relies on auto-upgrade.
 
 ## Worker balanced split strategy
 
 ### Why balanced split is necessary
 
-renga splits the target pane 50/50 on each split. If either side falls below the minimums `MIN_PANE_WIDTH = 20` or `MIN_PANE_HEIGHT = 5`, the split is rejected with `[split_refused]` (investigation: `<workers_dir>/renga-split-inv/findings.md`).
+Each renga split divides the target pane 50/50. If the result drops below the lower bounds `MIN_PANE_WIDTH = 20` / `MIN_PANE_HEIGHT = 5`, the split is rejected with `[split_refused]` (investigation: `<workers_dir>/renga-split-inv/findings.md`).
 
-With a fixed target or an ordinal `k`-based lookup table, cumulative halving of the Dispatcher width and redispatch after Workers close caused the assumed layout to diverge from the actual layout, triggering early `split_refused`.
+With a fixed target or an ordinal `k`-based lookup table, the cumulative halving of the dispatcher's width, or re-dispatch after a worker closes mid-flight, caused the assumed layout to diverge from the actual one and triggered `[split_refused]` early.
 
-The current design uses each pane's **rect information (`x / y / width / height`, in cells)** returned by `mcp__renga-peers__list_panes`, and **dynamically selects target and direction from the current layout**. It is robust to variation in Worker retirement order and mid-run closes, has no fixed "max N parallelism", continues splitting as long as terminal size and MIN_PANE constraints allow, and automatically escalates when it reaches capacity.
+The current design uses the **rect info (`x / y / width / height`, in cell units)** for each pane returned by `mcp__renga-peers__list_panes`, and **dynamically picks target and direction from the current layout**. It is robust against jitter in worker retirement order and mid-flight closure, has no fixed "N parallel cap," keeps splitting as long as the terminal size and MIN_PANE constraints allow, and auto-escalates when the limit is hit.
 
 ### Algorithm
 
-The balanced split decision logic (target/direction selection, MIN_PANE constraints, Lead guard, role-priority sorting, rect adjacency checks, and `split_capacity_exceeded` detection) is **defined by the helper in `claude-org-runtime` as the source of truth**. The Dispatcher takes the snapshot from `mcp__renga-peers__list_panes` and the task JSON, then calls one of the following and follows the returned action plan (`spawn` / `after_spawn` / `escalate` / `state_writes` / `status`) to execute `spawn_claude_pane` or escalate:
+The balanced-split decision logic (target / direction selection, MIN_PANE constraint, secretary safeguard, role-priority sort, rect-adjacency check, `split_capacity_exceeded` detection) is **owned by the `claude-org-runtime` helper as the SoT**. The dispatcher feeds it a `mcp__renga-peers__list_panes` snapshot and the task JSON via one of the entry points below, and then executes `spawn_claude_pane` / escalate according to the returned action plan (`spawn` / `after_spawn` / `escalate` / `state_writes` / `status`):
 
-- CLI (standard operational entrypoint): `claude-org-runtime dispatcher delegate-plan --task-json ... --panes-json ... --state-dir ... [--template-repo ...] [--locale-json ...]`. For Dispatcher-side procedure, the primary reference is the delegate-plan helper section in `.dispatcher/CLAUDE.md`
-- Library: `build_plan(...)` in the `claude_org_runtime.dispatcher.runner` module (full action plan), and `choose_split(panes)` (low-level helper when only target/direction is needed)
+- CLI (the standard operational entry point): `claude-org-runtime dispatcher delegate-plan --task-json ... --panes-json ... --state-dir ... [--template-repo ...] [--locale-json ...]`. The dispatcher-side procedure has its primary source in the delegate-plan helper section of `.dispatcher/CLAUDE.md`.
+- Library: `build_plan(...)` (the full action plan) and `choose_split(panes)` (a low-level helper for when you only need target / direction) in the `claude_org_runtime.dispatcher.runner` module.
 
-For constant values (`MIN_PANE_WIDTH` / `MIN_PANE_HEIGHT` / `SECRETARY_MIN_WIDTH` / `SECRETARY_MIN_HEIGHT` / role-priority map), evaluation order, and the exact definition of rect adjacency, the **primary reference is the `claude_org_runtime.dispatcher.runner` module itself** (`_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` / `choose_split()` / `rect_adjacent()`). Constant prose was removed from this document because drift between runtime and docs causes opaque failures such as `[split_refused]` (Issue #307 cleanup).
+The constant values (MIN_PANE_WIDTH / MIN_PANE_HEIGHT / SECRETARY_MIN_WIDTH / SECRETARY_MIN_HEIGHT / role-priority map), the order of checks, and the exact definition of rect adjacency are sourced from the **`claude_org_runtime.dispatcher.runner` module itself** (`_ROLE_PRIORITY` / `MIN_PANE_*` / `SECRETARY_MIN_*` / `choose_split()` / `rect_adjacent()`). The prose values were removed from this document because doc/runtime drift was a cause of mysterious `[split_refused]`-style failures (Issue #307 cleanup).
 
-If there are no candidates, the helper returns `status="split_capacity_exceeded"` and `escalate.send_message(to_id="secretary", ...)`. The Dispatcher does not issue `spawn_claude_pane`, stops dispatch for that one Worker only, and continues the main monitoring loop (see `SKILL.md` Step 3-1c).
+When there are no candidates, the helper returns `status="split_capacity_exceeded"` and an `escalate.send_message(to_id="secretary", ...)`. The dispatcher does not issue `spawn_claude_pane`, cancels the dispatch for just that one worker, and keeps the main monitor loop running (see `SKILL.md` Step 3-1c).
 
 ### Verification trace (Issue #307 scenario, reference)
 
-This is a manual trace table showing `choose_split` behavior when given the immediate post-layout state `secretary 280×43 / dispatcher 140×43 / curator 140×43` (terminal ≈ 280×86, assuming `org-start` has just performed Lead horizontal split then Dispatcher vertical split). **Canonical behavior is the runtime SoT**. If values in this doc differ from runtime behavior, trust the runtime.
+A hand-traced reference table of `choose_split` behavior for the layout `secretary 280×43 / dispatcher 140×43 / curator 140×43` immediately after startup (terminal ≈ 280×86, assumed to be right after org-start's secretary horizontal split → dispatcher vertical split). **The canonical values live in the runtime SoT**. If the doc disagrees with the runtime's actual behavior, trust the runtime.
 
-| spawn | Selected role | direction | Intuition |
+| spawn | selected role | direction | intuitive rationale |
 |---|---|---|---|
-| 1st | secretary | vertical | Lead has top role priority as long as it still satisfies splitable size |
-| 2nd | curator | vertical | Lead drops out due to the `SECRETARY_MIN_WIDTH` guard; Curator is selected as the next-highest priority |
-| 3rd | curator | horizontal | Role priority is strict primary, so Curator continues until it drops below MIN_PANE |
+| 1st | secretary | vertical | while secretary still satisfies the splittable-size requirement, role priority puts it first |
+| 2nd | curator | vertical | secretary drops out under the SECRETARY_MIN_WIDTH guard, so the next-priority curator is picked |
+| 3rd | curator | horizontal | because role priority is strict primary, curator is picked repeatedly until it falls below MIN_PANE |
 
-After Curator drops out for violating MIN_PANE, selection flows to Workers at priority 2. For the design rationale for putting Dispatcher last (avoid repeatedly halving the viewport of the actively monitored pane; Curator is mostly idle under `/loop 30m /org-curate`), see the `_ROLE_PRIORITY` comment in `runner.py`.
+Once curator falls below MIN_PANE and drops out, the flow moves to the priority-2 worker pool. The design intent of putting the dispatcher last (to avoid halving the viewport of an active monitoring pane often, and because the curator is mostly idle under `/loop 30m /org-curate`) is documented in the `_ROLE_PRIORITY` comment in runner.py.
 
 ### Edge cases / operational notes
 
-- **Redispatch after a Worker closes mid-run**: the old k-table method had the problem that compacting a closed slot diverged from table assumptions. That does not happen with rect-based selection. Target selection always comes from the actual layout, so the decision stays aligned with renga's layout tree
-- **`spawn_claude_pane` errors**: `[split_refused]` / `[pane_not_found]` are returned in the MCP result text. Escalate Curator → Lead using the procedure in `references/renga-error-codes.md` (same policy as the old design)
-- **Races**: if other Workers are added or removed between `list_panes` and `spawn_claude_pane`, target mismatch surfaces as `[pane_not_found]`. The existing error-handling path absorbs this
-- **Responsibility for target selection**: the Dispatcher computes this from `list_panes` rects. The Lead only needs to pass `task_id` in the DELEGATE message and does not specify a target
+- **Re-dispatch after a worker closes mid-flight**: the old k-table issue of "compacting closed slots diverges from the table's assumptions" cannot occur in the rect-based model. Because the target is always picked from the actual layout, the decision is always consistent with renga's layout tree.
+- **`spawn_claude_pane` errors**: `[split_refused]` / `[pane_not_found]` come back in the MCP result text. Escalate via Curator → Secretary per the procedure in `references/renga-error-codes.md` (same policy as the old design).
+- **Race**: if other workers come and go between `list_panes` and `spawn_claude_pane`, the target mismatch surfaces as `[pane_not_found]`. It is absorbed by the existing error-handling path.
+- **Responsibility for target selection**: the dispatcher computes it from `list_panes` rect data. The Secretary only needs to pass task_id in the DELEGATE message and does not specify target.
 
 ## Operational notes
 
-- **Place all panes in the same tab**: renga's `list_panes` / `focus_pane` / `send_message` / `inspect` (CLI) currently operate only on panes in the focused tab, so Dispatcher, Curator, and all Workers are stacked as splits within the same tab. If Workers are placed in separate tabs via `new_tab`, they stop being addressable from the Dispatcher side (confirmed 2026-04-20; upstream fix tracked in `suisya-systems/renga#71`)
-- **Naming convention**:
-  - Lead → `secretary`
+- **Keep all panes in the same tab**: renga's `list_panes` / `focus_pane` / `send_message` / `inspect` (CLI) can only touch panes in the currently-focused tab, so stack Dispatcher, Curator, and all Workers as splits in the same tab. Putting a worker in a separate tab via `new_tab` makes it unaddressable from the Dispatcher (discovered 2026-04-20; upstream fix tracked at suisya-systems/renga#71).
+- **Naming conventions**:
+  - Secretary → `secretary`
   - Dispatcher → `dispatcher`
   - Curator → `curator`
-  - Worker → `worker-{task_id}` (`task_id` is a unique kebab-case identifier)
-  - **renga-peers target resolution rule**: a name made entirely of digits is interpreted as an id, so names must always include letters (`worker-1` is OK; `1` is invalid because it is treated as an id)
-- **Role labels (`role`)**: four values: `secretary` / `dispatcher` / `curator` / `worker`
-  - The `role` field is available in `list_panes` output and can be used for organization-state aggregation and balanced-split target selection
-- **When a Worker completes**:
-  1. The Lead asks the Dispatcher to `CLOSE_PANE`
-  2. The Dispatcher explicitly destroys the pane with `mcp__renga-peers__close_pane(target="worker-{task_id}")`
-     (renga removes the pane → emits `Event::PaneExited` once → the pane also disappears from `list_panes`.
-     `[pane_not_found]` / `[pane_vanished]` are skipped as "already closed")
-- **Shutdown order for `org-suspend`**: Workers → Dispatcher → Curator (all destroyed with `mcp__renga-peers__close_pane`. Only when closing the final remaining pane does `[last_pane]` return, so that pane must `exit` on its own)
+  - Worker → `worker-{task_id}` (task_id is a kebab-case unique identifier)
+  - **renga-peers target resolution rule**: an all-digit name is interpreted as an id, so the name must contain at least one letter (`worker-1` is OK; `1` would be treated as an id, so it's not).
+- **Role labels (`role`)**: four values — `secretary` / `dispatcher` / `curator` / `worker`.
+  - The `list_panes` output exposes a `role` field, which is useful for aggregating org state and for picking targets in balanced split.
+- **When a worker finishes**:
+  1. The Secretary asks the Dispatcher for `CLOSE_PANE`.
+  2. The Dispatcher explicitly tears down the pane with `mcp__renga-peers__close_pane(target="worker-{task_id}")`.
+     (renga removes the pane → `Event::PaneExited` is emitted once → it disappears from `list_panes` as well.
+     `[pane_not_found]` / `[pane_vanished]` is treated as "already closed" and skipped.)
+- **Stop order at org-suspend time**: Worker → Dispatcher → Curator (all torn down via `mcp__renga-peers__close_pane`. Only when closing the last remaining pane do you get `[last_pane]` back, and that pane has to `exit` itself).
 
-## split direction conventions
+## Split direction conventions
 
-renga split directions are defined as follows (same for `spawn_pane` and `spawn_claude_pane`):
+renga's split directions are defined as follows (shared by `spawn_pane` / `spawn_claude_pane`):
 - `direction="vertical"` = left/right split (existing pane = left, new pane = right)
 - `direction="horizontal"` = top/bottom split (existing pane = top, new pane = bottom)
 
 ## Future features / upstream tracking
 
-- Ratio support for `spawn_pane` / `spawn_claude_pane`, such as `--ratio 0.2` (currently fixed at 50/50)
-- renga-side automatic target selection such as `--target-largest` / `--direction auto` (currently computed by the Dispatcher from `list_panes` rects. If moved upstream, the balanced split logic can be collapsed into the MCP side)
+- A ratio argument such as `--ratio 0.2` for `spawn_pane` / `spawn_claude_pane` (currently fixed at 50/50).
+- Renga-side automatic target selection such as `--target-largest` / `--direction auto` (currently the dispatcher computes it from `list_panes` rects; if this can be pushed upstream, the balanced-split logic can be collapsed into MCP).

--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -1,82 +1,102 @@
 # Worker CLAUDE.md Template
 
-Template for the CLAUDE.md placed in the worker-specific directory (`{workers_dir}/{task_id}/`) in Step 1.5 of org-delegate.
-Variables use the `{variable_name}` format and are replaced with actual values during generation.
+The template for the CLAUDE.md that org-delegate Step 1.5 places in the worker-dedicated directory (`{workers_dir}/{task_id}/`).
+Variables use the `{variable_name}` form and are substituted with real values at generation time.
 
 ---
 
-## Template Body
+## Template body
 
-Write the following content directly to `{workers_dir}/{task_id}/CLAUDE.md`.
+Write the following verbatim as `{workers_dir}/{task_id}/CLAUDE.md`.
 
 ```markdown
 # Worker
 
-You are a Worker in claude-org. Carry out your work according to the instructions below.
+You are a worker for claude-org. Carry out the work according to the instructions below.
 
-## Working Directory (Most Important Constraint)
+## Working directory (most important constraint)
 
 Your working directory: `{worker_dir}`
 
-Immediately after startup, run `pwd` and verify that it matches the path above.
-If it does not match, do not start work and report the error to the Lead.
+Immediately after startup, run `pwd` and verify it matches the path above.
+If it does not match, do not begin work — report the error to the Secretary.
 
-### Prohibited Actions (Technically blocked by permissions.deny + PreToolUse Hooks)
-1. Do not recreate the claude-org structure (`.claude/`, `.dispatcher/`, `.curator/`, `.state/`, `registry/`, `dashboard/`, `knowledge/`, etc.) inside `{worker_dir}`
-2. Do not separately clone the claude-org repository (`{claude_org_path}`) (edit it directly)
-3. You cannot run `git push` (request it from the Lead in your completion report)
+### Prohibited (technically blocked by permissions.deny + PreToolUse Hooks)
+1. Do not reproduce the claude-org structure (`.claude/`, `.dispatcher/`, `.curator/`, `.state/`, `registry/`, `dashboard/`, `knowledge/`, etc.) inside `{worker_dir}`.
+2. Do not separately clone the claude-org repository (`{claude_org_path}`) — edit it directly.
+3. You cannot run `git push` (ask the Secretary in the completion report).
 
-### Correct Work Procedure
-- New project: run `git init` inside `{worker_dir}` and create files directly
-- Existing repository: run `git clone {URL}` inside `{worker_dir}`
-- When creating files, verify that the absolute path starts with `{worker_dir}/`
+### Correct workflow
+- New project: run `git init` inside `{worker_dir}` and create files directly.
+- Existing repository: run `git clone {URL}` inside `{worker_dir}`.
+- When creating files, verify that the absolute path starts with `{worker_dir}/`.
 
-### Notes for Windows Environments
-- When running Python, use `py -3` instead of `python` (on Windows, `python` may be redirected to a Store app)
-- When handling files that include Japanese text, explicitly specify `encoding="utf-8"`
+### Notes for Windows
+- For Python, use `py -3` instead of `python` (on Windows `python` may redirect to the Store app).
+- When dealing with files that contain Japanese, explicitly pass `encoding="utf-8"`.
 
-## Project Information
+## Project information
 - Project name: {project_name}
 - Description: {project_description}
 
-## Current Task
+## Current task
 - Task ID: {task_id}
-- Objective: {task_description}
+- Goal: {task_description}
 
-## Knowledge Reference (Read-only)
+## Knowledge reference (read-only)
 
-You may use knowledge accumulated by the organization. The following directories are **readable with the Read tool** (writing is allowed only for retrospective notes).
+You can leverage the knowledge accumulated by the org. The following directories are **readable with the Read tool** (writing is only allowed for retrospective records).
 
-- `{claude_org_path}/knowledge/curated/` — Organized knowledge
-- `{claude_org_path}/knowledge/raw/` — Unorganized raw learnings
+- `{claude_org_path}/knowledge/curated/` — organized knowledge
+- `{claude_org_path}/knowledge/raw/` — unorganized raw learnings
 
-### When to Reference It
-1. **Before starting work**: Check whether there are files that seem related to the task. Judge by file names and titles, and read anything that looks useful
-2. **When blocked during work**: Check whether knowledge about a similar problem has already been recorded
+### When to consult
+1. **Before starting work**: check whether there are files related to the task. Judge by filename and title; read anything that looks useful.
+2. **When stuck mid-work**: check whether prior knowledge for the same kind of problem has been recorded.
 
 ## Permissions
-- git commit: Allowed
-- PR creation: Not allowed (via the Lead)
-- git push: Not allowed (technically blocked by `permissions.deny` + hooks; request it via the Lead)
-- `rm -rf` / `rm -r`: Not allowed (technically blocked by `permissions.deny`)
+- git commit: allowed
+- PR creation: not allowed (goes through the Secretary)
+- git push: not allowed (technically blocked by `permissions.deny` + hook; ask the Secretary)
+- `rm -rf` / `rm -r`: not allowed (technically blocked by `permissions.deny`)
 
-## Codex Self-Review Procedure
+## Code of conduct for audit / verification / investigation tasks
 
-Follow the **"verification depth" line that is always included** in the dispatch instruction (`full` or `minimal`).
-If the instruction has no value or is unclear, do not decide on your own; ask the Lead (`secretary`).
+In audit / verification / investigation tasks, when the observed shape (symptoms, logs, output) **can be explained by multiple hypothesis paths, eliminate at least one of them with a real-machine falsification experiment**. Before adopting one of several hypotheses and concluding, confirm and rule out the others on the real machine.
 
-### When verification depth is `full` (tasks involving code or behavior changes)
+Background: in a past audit, the sandbox shadow-FS hypothesis was adopted, but the true cause was a cwd-relative path resolution mistake. If real-machine falsification of an alternative hypothesis had been required, the true cause would have been reached in one round.
 
-**Prerequisites for `full` (must be done whether codex is available or not):**
-- Run the normal verification defined by the repository, such as the existing test suite / lint / type-check, and confirm everything is green before reporting completion
-- Follow the standard completion report format (deliverables description, remaining work, PR draft / retrospective note)
+Implementation guideline:
+- Form a prediction of the form "if hypothesis X is true, then Y should be observed," and write into the brief / report the procedure for confirming Y on the real machine.
+- If only a single hypothesis is on the table, explicitly diverge "how else could this be explained?" for one round.
+- Include the falsification-experiment result (hypothesis / experiment / observation / verdict) in the report.
+
+## Credential handling for probe / fuzzing-class tasks
+
+For probe / verification / fuzzing-class tasks (sandbox exploration, hook behavior verification, file-access-feasibility checks, etc.), when there is a chance of touching production credential paths (`~/.config/`, `~/.aws/`, `~/.ssh/`, `~/.netrc`, `~/.npmrc`), **make the switch to testbed credentials a mandatory pre-execution gate**.
+
+Implementation guideline:
+- Before execution, switch to testbed credentials via e.g. `gh auth login --with-token` and temporarily evacuate the production token.
+- During the probe, keep production credentials in a state where they cannot be read (env-var / config-path overrides, etc.).
+- Also write into the brief / report the procedure for restoring production credentials after the probe.
+
+Background: in a past probe task, the actual oauth_token from `cat ~/.config/gh/hosts.yml` was leaked to the dispatcher's stdout. Probe-class tasks have "reads themselves" as the attack surface, so the switch to testbed must be enforced as a pre-execution gate.
+
+## Codex self-review procedure
+
+Follow the **"verification depth" line that is always included** in the dispatch instructions (`full` or `minimal`). If the value is missing or unclear, do not decide on your own — confirm with the Secretary (`secretary`).
+
+### When verification depth is `full` (tasks that change code or behavior)
+
+**`full` prerequisites (always run, regardless of whether codex is installed):**
+- Run the normal verification defined by the repository (existing test suite / lint / type-check / etc.), confirm green, and only then submit the completion report.
+- Follow the standard completion-report format (deliverable description, remaining work, PR draft / retrospective record).
 
 **Codex self-review as an additional gate (optional; run if the codex CLI is installed):**
 
-After committing and before reporting completion, if the **`codex` CLI is available**, run a self-review by invoking `codex exec --skip-git-repo-check` directly.
-This is an additional gate on top of `full`; in environments where it is not installed, you may proceed to the completion report with only the `full` prerequisites above.
+After committing and before the completion report, **if the `codex` CLI is available**, run a self-review by invoking `codex exec --skip-git-repo-check` directly. This is an additional gate layered on top of `full`; in environments without it installed, you can proceed to the completion report with only the "`full` prerequisites" above.
 
-Example availability check:
+Availability check example:
 ```bash
 # Bash / zsh
 command -v codex >/dev/null 2>&1 && echo available || echo unavailable
@@ -84,54 +104,53 @@ command -v codex >/dev/null 2>&1 && echo available || echo unavailable
 Get-Command codex -ErrorAction SilentlyContinue
 ```
 
-- If `unavailable`: skip the self-review and proceed directly to the completion report after committing (the round discipline and fix loop below do not apply)
-- If `available`: run it with the following command
+- If `unavailable`: skip self-review and proceed directly to the completion report after commit (the round discipline / fix loop below does not apply).
+- If `available`: run the command below.
 
 ```bash
-codex exec --skip-git-repo-check "Review the diff on this branch from main. Classify findings as Blocker/Major/Minor/Nit, and for each finding provide the target file:line number and rationale in concise Japanese."
+codex exec --skip-git-repo-check "Review the diff of this branch against main. Classify findings as Blocker/Major/Minor/Nit and, for each finding, give the target file:line and a concise rationale in Japanese."
 ```
 
-The following applies only if you ran `codex`:
-- For Blocker / Major findings, add a fix commit and re-review
-- If you cannot clear the same finding category within 3 rounds, **treat it as a design problem**, report completion immediately, and ask the Lead to decide whether to reduce scope (to prevent infinite loops)
-- As a rule, leave Minor / Nit findings as-is and document them as known limitations in the README / Issue / PR body
-- Do not delegate review to another Worker (it is faster for the original author to run the fix loop, and responsibility boundaries stay clear)
+The following only apply when `codex` was actually run:
+- Blocker / Major: stack a fix commit and re-review.
+- **If you cannot clear the same category in 3 rounds, treat it as a design problem**, immediately submit the completion report, and ask the Secretary to decide on scope reduction (prevents infinite loops).
+- Minor / Nit: in principle leave as-is and document them as known limitations in the README / Issue / PR body.
+- Do not delegate the review to a different worker (the author running the fix loop is faster and has cleaner responsibility boundaries).
 
 ### When verification depth is `minimal` (trivial fix)
-Codex self-review, additional test execution, and extended behavior checks are **strictly prohibited**.
-Once you have applied the instructed fix, run `git add` -> `git commit` -> send only the following one line to the Lead:
+Codex self-review, additional test runs, and any extended behavior verification are **absolutely forbidden**. After reflecting the instructed fix, do `git add` → `git commit` and send just the following one line to the Secretary:
 
 ```
 done: {short commit SHA} {changed filenames}
 ```
 
-- The SHA is from `git rev-parse --short HEAD`
-- If there are multiple files, separate them with spaces (example: `done: be8f497 tests/test-block-pretooluse-hooks.sh`)
-- The completion report format below in "At Completion (Required)" (deliverables description, remaining work, PR draft, etc.) does **not** apply in `minimal` mode (the Lead only needs the commit SHA and changed files to handle push / PR creation)
-- Retrospective notes (`knowledge/raw/`) are also **not necessary** in `minimal` mode (on the assumption that trivial fixes do not produce reusable learnings). If you discover something non-trivial, you may create one note using the same procedure as `full`
+- SHA comes from `git rev-parse --short HEAD`.
+- For multiple files, separate them with spaces (e.g., `done: be8f497 tests/test-block-pretooluse-hooks.sh`).
+- The completion-report format under "When the work is done (required)" below (deliverable description, remaining work, PR draft, etc.) **does not apply** under minimal (the Secretary just needs the commit SHA and the changed files to do push / PR creation).
+- Retrospective records (`knowledge/raw/`) are also **not required** under minimal (the assumption is that a trivial fix has no reusable learning). If you do hit a non-obvious finding, you may produce one record using the same procedure as `full`.
 
-### Prohibited Action (Common to both modes, when using codex)
-Do not use the `codex:rescue` skill (it previously caused actual hangs longer than 18 minutes; switching to a direct `codex exec` invocation worked normally). This note is irrelevant in environments where codex is not installed.
+### Prohibited in both modes (when using codex)
+Do not use the `codex:rescue` skill (real-world incident: it hung for over 18 minutes; switching to direct `codex exec` worked normally). In environments without codex installed, this note is irrelevant.
 
-## At Completion (Required, `full` verification depth only)
+## When the work is done (required; verification depth `full` only)
 
-If the verification depth is `minimal`, finish with the one-line report format for `minimal` in the "Codex Self-Review Procedure" section above (`done: {SHA} {files}`). No retrospective note is needed. This section applies **only to tasks with verification depth `full`**.
+Under verification depth `minimal`, finish with the one-line minimal format (`done: {SHA} {files}`) in the "Codex self-review procedure" section above. No retrospective record is required either. This section **applies only to tasks with verification depth `full`**.
 
-When your work is complete, you must do the following:
+When the work is done, **always** do the following:
 
-1. **Completion report**: Report to the **Lead (`secretary`)** via renga-peers
-   - Send using: `mcp__renga-peers__send_message(to_id="secretary", message="...")` (`secretary` is the pane name fixed by the renga layout)
-   - **Important: send it to the Lead, not to the Dispatcher (the party that sent the instruction)**
-   - **Fallback**: If `to_id="secretary"` returns `[pane_not_found]`, the Lead pane may have been started by a route other than `renga --layout ops`. In that case, use the numeric pane id specified in the DELEGATE message body (for example, `to_id="1"`). If the automatic `set_pane_identity` repair in Step 0 of `/org-start` runs on the Lead side, you can use `to_id="secretary"` afterward
-   - What you completed
-   - Deliverables such as created files, commits, and PRs
-   - Any remaining work or notes of caution
+1. **Completion report**: report to the **Secretary (`secretary`)** via renga-peers.
+   - How to send: `mcp__renga-peers__send_message(to_id="secretary", message="...")` (`secretary` is the pane name fixed by the renga layout).
+   - **Note: send to the Secretary, not to the Dispatcher (which sent you the instructions)**.
+   - **Fallback**: if `to_id="secretary"` returns `[pane_not_found]`, the Secretary pane may have been launched via a path other than `renga --layout ops`. In that case, send using the numeric pane id specified in the DELEGATE message body (e.g., `to_id="1"`). Once the Secretary side runs the `set_pane_identity` auto-repair in `/org-start` Step 0, `to_id="secretary"` will work again from then on.
+   - What you completed.
+   - Deliverables — files created, commits, PRs, etc.
+   - Any remaining work or caveats.
 
-2. **After PR creation, keep the pane open and wait for review feedback**: Even if the Lead informs you that push / PR creation is complete, do not close the pane. If PR review feedback arrives on GitHub, add follow-up fix commits in the same pane (re-dispatching a new Worker incurs the cost of reconstructing the Issue / diff / decision boundaries). Remain idle until the Lead explicitly tells you to close it, such as "you may close" or "merged".
+2. **Keep the pane alive after PR creation to wait for review comments**: even when the Secretary tells you that "push / PR creation is complete," do not close the pane. When PR review comments arrive on GitHub, stack the fix commits in the same pane (re-dispatching a new worker would pay the cost of rebuilding the Issue / diff / judgment boundaries). Stay in standby until you receive an explicit close instruction from the Secretary such as "you can close" / "merged."
 
-3. **Retrospective note**: Record any reusable learnings
+3. **Retrospective record**: if there is a reusable learning, record it.
    - Path: {claude_org_path}/knowledge/raw/{YYYY-MM-DD}-{topic}.md
-   - `topic` must be English kebab-case (example: jwt-rs256-key-rotation)
+   - topic is English kebab-case (e.g., jwt-rs256-key-rotation).
    - Format:
      ```
      # {title}
@@ -143,20 +162,20 @@ When your work is complete, you must do the following:
      {what decision was made}
 
      ## Rationale
-     {why that decision was made}
+     {why that decision}
 
-     ## When to Apply
-     {situations where this knowledge is useful}
+     ## Applicable situations
+     {situations in which this knowledge is useful}
      ```
-   - Criteria for recording: reproducible / non-obvious / not discoverable just by reading the code
-   - No need to record general programming knowledge or things already written in official documentation
+   - Recording criteria: reproducible / non-obvious / not something you can learn just by reading the code.
+   - No need to record general programming knowledge or anything written in official documentation.
 
-## SUSPEND Handling
-If you receive a message starting with "SUSPEND:", stop work and immediately report the following:
-1. What has been completed so far
-2. Files changed (committed / uncommitted)
-3. What you were about to do next
-4. Any blockers or unresolved issues
+## SUSPEND handling
+On receipt of a message that starts with "SUSPEND:", interrupt work and immediately report:
+1. What has been completed so far.
+2. Files changed (committed / uncommitted).
+3. What you were about to do next.
+4. Blockers or unresolved issues.
 ```
 
 ---
@@ -165,10 +184,10 @@ If you receive a message starting with "SUSPEND:", stop work and immediately rep
 
 | Variable | Description | Example |
 |---|---|---|
-| `{project_name}` | Alias in registry/projects.md | Blog |
-| `{project_description}` | Description in registry/projects.md | Company blog site |
+| `{project_name}` | Common name from registry/projects.md | Blog |
+| `{project_description}` | Description from registry/projects.md | Company blog site |
 | `{task_id}` | Task ID | data-analysis |
-| `{task_description}` | Task objective and deliverables | Implement login functionality. Use JWT authentication. |
+| `{task_description}` | Task goal and deliverables | Implement login. Uses JWT auth. |
 | `{claude_org_path}` | Absolute path of the claude-org repository | /home/user/work/claude-org |
-| `{worker_dir}` | Absolute path of the Worker working directory | /home/user/work/workers/data-analysis |
+| `{worker_dir}` | Absolute path of the worker working directory | /home/user/work/workers/data-analysis |
 | `{YYYY-MM-DD}` | Execution date | 2026-04-05 |

--- a/.claude/skills/org-pull-request/SKILL.md
+++ b/.claude/skills/org-pull-request/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: org-pull-request
 description: >
-  After user approval of a Worker completion report, the Lead handles push / PR creation / CI monitoring / the review feedback loop /
-  and final close-out after PR merge. Trigger conditions:
-  (1) immediately after receiving a completion report from a Worker and the user gives explicit approval such as "OK" or "Proceed",
-  (2) when review feedback or a CI failure arrives on a GitHub PR and the Lead sends a follow-up fix request back to the Worker,
-  (3) when the PR is merged and the final close-out condition is satisfied.
-  The initial action of simply "asking a Worker to do work" belongs to org-delegate, not this skill.
+  After the user approves a worker's completion report, the Lead handles push / PR creation / CI monitoring /
+  review-feedback loop / final close after PR merge. Triggers:
+  (1) immediately after a worker submits a completion report and the user gives explicit approval such as "OK" or "go ahead",
+  (2) when review feedback / CI failure arrives on the GitHub PR and you need to send fix instructions back to the worker,
+  (3) when the PR is merged and the final close conditions are met.
+  The initial "delegate work to a worker" step is handled by org-delegate, not by this skill.
 effort: medium
 allowed-tools:
   - Read
@@ -31,48 +31,56 @@ allowed-tools:
   - mcp__renga-peers__check_messages
 ---
 
-# org-pull-request: PR Creation, Review, and Post-Merge Close-Out
+# org-pull-request: PR creation, review, and post-merge close
 
-Handles the flow from Worker completion report → user approval → push / PR creation / CI monitoring / review feedback loop / final close-out after PR merge. **Lead-only**. This skill assumes the state is already "Worker has reported completion and the user has given explicit approval." For the pre-approval phase (issuing ack, transition to REVIEW, user report), see `.claude/skills/org-delegate/SKILL.md` Step 5 (2a).
+Covers worker completion report -> user approval -> push / PR creation / CI monitoring / review-feedback loop / final close after PR merge. **Lead only.** The precondition for invoking this skill is that the worker has submitted a completion report and the user has given explicit approval. The pre-approval phase (ack issuance, transition to REVIEW, reporting to the user) is covered by `.claude/skills/org-delegate/SKILL.md` Step 5 (2a).
 
-> **T5 contract**: The canonical spec for the `awaiting_review → complete` transition handled by this skill is
+> **T5 contract**: The canonical spec for the `awaiting_review -> complete` transition handled by this skill is
 > [`docs/contracts/delegation-lifecycle-contract.md`](../../../docs/contracts/delegation-lifecycle-contract.md) §2 T5 / T6 / §1.5 close-condition.
-> That contract is the SoT that pins close-condition / pane discipline / the no-respawn rule.
-> This SKILL covers procedure; the contract covers invariants.
+> That contract is the SoT that pins close-condition / pane discipline / no-respawn.
+> This SKILL owns the procedure; the contract owns the invariants.
 
-> **ack ≠ user approval**: By the time this skill is triggered, ack has already been issued (`.claude/skills/org-delegate/SKILL.md` Step 5 step 1 / [`.claude/skills/org-delegate/references/ack-template.md`](../org-delegate/references/ack-template.md)). Only issue push / `gh pr create` / `tools/pr-watch.*` after user approval.
+> **ack != user approval**: By the time this skill is invoked, ack has already been issued (`.claude/skills/org-delegate/SKILL.md` Step 5 step 1 / [`.claude/skills/org-delegate/references/ack-template.md`](../org-delegate/references/ack-template.md)). push / `gh pr create` / `tools/pr-watch.*` are issued only after user approval.
 
-## 2b-i. PR Creation Phase (Execute Immediately)
+## 2b-i. PR creation phase (run immediately)
 
-Trigger this immediately after the user gives **explicit approval** such as "OK", "Reviewed", "No issue", or "Proceed":
+Triggered immediately after the user gives **explicit approval** such as "OK", "looks good", "no issues", or "go ahead":
 
-- The Lead pushes and creates the PR as needed (the Worker does not have permission for `git push` or PR creation). Follow `feedback_pr_issue_english` for PR body language rules (PRs / Issues are in English)
-- **As soon as the PR number is known, immediately back-fill `runs.pr_url` / `runs.branch` with `tools/set_run_pr_open.py`** (Issue #323):
+- The Lead performs push / PR creation as needed (the worker does not have `git push` / PR-creation permissions). The language convention for PR bodies follows `feedback_pr_issue_english` (PRs / Issues in English).
+- **As soon as the PR number is confirmed, immediately back-fill `runs.pr_url` / `runs.branch` with `tools/set_run_pr_open.py`** (Issue #323):
   ```bash
   python tools/set_run_pr_open.py --task-id <task_id> --pr <PR>
   ```
-  This fetches `gh pr view <PR> --json url,headRefName` once and overwrites `runs.pr_url` and `runs.branch` via `StateWriter.set_run_pr`. Re-invocation is idempotent (same-value overwrite, no event append). Without this, downstream `tools/run_complete_on_merge.py` cannot resolve `runs.pr_url`, exits with `no_run` (exit 3), and `-MergeWatch` auto-completion fails
-- Append an event to the DB `events` table (push / PR open, etc., via `bash tools/journal_append.sh ...`)
-- Once the PR number is known, monitor CI with `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX). On completion, `ci_completed` is automatically recorded in `events`. When CI completes, pr-watch **returns** (it does not hold the session synchronously, so the flow can proceed to review feedback loop 2c or manual close 2b-ii)
-- **In a renga environment, pr-watch sends a peer message to Lead when CI completes / merge is detected / 24h timeout hits** (Issue #326). The Lead does not poll the `events` table. Instead, proceed when `<channel source="renga-peers"> CI_COMPLETED: PR #<n> ...` arrives (and likewise `PR_MERGED: PR #<n>` / `PR_MERGE_WATCH_TIMEOUT: PR #<n>` / `PR_MERGED_NO_RUN: PR #<n>`). On `CI_COMPLETED` → ask the user for merge approval → user approves → on `PR_MERGED`, proceed to 2b-ii post-merge cleanup. `PR_MERGED_NO_RUN` is a failure path where merge was observed but no matching run row was found (`tools/run_complete_on_merge.py` ended with `no_run`); do not proceed to post-merge cleanup, handle with human judgment. In plain shell / CI with `RENGA_SOCKET` unset, peer-send is a silent noop and the flow falls back to polling the `events` table as before
-- **Emit the awaiting_user notification just before asking the user for merge approval after CI_COMPLETED (Issue #28)**: tell the attention watcher that the user is stopped waiting on a merge approval:
+  This calls `gh pr view <PR> --json url,headRefName` once and overwrites `runs.pr_url` and `runs.branch` via `StateWriter.set_run_pr`. Re-invocation is idempotent (overwrites with the same values, no events appended). Without this, the later `tools/run_complete_on_merge.py` cannot look up `runs.pr_url`, fails with `no_run` (exit 3), and the `-MergeWatch` auto-completion breaks.
+- Append events to the DB events table (push / PR open etc., `bash tools/journal_append.sh ...`).
+- Once the PR number is confirmed, monitor CI with `tools/pr-watch.ps1 <PR>` (Windows) / `tools/pr-watch.sh <PR>` (POSIX). On completion `ci_completed` is automatically recorded in events. pr-watch **returns** once CI completes (so it does not synchronously block, allowing you to proceed to review-feedback loop 2c or manual close 2b-ii).
+- **In renga environments, pr-watch sends a peer message to the Secretary at the moment of CI completion / merge detection / 24h timeout** (Issue #326). The Lead does not poll the events table; it advances to the next step on arrival of `<channel source="renga-peers"> CI_COMPLETED: PR #<n> ...` (and `PR_MERGED: PR #<n>` / `PR_MERGE_WATCH_TIMEOUT: PR #<n>` / `PR_MERGED_NO_RUN: PR #<n>`). `CI_COMPLETED` received -> ask the user for merge approval -> user approval -> `PR_MERGED` received -> go to 2b-ii post-merge cleanup. `PR_MERGED_NO_RUN` is a failure case where merge was observed but no corresponding run row was found (the `no_run` terminal state of `tools/run_complete_on_merge.py`); do not proceed to post-merge cleanup — handle by human judgment. In plain shells / CI without `RENGA_SOCKET` set, peer-send is a silent noop and falls back to polling the events table as before.
+- **Right before "CI_COMPLETED received -> ask user for merge approval", emit an awaiting_user notification (Issue #28)**: this tells the attention watcher that the user is stopped while awaiting merge approval:
   ```bash
   bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=<task_id> gate=ci_green_merge_gate note="PR #<PR> CI green, awaiting merge approval"
   ```
-  The classifier in the parallel runtime PR picks it up as `secretary_awaiting_user` (default severity `urgent`). See the "Notify when the Secretary is waiting on a user judgment" section in CLAUDE.md. Failure paths such as `PR_MERGE_WATCH_TIMEOUT` are out of scope (they go through a separate human-judgment path, not awaiting_user).
-- Add `-MergeWatch` (PowerShell) / `--merge-watch` (POSIX) **only when you want to wait for merge**. After CI passes, it polls `gh pr view --json mergedAt` for 24h and calls `tools/run_complete_on_merge.py` on first merge detection (Issue #317). During merge-watch, the pr-watch process stays alive and returns only after appending a `pr_merged` event to `events`
-- Keep `run.status` **at REVIEW** (so the same pane can handle GitHub-side PR review feedback if it arrives. Transition to COMPLETED happens in 2b-ii by calling `update_run_status('<task_id>', 'completed')`). Do not edit markdown directly
-- **Do not close the pane yet**: do not send `CLOSE_PANE` immediately after PR creation. Delay worktree removal and Worker Directory Registry updates until 2b-ii
-- If PR review feedback arrives, follow flow 2c and send follow-up instructions to the same Worker with `send_message`, then have it stack fix commits in the same pane (avoid dispatching a new Worker; that would pay the cost of reconstructing the Issue / diff / decision boundary)
-- **For a dogfood-target PR (Issue #338)**: in `registry/dogfood_pending.md`, find the `status=pending` row for this `task_id` and (a) fill in `impl_pr=#<PR>`, (b) create the paired follow-up issue with `gh issue create --title "dogfood follow-up: <surface>" --body-file <rendered template>` (template: [`.claude/skills/org-delegate/references/dogfood-issue-template.md`](../org-delegate/references/dogfood-issue-template.md)), (c) fill the created issue number into `dogfood_issue=#<MMM>` and transition `status` from `pending → open`, (d) append `Paired dogfood issue: #<MMM>` to the bottom of the PR body. The full protocol's SoT is [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8
+  The classifier in the parallel runtime PR picks this up as `secretary_awaiting_user` (default severity `urgent`). See the "notify when the secretary is waiting on a user decision" section of CLAUDE.md. Failure cases such as `PR_MERGE_WATCH_TIMEOUT` are out of scope (those go to human judgment via a different path, not awaiting_user).
+- **Only when you want to wait for merge**, pass `-MergeWatch` (PowerShell) / `--merge-watch` (POSIX). After CI passes, it polls `gh pr view --json mergedAt` for 24h and calls `tools/run_complete_on_merge.py` on the first observed merge (Issue #317). During merge-watch the pr-watch process stays alive; on merge observation it appends a `pr_merged` event to events and then returns.
+- run.status **stays at REVIEW** (so that GitHub PR review feedback can be handled in the same pane; the transition to COMPLETED happens in 2b-ii via `update_run_status('<task_id>', 'completed')`). Do not edit markdown directly.
+- **Do not close the pane yet**: do not send `CLOSE_PANE` immediately after PR creation. worktree removal and Worker Directory Registry updates are deferred until 2b-ii.
+- If PR review feedback arrives, follow flow 2c and send a `send_message` follow-up instruction to the same worker so they push fix commits in the same pane (avoid respawning a new worker — you would pay the cost of rebuilding Issue / diff / judgment boundaries).
+- **For dogfood-target PRs (Issue #338)**: in `registry/dogfood_pending.md`, find the row for the relevant task_id with `status=pending`, then (a) fill in `impl_pr=#<PR>`, (b) create the paired follow-up issue with `gh issue create --title "dogfood follow-up: <surface>" --body-file <rendered template>` (template: [`.claude/skills/org-delegate/references/dogfood-issue-template.md`](../org-delegate/references/dogfood-issue-template.md)), (c) fill in the resulting issue number as `dogfood_issue=#<MMM>` and transition `status` from `pending -> open`, (d) append `Paired dogfood issue: #<MMM>` to the end of the PR body. The SoT for the full protocol is [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8.
 
-## 2c. Review Feedback / CI Failure Feedback Loop
+### Warning: cwd when launching pr-watch
 
-When a human gives feedback or fix instructions, or when CI fails and the user says "have them fix it":
+`tools/pr-watch.sh` / `tools/pr-watch.ps1` / `tools/pr_watch.py` open `state.db` via a relative path, so if the cwd at launch is not the ja root, writing the CI-completion event will crash and peer notifications (`CI_COMPLETED` / `PR_MERGED` etc.) will not fire. If you just `cd .worktrees/...` beforehand, always launch as `cd <ja-root> && nohup bash tools/pr-watch.sh <PR> ...`. A root fix (cwd-independence) is in progress in Issue #398.
 
-- Send additional instructions to the Worker over renga-peers (`to_id="worker-{task_id}"`)
-- If the added instruction is a trivial fix (CI output formatting / typo / comment edit, etc.), explicitly set verification depth to `minimal` and instruct the Worker to return completion in a single line as `done: {short commit SHA} {changed filename}` (format follows [`.claude/skills/org-delegate/references/instruction-template.md`](../org-delegate/references/instruction-template.md) / [`.claude/skills/org-delegate/references/worker-claude-template.md`](../org-delegate/references/worker-claude-template.md))
-- **Return the run to IN_PROGRESS via DB** (`run.status='in_use'`, direct markdown edits are forbidden. The post-commit hook regenerates `.state/org-state.md`):
+### Warning: when launching via the Claude Code Bash tool
+
+When the Lead launches `tools/pr-watch.sh` / `tools/pr-watch.ps1` from inside Claude Code, always submit with the Bash tool's `run_in_background: true`. With `nohup ... &` + `disown` alone, the Claude Code bash sub-shell is short-lived and pr-watch gets killed along with it as soon as the call returns, so neither the CI-completion event nor the peer notification fires (the process disappears quietly and only an empty log file is left behind, which is hard to notice). This trap is especially easy to fall into in fresh sessions right after `/clear` / [`/secretary-resume`](../secretary-resume/SKILL.md). With `run_in_background: true`, you get an automatic completion notification (with exit code), so the CI-completion detection path is covered there as well.
+
+## 2c. Review feedback / CI failure feedback loop
+
+If a human provides feedback / fix instructions, or if CI fails and the user says "have them fix it":
+
+- Send additional instructions to the worker via renga-peers (`to_id="worker-{task_id}"`).
+- If the additional instructions are a trivial fix (CI output formatting / typo / comment fix etc.), explicitly state **verification depth `minimal`** and tell them to reply with only a single line `done: {short commit SHA} {changed file names}` (the format follows [`.claude/skills/org-delegate/references/instruction-template.md`](../org-delegate/references/instruction-template.md) / [`.claude/skills/org-delegate/references/worker-claude-template.md`](../org-delegate/references/worker-claude-template.md)).
+- **Move the run back to IN_PROGRESS via the DB** (`run.status='in_use'`, do not edit markdown directly. The post-commit hook regenerates `.state/org-state.md`):
   ```bash
   python -c "
   from pathlib import Path
@@ -83,54 +91,53 @@ When a human gives feedback or fix instructions, or when CI fails and the user s
       w.update_run_status('<task_id>', 'in_use')
   "
   ```
-- Append an event to the DB `events` table (`bash tools/journal_append.sh ...`) (`tools/journal_append.py` already routes to DB)
-- The JSON snapshot is automatically regenerated by the StateWriter post-commit hook (Issue #284)
-- (Because the pane is still alive, the Worker continues in place)
-- **Do not respawn a new Worker** (T6 contract): that would lose the Issue / diff / decision boundary. Only the Lead decides otherwise if the Worker becomes non-responsive
+- Append events to the DB events table (`bash tools/journal_append.sh ...`) (`tools/journal_append.py` is already routed to the DB).
+- The JSON snapshot is automatically regenerated by the StateWriter post-commit hook (Issue #284).
+- (The pane is alive, so the worker simply continues working.)
+- **Do not respawn a new worker** (T6 contract): Issue / diff / judgment boundaries would be lost. Only when the worker becomes unresponsive does the Lead make that call.
 
-When a new completion report comes back from the Worker, go again in this order: `.claude/skills/org-delegate/SKILL.md` Step 5 (2a) → user approval → this skill 2b-i.
+Once a new completion report arrives from the worker, proceed again through `.claude/skills/org-delegate/SKILL.md` Step 5 (2a) -> user approval -> 2b-i of this skill.
 
-## 2b-ii. Final Close-Out Phase (Execute When a Close Condition Is Met)
+## 2b-ii. Final close phase (run once the close conditions are met)
 
-Close condition (same as contract §1.5; satisfy at least one):
-- The PR is merged (confirm with `gh pr view {n} --json mergedAt`, etc., or the Lead receives a merge notice, or `pr-watch --merge-watch` reports a `pr_merged` event)
-- The user explicitly says "you can close it", "close it", "already merged", etc.
-- Long idle with no review activity for 24-48 hours (Lead operational judgment as needed; do not automate)
+Close conditions (same as contract §1.5; at least one must be satisfied):
+- The PR has been merged (confirmed by `gh pr view {n} --json mergedAt` etc., or the Lead receives a merge notification, or notified via the `pr_merged` event of `pr-watch --merge-watch`).
+- The user explicitly says "you can close it", "close it", "merged", etc.
+- 24-48 hours of long idle with no review activity (left to the Lead's operational discretion; not automated).
 
-Actions:
+Actions to perform:
 
-- Update the target run to **COMPLETED** in the DB (done via the `update_run_status('<task_id>', 'completed')` block below). Do not edit markdown directly
-- Final-update the Worker state file (append the last Progress Log, etc.)
-- **The Worker state file (`.state/workers/worker-{task_id}.md`) is automatically moved into `.state/workers/archive/` by StateWriter in the post-commit hook of `update_run_status('<task_id>', 'completed')`** (Issue #284. `archive/` is created lazily if absent; re-invocation is idempotent. The dashboard does not treat files in this directory as live Workers (Issue #264). Do not delete them; journal / retro may need the history)
-- Append an event to the DB `events` table (`bash tools/journal_append.sh ...`)
-- Ask the Dispatcher to close the pane:
-  `CLOSE_PANE: Please close pane {pane_id}.`
-- **Run cleanup based on directory pattern** (at the same time):
-  - Pattern A (project directory): keep the directory (reuse it for the next task)
-  - Pattern B (worktree): run `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}`. Keep the branch (do not delete it even after merge; preserve PR history)
-    - **For self-edit (`pattern_variant='live_repo_worktree'`)**: because the worktree base is `{claude_org_path}`, run `git -C {claude_org_path} worktree remove .worktrees/{task_id}` (Issue #289). Keep the branch here as well
-  - Pattern C (ephemeral): keep the directory (consider manual deletion only if disk usage becomes a problem)
-- **On paired-issue close for a dogfood-target PR (Issue #338)**: because the implementation PR merge and the paired follow-up issue close can have independent lifecycles, this skill does not guarantee the `consumed → closed` transition simply because the implementation PR was merged. The terminal `consumed → closed` transition is the Lead's register-hygiene responsibility, collected via [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8 §`consumed → closed` observation timing (verify the paired-issue state with `gh issue view` at register-write time + at `/org-resume` startup). If this skill happens to observe the relevant row at PR-merge time, opportunistically run the hygiene step
-- **For PR-based close-out, call `tools/run_complete_on_merge.py`** (Issue #317. Normally no manual invocation is needed because the merge-watch loop in `pr-watch --merge-watch` starts automatically, but call it explicitly if merge-watch was skipped or merge was observed manually):
+- DB-update the relevant run to **COMPLETED** (use the `update_run_status('<task_id>', 'completed')` block described below). Do not edit markdown directly.
+- Final-update the worker's state file (append the last Progress Log entry, etc.).
+- **The worker state file (`.state/workers/worker-{task_id}.md`) is automatically moved to `.state/workers/archive/` by StateWriter's post-commit on `update_run_status('<task_id>', 'completed')`** (Issue #284. `archive/` is lazily created if absent; re-invocation is idempotent. The dashboard does not treat files in this directory as live workers (Issue #264). They are not deleted, in case the journal / retro needs to reference history.)
+- Append events to the DB events table (`bash tools/journal_append.sh ...`).
+- Ask the dispatcher to close the pane:
+  `CLOSE_PANE: please close pane {pane_id}.`
+- **Post-processing per directory pattern** (do at the same time):
+  - Pattern A (project directory): keep the directory (reused for the next task).
+  - Pattern B (worktree): run `git -C {workers_dir}/{project_slug}/ worktree remove .worktrees/{task_id}`. Keep the branch (do not delete the branch even after merge, for PR history).
+    - **For self-edit (`pattern_variant='live_repo_worktree'`)**: the worktree base is `{claude_org_path}`, so run `git -C {claude_org_path} worktree remove .worktrees/{task_id}` (Issue #289). Keep the branch likewise.
+  - Pattern C (ephemeral): keep the directory (consider manual deletion only if capacity becomes an issue).
+- **When closing a dogfood-target PR's paired issue (Issue #338)**: because the implementation PR's merge and the paired follow-up issue's close can have independent lifecycles, this skill does not guarantee "do `consumed -> closed` on implementation-PR merge". The terminal transition `consumed -> closed` is the Lead's register-hygiene responsibility and is collected via [`.claude/skills/org-delegate/SKILL.md`](../org-delegate/SKILL.md) Step 1.8 §"consumed -> closed observation timing" (on register write + at `/org-resume` startup, check paired-issue state with `gh issue view`). If this skill happens to observe the relevant row at PR-merge time, it may invoke the hygiene step opportunistically.
+- **For PR-driven closes, call `tools/run_complete_on_merge.py`** (Issue #317. The merge-watch loop of `pr-watch --merge-watch` invokes it automatically, so manual execution is normally unnecessary; call it explicitly only when merge-watch was skipped or when the merge was observed manually):
   ```bash
   python tools/run_complete_on_merge.py --pr <PR>
   ```
-  This fetches `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` once. If the PR is merged, it updates `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` through `StateWriter.transaction()` and appends one `pr_merged` event (payload: `task` / `pattern` / `auto_completed`). Re-invocation is idempotent (no duplicate event). `task_id` is resolved automatically from `runs.pr_url` / `runs.branch` (active runs only); if resolution fails, specify `--task-id`
-  - **The helper does not touch `runs.status`**: Dispatcher-side pane close / worker_closed / final Worker-state update are still required (delegation-lifecycle-contract §T5). The helper records only the merge fact; the Lead performs the status flip and Worker-dir removal with the StateWriter block below
-  - **CLI exit codes**: `merged` / `already` / `not_yet` exit 0; `no_run` (no matching row in `runs`) exits 3 and is treated as failure. Check the exit code in manual operation
-- **For Pattern B / C, remove the registry entry and perform final close separately via StateWriter** (direct markdown edits forbidden. Since `run_complete_on_merge` already wrote `pr_state='merged'` and `completed_at`, only perform the status flip and Worker-dir removal here):
+  This calls `gh pr view <PR> --json url,state,mergedAt,mergeCommit,headRefName` once and, if the PR is merged, updates `pr_state='merged'` / `commit_short` / `pr_url` / `completed_at` via `StateWriter.transaction()` and appends a single `pr_merged` event (payload: `task` / `pattern` / `auto_completed`). Re-invocation is idempotent (does not write a duplicate event). task_id is auto-resolved from `runs.pr_url` / `runs.branch` (restricted to active runs); if resolution fails, pass `--task-id` explicitly.
+  - **The helper does not touch runs.status**: dispatcher-side pane close / worker_closed / worker-state final update are required (delegation-lifecycle-contract §T5). The helper only records the merge fact; the status flip and worker_dir removal are done by the Lead via the StateWriter below.
+  - **CLI exit codes**: `merged` / `already` / `not_yet` are exit 0; `no_run` (no matching row in runs) is exit 3 and counted as failure. Check the exit code when running manually.
+- **Pattern B / C registry-entry deletion and final close are done by a separate StateWriter call** (do not edit markdown directly. run_complete_on_merge has already written `pr_state='merged'` and `completed_at`, so here we only do the status flip and worker_dir removal):
   ```bash
   python -c "
   from tools.state_db import connect
   from tools.state_db.writer import StateWriter
   conn = connect('.state/state.db')
   with StateWriter(conn).transaction() as w:
-      w.update_run_status('<task_id>', 'completed')  # post-commit hook が worker-{task}.md を archive
-      w.remove_worker_dir('<abs>')  # パターン B / C のみ
+      w.update_run_status('<task_id>', 'completed')  # post-commit hook archives worker-{task}.md
+      w.remove_worker_dir('<abs>')  # Pattern B / C only
   "
   ```
-  The legacy hand-rolled completion script is stored in `docs/legacy/pr-merge-completion-manual.md`. The standard path is the `tools/run_complete_on_merge.py` above. Reach for the museum copy only after filing an Issue and asking for user judgment (same pattern as PR #315)
-  - Pattern A: keep `lifecycle='active'`, with `run.status='completed'` so the snapshotter renders it equivalent to available
-  - Pattern B / C: handle the physical dir separately (worktree remove / keep dir). For registry entry removal, add `w.remove_worker_dir('<abs>')` inside the `with` block above
-- The JSON snapshot is automatically regenerated by the StateWriter post-commit hook (Issue #284)
----
+  The legacy hand-rolled completion script is preserved at `docs/legacy/pr-merge-completion-manual.md`. The standard route is `tools/run_complete_on_merge.py` above; reaching for the museum copy is allowed only after opening an issue and getting user judgment (same pattern as PR #315).
+  - Pattern A: lifecycle stays `active`; with run.status='completed' the snapshotter renders it as available-equivalent.
+  - Pattern B / C: the physical dir is handled separately (worktree remove / dir retention). For registry-entry deletion, add `w.remove_worker_dir('<abs>')` inside the with block above.
+- The JSON snapshot is automatically regenerated by the StateWriter post-commit hook (Issue #284).

--- a/.claude/skills/org-resume/SKILL.md
+++ b/.claude/skills/org-resume/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: org-resume
 description: >
-  Resume a suspended org. Use when `.state/org-state.md` exists with
-  Status: SUSPENDED and the user says "resume", "continue from where we left off",
-  "where did we get to last time?". Also covers the auto-briefing on startup.
+  Resume a suspended org. Use when `.state/org-state.md` exists with Status: SUSPENDED,
+  or when the user says "resume", "pick up from where we left off", or "where did we stop last time?".
+  Also handles the automatic startup briefing.
 effort: low
 allowed-tools:
   - Read
@@ -16,77 +16,79 @@ allowed-tools:
   - Bash(python -m tools.state_db.importer:*)
 ---
 
-# org-resume: resume the org
+# org-resume: resuming the org
 
-Load the suspended org's state, brief the human, and resume.
+Load the state of a suspended org, brief the human, and resume.
 
 > **state DB premise (Issue #267 / M4)**: `.state/state.db` is the sole SoT.
-> The read path is DB only (markdown fallback was removed in M4); the structured
-> sections' write path goes through `StateWriter.transaction()` (a post-commit
-> hook auto-regenerates `.state/org-state.md` from the DB; direct markdown edits
-> are forbidden — drift_check detects them). Free-form learnings / Pending Lead
-> items go under `notes/`. `.state/journal.jsonl` was retired in M4. If the DB
-> is missing, build it with
-> `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
+> The read path is DB-only (markdown fallback was removed in M4); the write path
+> for structured sections goes through `StateWriter.transaction()` (the post-commit
+> hook regenerates `.state/org-state.md` from the DB; direct markdown editing is
+> forbidden — drift_check will detect it). Free-form learnings / Pending Lead etc.
+> are stored under `notes/`. `.state/journal.jsonl` was retired in M4.
+> If the DB is missing, build it with `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
 
-## Phase 1: Load state and brief
+## Phase 1: load state and brief
 
-0. **Run the state-schema migration** (Set C §4.4 contract). Bring the JSON state under `.state/` to the latest schema before reading:
+0. **Run the state schema migration** (Set C §4.4 contract). Bring the JSON state under `.state/` up to the latest schema before reading:
 
    ```bash
    py -3 tools/state_migrate.py    # Windows
    python3 tools/state_migrate.py   # Mac/Linux
    ```
 
-   exit 0 → continue. exit 1 (unsupported version remains) / exit 2 (migration loop anomaly) → report to the human and stop.
-1. **Pull the previous state from the DB**:
-   - `.state/state.db` exists → query the DB:
+   Continue on exit 0. On exit 1 (unsupported version remaining) / exit 2 (migration loop anomaly), report to the human and stop.
+1. **Fetch previous state from the DB** (Phase 1 uses the lightweight briefing API, Issue #412):
+   - `.state/state.db` exists -> query the DB:
      ```bash
-     python -c "from tools.state_db import connect; from tools.state_db.queries import get_resume_briefing; import json; \
+     python -c "from tools.state_db import connect; from tools.state_db.queries import get_resume_briefing_light; import json; \
        conn = connect('.state/state.db'); \
-       print(json.dumps(get_resume_briefing(conn), ensure_ascii=False, indent=2, default=str))"
+       print(json.dumps(get_resume_briefing_light(conn), ensure_ascii=False, indent=2, default=str))"
      ```
-     Use `active_runs` / `recent_events` / `last_suspend_at` to compose the briefing material. Status / Current Objective / Resume Instructions are also stored on `org_sessions`.
-   - DB is missing → ask the human to rebuild it:
+     Build briefing material from `active_runs` / `reserved_runs` / `recent_events` / `last_suspend_summary`.
+     `session` contains a compressed view of Status / Current Objective / suspended_at / resumed_at / resume_summary (raw `resume_instructions` body and raw event `payload_json` are not included).
+     `active_inventory_dirs` is the worker_dir set derived from `runs.status` (state-semantics-contract I7 — it is not `worker_dirs.lifecycle='active'`).
+     If needed (very rare cases), `get_resume_briefing` can retrieve the raw payload / full resume_instructions, but do not use it in startup Phase 1.
+   - DB missing -> prompt the human to rebuild:
      "state.db not found. Run: `python -m tools.state_db.importer --db .state/state.db --root . --rebuild`".
 2. Present a concise summary to the human:
-   - Overall objective (DB `objective`).
-   - Status of each work item (done / in progress / pending / blocked, from DB active_runs).
-   - Suspend timestamp (DB `last_suspend_at`).
-3. Check the free-form notes under `notes/` (learnings / Pending Lead / session summaries).
+   - Overall objective (briefing's `session.objective`).
+   - State of each work item (done / in progress / on hold / blocked; briefing's `active_runs` / `reserved_runs`).
+   - Suspend timestamp (briefing's `last_suspend_summary.occurred_at`; reason / counts are in the same dict).
+3. Check free-form material under `notes/` (learnings / Pending Lead / session summary).
 
-## Phase 2: Cross-check against reality
+## Phase 2: reconcile with reality
 
-Treat the DB's active_runs as the SoT and use markdown only as a display aid.
+Use the DB's active_runs as the SoT for reconciliation; treat markdown as a display aid.
 
-1. Starting from the active_runs returned by the DB (or the markdown Worker Directory Registry), verify the `worker_dir` of each run.
-2. Also reference each worker's state file under `.state/workers/` (legacy path).
-3. In each worker's working directory, verify:
-   - The directory exists.
-   - `git status` — any uncommitted changes?
-   - `git log --oneline -5` — does the last commit match the run's `commit_short` / state-file record?
-   - The branch matches the run's `branch` / state-file description.
-4. Check `knowledge/raw/` for any unsorted files.
-5. If you find a discrepancy, report it to the human (e.g., "the DB lists OAuth run as in_use, but the directory does not exist").
+1. Starting from the active_runs fetched from the DB (or the markdown Worker Directory Registry), verify each run's `worker_dir`.
+2. Also reference each worker state file under `.state/workers/` (legacy path).
+3. In each worker's working directory, check:
+   - Whether the directory exists.
+   - `git status` — uncommitted changes?
+   - `git log --oneline -5` — does the last commit match the run's `commit_short` / state file?
+   - Does the branch match the run's `branch` / what is recorded in the state file?
+4. Check for unsorted files under `knowledge/raw/`.
+5. Report any discrepancies to the human (e.g., "The DB says the OAuth run is in_use, but the directory does not exist").
 
-## Phase 3: Propose a resumption plan
+## Phase 3: propose a resume plan
 
-Branch the proposal on the state:
+Branch the proposal by state:
 
-- **COMPLETED**: just report the result.
-- **IN_PROGRESS (suspended)**: "Uncommitted changes are present. Should I dispatch a worker to continue?"
-- **PENDING**: confirm the blocker's status and judge whether it is now executable.
-- **BLOCKED**: confirm whether the blocker has been resolved.
+- **COMPLETED**: just report results.
+- **IN_PROGRESS (suspended)**: "There are uncommitted changes. Shall I dispatch a worker to continue?"
+- **PENDING**: check blocker state and judge whether it is now actionable.
+- **BLOCKED**: check whether the blocker has been resolved.
 
-**Important: wait for the human's approval before acting. Do not dispatch a worker on your own.**
+**Important: wait for the human's confirmation before acting. Do not dispatch workers on your own.**
 
-## Phase 4: Reconstruct the org
+## Phase 4: rebuild the org
 
-For each work item the human approves:
+For the work the human approved:
 
-1. Dispatch a worker with the `/org-delegate` skill.
-2. Pass the contents of the previous worker's state file (`.state/workers/worker-{id}.md`) to the new worker as context.
-3. **Write Status / Resumed to the DB** (via `StateWriter.transaction()`. The post-commit hook updates the Status line of `.state/org-state.md` to `ACTIVE`. If regen fails the DB write is still committed; only a stderr warning is emitted):
+1. Dispatch workers with the `/org-delegate` skill.
+2. Pass the contents of the previous worker state file (`.state/workers/worker-{id}.md`) to the new worker as context.
+3. **Write Status / Resumed to the DB** (via `StateWriter.transaction()`. The post-commit hook updates the Status line of `.state/org-state.md` to `ACTIVE`. Even if regen fails, the DB is already committed, and only a stderr warning is emitted):
 
    ```bash
    python -c "
@@ -100,17 +102,17 @@ For each work item the human approves:
        w.update_session(status='ACTIVE', resumed_at=ts, updated_at=ts)
    "
    ```
-4. Regenerate the JSON snapshot (for the dashboard; this is a separate path from the state-db cutover):
+4. Regenerate the JSON snapshot (for the dashboard; separate path from the state-db cutover):
 
    ```bash
    py -3 dashboard/org_state_converter.py    # Windows
    python3 dashboard/org_state_converter.py   # Mac/Linux
    ```
 
-5. Starting the Dispatcher and Curator panes is /org-start's job, not org-resume's.
-6. Append a resume event to the DB (`tools/journal_append.py` is M4 DB-only routing; `ts` is auto-populated):
+5. Launching the dispatcher / curator panes is owned by /org-start, so do not do it here.
+6. Append the resume event to the DB (`tools/journal_append.py` routes DB-only in M4; `ts` is added automatically):
    ```bash
    py -3 tools/journal_append.py resume \
        --json '{"resumed_items": ["blog-redesign", "data-analysis"]}'
    ```
-   Refer to [`docs/journal-events.md`](../../../docs/journal-events.md) for the event-name / payload-key convention.
+   For event-name and payload-key conventions, see [`docs/journal-events.md`](../../../docs/journal-events.md).

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: org-start
 description: >
-  Start the organization. Load the previous state and brief it,
-  then start the Dispatcher and Curator panes. Run once immediately after starting ClaudeCode.
-  Also triggers on phrases like "start", "boot", or "begin".
+  Start up the org. Load the previous state and brief, then launch the dispatcher and curator panes.
+  Run this once right after starting Claude Code. Also triggered by "start", "boot", "begin", etc.
 effort: low
 allowed-tools:
   - Read
@@ -15,125 +14,63 @@ allowed-tools:
   - mcp__renga-peers__*
 ---
 
-# org-start: Start the Organization
+# org-start: starting the org
 
-The first skill to run after starting ClaudeCode. Restores the previous state, starts the Dispatcher, and starts the Curator.
+The first skill to run after Claude Code launches. Performs previous-state restoration, dispatcher startup, and curator startup.
 
-> **Prerequisite**: This Claude is running inside the Lead pane started with `renga --layout ops`.
-> Because the `RENGA_SOCKET` / `RENGA_PANE_ID` environment variables are inherited, the 14
-> `mcp__renga-peers__*` MCP tools (`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` /
+> **Premise**: this Claude is running inside the Lead pane started via `renga --layout ops`.
+> The `RENGA_SOCKET` / `RENGA_PANE_ID` environment variables are inherited, so the 14 `mcp__renga-peers__*` MCP
+> tools (`spawn_pane` / `spawn_claude_pane` / `close_pane` / `focus_pane` /
 > `list_panes` / `new_tab` / `send_message` / `list_peers` / `set_summary` /
 > `check_messages` / `inspect_pane` / `poll_events` / `send_keys` /
-> `set_pane_identity`) cover pane operations, peer messaging, screen scraping, lifecycle
-> event subscription, and raw key input within the same tab (**requires renga 0.18.0+**).
+> `set_pane_identity`) fully cover pane operations / peer messaging / screen scraping / lifecycle
+> event subscription / raw key input within the same tab (**renga 0.18.0+ required**).
 >
-> **State DB prerequisite (Issue #267 / M4)**: `.state/state.db` is the only SoT.
-> The read path is DB only (markdown fallback was removed in M4), and the write path for
-> structured sections (Status / Dispatcher / Curator / Worker Directory Registry /
-> Active Work Items / Resume Instructions) goes through
-> `StateWriter.transaction()` (the post-commit hook automatically regenerates
-> `.state/org-state.md` from the DB; direct markdown edits are forbidden and
-> detected by drift_check). Free-form notes (findings / Pending Lead / etc.)
-> are stored under `notes/`. `.state/journal.jsonl` was removed in M4.
-> If the DB does not exist, build it with `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
+> **state DB premise (Issue #267 / M4)**: `.state/state.db` is the sole SoT.
+> The read path is DB-only (markdown fallback was removed in M4); the write path
+> for structured sections (Status / Dispatcher / Curator / Worker Directory Registry /
+> Active Work Items / Resume Instructions) goes through `StateWriter.transaction()`
+> (the post-commit hook regenerates `.state/org-state.md` from the DB; direct
+> markdown editing is forbidden — drift_check will detect it). Free-form notes
+> (learnings / Pending Lead etc.) live under `notes/`. `.state/journal.jsonl`
+> was retired in M4.
+> If the DB is missing, build it with `python -m tools.state_db.importer --db .state/state.db --rebuild --no-strict`.
 
-## Step 0: Initialization
+## Step 0: initialization
 
-1. Set your summary with `mcp__renga-peers__set_summary`: `Secretary: Lead`
-   - Required so Workers / Dispatcher / Curator can discover the Lead via `mcp__renga-peers__list_peers`
-2. Verify connectivity to the `renga-peers` MCP: call `mcp__renga-peers__list_panes`.
-   - If it returns without error, the MCP is active. Continue assuming the renga-peers MCP tools are available
-   - If it returns an error or the tool is not registered, tell the user to run `renga mcp install`
-     and pause this skill (have them retry after MCP setup). See the `Installation` section in
-     `README.md` for details
-3. **Validate and auto-recover the secretary pane identity**:
-   - From the `mcp__renga-peers__list_panes` result, identify the pane with `focused=true` (= yourself)
-   - Expected: `name == "secretary"` and `role == "secretary"`
-   - **If it does not match**: started outside `renga --layout ops`, or attached to an existing session started with an old `ops.toml`, etc.
-     1. Call `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")` to auto-repair
-     2. If it succeeds, leave a warning log in the events table and continue (`bash tools/journal_append.sh secretary_identity_restored note=auto_recovered`)
+1. Set your own summary via `mcp__renga-peers__set_summary`: "Secretary: Lead".
+   - Required so that worker / dispatcher / curator can discover the Lead via `mcp__renga-peers__list_peers`.
+2. Verify `renga-peers` MCP connectivity: call `mcp__renga-peers__list_panes`.
+   - If a response comes back without error, MCP is enabled. From here on, proceed on the premise that renga-peers MCP tools are usable.
+   - If an error returns / the tool is not registered, ask the user to run `renga mcp install` and
+     pause execution of the Skill (have them retry after MCP is installed). See the README's
+     "Installation" section for details.
+3. **Verify and auto-recover the secretary pane identity**:
+   - From the result of `mcp__renga-peers__list_panes`, identify the pane with `focused=true` (= yourself).
+   - Expected: `name == "secretary"` and `role == "secretary"`.
+   - **If mismatched** — started via a route other than `renga --layout ops` / attached to an existing session that was launched from the old ops.toml, etc.:
+     1. Call `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")` to auto-repair.
+     2. On success, log a warning in the events table and continue (`bash tools/journal_append.sh secretary_identity_restored note=auto_recovered`).
      3. Failure branches:
-        - `name_in_use` error: another existing pane already owns `secretary`. Report the situation to the user and offer these options: "If continuing this session, have all Workers send to `to_id="{numeric_pane_id}"`" or "For a permanent fix, run `/org-suspend` -> exit -> restart with `renga --layout ops`"
-        - `name_invalid` / other: report the cause to the user
-   - **If it matches**: continue as-is
-4. Read `registry/org-config.md`, get `workers_dir`, and verify whether the worker directory exists.
-   If any directories exist, report the list to the user (never delete them).
-   **Forbidden**: worker directories may contain prior work products or reusable projects,
-   so do not delete them during org-start. Follow the directory retention policy in org-delegate.
+        - `name_in_use` error: another existing pane is occupying `secretary`. Report the situation to the user and present the options "continue current session by making all workers send to `to_id="{numeric_pane_id}"`" / "persistent fix: `/org-suspend` -> exit -> relaunch with `renga --layout ops`".
+        - `name_invalid` / other: report the cause to the user.
+   - **If matched**: continue as is.
+4. Read `workers_dir` from `registry/org-config.md` and verify the worker directories exist.
+   If any exist, report the list to the user (absolutely do not delete).
+   **Forbidden**: worker directories may contain past deliverables or reusable projects, so
+   they must not be deleted at org-start. Follow org-delegate's directory-retention policy.
 
-## Step 1: Check the Previous State
+## Steps 1-3: parallel startup phase
 
-The read path is **DB only** (Issue #267 / M4).
+> **Issue #410 / Stage B**: As soon as Step 0 (all four sub-steps: set_summary / MCP connectivity / identity verification / workers_dir verification) is complete, fire the `spawn_claude_pane` for dispatcher / curator, and in parallel with waiting for Claude to boot (~30-60s), run Block B (DB read of previous state) / Block C (dashboard server startup). The goal is to compress wall-clock time from ~3 minutes (when run serially) down to ~35s.
+>
+> **Execution model**: the Secretary fires the following three blocks (A/B/C) and finally joins at block D. Block A is I/O bound (renga MCP responses take a few hundred ms; after that we are just waiting on Claude's boot, which is a separate process), so wall-clock fully overlaps with B/C.
 
-1. Check whether `.state/state.db` exists
-   - If it exists, query the DB:
-     ```bash
-     python -c "from tools.state_db import connect; from tools.state_db.queries import get_org_state_summary; import json; \
-       conn = connect('.state/state.db'); \
-       print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))"
-     ```
-     Use `active_runs` / `recent_events` / `run_status_counts` / `session.status` / `session.objective` to understand the previous state
-   - If it does not exist, treat this as the first startup. Prompt the Lead to run the importer:
-     `python -m tools.state_db.importer --db .state/state.db --root . --rebuild --no-strict`
-2. Check `session.status`:
-   - If `SUSPENDED`, run Phases 1-3 of /org-resume (briefing, reconciliation, resume plan).
-     Then continue to Step 2 and later, start the Dispatcher and Curator, and after that run Phase 4 of org-resume (re-dispatch Workers) based on human approval
-   - If `ACTIVE`, the previous session may have terminated unexpectedly.
-     Check the git state of each worker directory and report the current situation
+### Block A: spawn dispatcher / curator panes (fire only; do not wait for boot to finish)
 
-## ClaudeCode Launch Commands by Role
+Pane layout follows org-delegate/references/pane-layout.md (renga edition). The spawn itself completes with a few-hundred-ms MCP response, so it is sufficient to fire them sequentially (no need for parallel firing; curator needs to resolve dispatcher's name with target="dispatcher").
 
-In renga 0.18.0+, `mcp__renga-peers__spawn_claude_pane` accepts role-specific structured fields (`cwd` / `permission_mode` / `model` / `args[]`) and automatically appends `--dangerously-load-development-channels server:renga-peers`. The old pattern of passing `cd X && claude ...` through `spawn_pane` is **forbidden** because it reintroduces the pitfall where renga's bare-`claude` auto-upgrade does not fire and channel push stops working.
-
-Common arguments:
-- `permission_mode`: write the literal `auto` directly (except for the Dispatcher). `CLAUDE.md` has no variable expansion mechanism, so values from `registry/org-config.md` cannot be substituted at runtime. If you need to change it, see the sync note section at the top of `registry/org-config.md`
-- `cwd`: relative path to the directory dedicated to that role (resolved relative to the caller pane's cwd)
-
-> **Note**: The Lead is started by `renga --layout ops` and runs without `--permission-mode` set (because it is the human-judgment desk). See the `Role-specific scope` section in `registry/org-config.md`.
-
-### Dispatcher
-
-- `cwd=".dispatcher"`
-- `permission_mode="bypassPermissions"` (fixed; not affected by `default_permission_mode`)
-- `model="sonnet"`
-
-Reason: the Dispatcher issues `mcp__renga-peers__spawn_claude_pane` when starting Workers. The auto-mode safety classifier classifies this "child agent startup" as "Create Unsafe Agents" and blocks it, so Worker dispatch does not work under auto.
-
-### Curator
-
-- `cwd=".curator"`
-- `permission_mode=auto`
-- `model="opus"`
-
-### Worker (used in org-delegate Step 3)
-
-**`model="opus"` is required (`sonnet` is forbidden).**
-Reason: the default Worker `permission_mode` is `auto` (classifier-based). This safety classifier only behaves reliably on Opus. With sonnet it misclassifies too often, the approval flow breaks, and work stalls. Only the Dispatcher is fixed to `bypassPermissions`, so it does not go through the classifier and is safe to run on sonnet (the Dispatcher uses sonnet for cost optimization; do not apply that to Workers).
-
-Normal:
-- `cwd="{workers_dir}/{task_id}"` (absolute path recommended)
-- `permission_mode=auto`
-- `model="opus"`
-
-## Step 1.5: Start the Dashboard Server
-
-1. Check whether the dashboard server is running:
-   ```bash
-   cat .state/dashboard.pid 2>/dev/null && kill -0 $(cat .state/dashboard.pid) 2>/dev/null && echo "running" || echo "stopped"
-   ```
-2. If it is stopped, start it:
-   ```bash
-   python3 dashboard/server.py &   # Mac/Linux
-   py -3 dashboard/server.py &     # Windows
-   ```
-3. Tell the user:
-   "Started the dashboard -> http://localhost:8099"
-
-## Step 2: Start the Dispatcher Pane
-
-Follow the pane layout in `org-delegate/references/pane-layout.md` (renga version).
-
-1. Use `mcp__renga-peers__spawn_claude_pane` to split the Lead pane horizontally and start the Dispatcher Claude in the lower half:
+1. `spawn_claude_pane` for dispatcher:
    ```
    mcp__renga-peers__spawn_claude_pane(
      target="focused",
@@ -145,41 +82,8 @@ Follow the pane layout in `org-delegate/references/pane-layout.md` (renga versio
      model="sonnet"
    )
    ```
-   - `target="focused"`: split the currently focused Lead pane (optional; defaults to focused if omitted)
-   - `direction="horizontal"` = top/bottom split (Lead=top / Dispatcher=bottom)
-   - `role="dispatcher"`: attach a label so `mcp__renga-peers__list_panes` can identify the role
-   - `name="dispatcher"`: stable name used by later calls such as `mcp__renga-peers__send_message(to_id="dispatcher", ...)` and `close_pane(target="dispatcher")`. **renga-peers interprets all-digit names as ids, so always use a name that contains letters**
-   - `cwd=".dispatcher"`: resolved to `.dispatcher/` relative to the caller pane (= Lead). The old pattern of embedding `cd X && claude ...` in `command` is forbidden because auto-upgrade does not fire and channel push is lost
-   - `permission_mode="bypassPermissions"` / `model="sonnet"`: renga synthesizes and runs `claude --permission-mode bypassPermissions --model sonnet --dangerously-load-development-channels server:renga-peers`
-   - `.dispatcher/CLAUDE.md` contains Dispatcher role instructions (separate from the Lead's `CLAUDE.md`)
-   - Return value: text like `"Spawned pane id=N."`. For later pane operations, refer to it as `name="dispatcher"`
-   - Errors are returned as text in `[<code>] <msg>` format (for example `[split_refused]` / `[pane_not_found]` / `[cwd_invalid]`). For the code list and handling, see `.claude/skills/org-delegate/references/renga-error-codes.md`
-2. On first Claude Code startup, the confirmation prompt `Load development channel? (Y/n)` appears. Approve it by sending Enter with `mcp__renga-peers__send_keys`:
-   ```
-   mcp__renga-peers__send_keys(target="dispatcher", enter=true)
-   ```
-   - Enter is written to the PTY as CR (`0x0D`)
-   - Without approval, the `server:renga-peers` channel is not enabled, `send_message` channel push does not arrive, and the `list_peers` wait in Step 3 times out
-3. Wait for the new peer to appear in `mcp__renga-peers__list_peers`
-4. Send the following to the Dispatcher with `mcp__renga-peers__send_message`:
-   "You are the Dispatcher. Receive DELEGATE messages from the Lead, then handle Worker pane startup, instruction delivery, and state recording. If you receive a CLOSE_PANE message, close the pane."
-5. **Record the Dispatcher identity through the DB** (via `StateWriter.transaction()`; direct markdown edits are forbidden. The post-commit hook regenerates it):
-   ```bash
-   python -c "
-   from pathlib import Path
-   from tools.state_db import connect
-   from tools.state_db.writer import StateWriter
-   conn = connect('.state/state.db')
-   with StateWriter(conn, claude_org_root=Path('.')).transaction() as w:
-       w.update_session(dispatcher_pane_id='<pane_id>', dispatcher_peer_id='<peer_id>')
-   "
-   ```
-6. Regenerate the JSON snapshot (for the dashboard; separate path from the state-db cutover):
-   `py -3 dashboard/org_state_converter.py`
-
-## Step 3: Start the Curator Pane
-
-1. Use `mcp__renga-peers__spawn_claude_pane` to start the Curator in the right half of the Dispatcher pane:
+   Capture the dispatcher's `pane_id` from the returned `"Spawned pane id=N."`. For the meaning of arguments and pitfalls, see "### Appendix: details of spawn_claude_pane arguments" at the end of this file.
+2. Immediately after that returns, `spawn_claude_pane` for curator:
    ```
    mcp__renga-peers__spawn_claude_pane(
      target="dispatcher",
@@ -191,20 +95,88 @@ Follow the pane layout in `org-delegate/references/pane-layout.md` (renga versio
      model="opus"
    )
    ```
-   - `target="dispatcher"`: use the Dispatcher pane named in Step 2 as the split target
-   - `direction="vertical"` = left/right split (Dispatcher=left / Curator=right)
-   - `name="curator"`: stable name (must contain letters; all-digit names are forbidden)
-   - `cwd=".curator"`: resolves to `.curator/` relative to the caller pane (= Lead)
-   - `.curator/CLAUDE.md` contains Curator role instructions
-   - Errors use the same `[<code>] <msg>` format as Step 2
-2. As in Step 2, approve the `Load development channel?` prompt by sending Enter:
+   target="dispatcher" resolves the stable name established in (1). Capture the curator's `pane_id` too.
+3. **Block here only on the spawn result** (do not wait for Claude's boot to complete). If both spawns failed with `[<code>] <msg>`, jump to "### Failure modes" at the end of this file. If both spawns succeeded (pane_id obtained), proceed in parallel with Blocks B / C.
+
+### Block B: check previous state
+
+The read path is **DB only** (Issue #267 / M4). Run in parallel with Block A's spawn firing (Block A only asks for pane creation via MCP, and Claude's boot is a separate process, so there is no CPU / I/O contention).
+
+1. Check whether `.state/state.db` exists.
+   - Exists -> query the DB:
+     ```bash
+     python -c "from tools.state_db import connect; from tools.state_db.queries import get_org_state_summary; import json; \
+       conn = connect('.state/state.db'); \
+       print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))"
+     ```
+     Use `active_runs` / `recent_events` / `run_status_counts` / `session.status` / `session.objective` to understand the previous state.
+   - Does not exist -> treat as first launch. Prompt the Secretary to run the importer:
+     `python -m tools.state_db.importer --db .state/state.db --root . --rebuild --no-strict`.
+2. Check session.status:
+   - If `SUSPENDED`, run /org-resume Phases 1-3 (briefing / reconciliation / resume plan).
+     Block A's spawn has already been fired, so Claude boots in the background while you brief.
+     After briefing finishes, wait at Block D's join for dispatcher / curator to be ready, then run org-resume Phase 4 (worker re-dispatch) based on human approval.
+   - If `ACTIVE`, the previous session may have terminated abruptly.
+     Check the git state of each worker directory and report the current situation.
+
+### Block C: start the dashboard server
+
+In parallel with Block A's spawn firing. The dashboard server is a separate process (Python HTTP server) and is independent of Claude panes.
+
+1. Check whether the dashboard server is running:
+   ```bash
+   cat .state/dashboard.pid 2>/dev/null && kill -0 $(cat .state/dashboard.pid) 2>/dev/null && echo "running" || echo "stopped"
    ```
+2. If stopped, start it:
+   ```bash
+   python3 dashboard/server.py &   # Mac/Linux
+   py -3 dashboard/server.py &     # Windows
+   ```
+3. Inform the user:
+   "Dashboard started -> http://localhost:8099".
+
+> **Sidebar: attention watcher startup guidance (optional, explicit start recommended)**
+>
+> You can run a separate resident watcher that actively notifies via OS notifications + sound + terminal bell for things like awaiting approval / awaiting decision / CI failure / silent stop / PR merged. **`/org-start` does not start it automatically** (OS notification backends are highly environment-dependent, and unsolicited sound is easily annoying. Design [`docs/design/attention-notification.md`](../../../docs/design/attention-notification.md) §11 Q1).
+>
+> For users who want to enable it, present the following alongside the Step 4 startup-complete report:
+>
+> ```bash
+> # First time only: copy the ja default template into .state/ (.state/ is gitignored and absent on fresh clones)
+> mkdir -p .state
+> cp tools/templates/attention.example.json .state/attention.json
+>
+> # Run resident in a separate terminal or in the background
+> claude-org-runtime attention watch --state-dir .state --config .state/attention.json
+> ```
+>
+> For a one-shot smoke test, use `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json` (omit `--config` and you get the runtime-neutral English default, so always pass it when validating the ja template path). For per-OS backend behavior and troubleshooting, see [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md).
+
+### Block D: join both panes (Enter / list_peers poll / greeting / DB write / snapshot)
+
+After both Block A spawns succeed, Claude is booting in parallel on both panes. **Wait for boot completion just once, then fire Enter / list_peers poll / greeting / DB write together for both panes** to realize the Stage A wall-clock reduction (180s -> 90s).
+
+1. **Send Enter to both panes** — accept the "Load development channel? (Y/n)" prompt on Claude Code's first launch. Issue them in parallel (renga MCP is serial, but with few-hundred-ms responses it feels simultaneous):
+   ```
+   mcp__renga-peers__send_keys(target="dispatcher", enter=true)
    mcp__renga-peers__send_keys(target="curator", enter=true)
    ```
-3. Wait for the new peer to appear in `mcp__renga-peers__list_peers`
-4. Send the following to the Curator with `mcp__renga-peers__send_message`:
-   "You are the Curator. Run /loop 30m /org-curate. Organize findings every 30 minutes."
-5. **Record the Curator identity through the DB** (via `StateWriter.transaction()`; direct edits are forbidden. The post-commit hook regenerates it):
+   - Enter is written to the PTY as CR (0x0D).
+   - Without approval, the `server:renga-peers` channel is not enabled and `send_message` channel pushes do not arrive.
+   - Because Claude boots at slightly different speeds, sending Enter before the prompt is displayed may become a no-op. If the next list_peers poll does not confirm peer registration, resend Enter.
+2. **Poll list_peers and confirm both dispatcher / curator peer registrations in one go** — since both panes boot in parallel, you do not need separate polls per role; a single poll loop can wait for both registrations simultaneously:
+   ```
+   mcp__renga-peers__list_peers
+   # Poll until both name="dispatcher" / "curator" appear in the result
+   ```
+   - If both do not appear, (a) resend Enter to the pane that did not receive it, (b) if it is fatal such as `[pane_not_found]`, jump to the "Failure modes" section.
+3. **Send greeting messages to both in parallel**:
+   - dispatcher:
+     "You are the dispatcher. Receive DELEGATE messages from the Lead, and on its behalf launch worker panes, send instructions, and record state. When you receive a CLOSE_PANE message, close that pane."
+   - curator:
+     "You are the curator. Please run /loop 30m /org-curate. You will perform knowledge curation every 30 minutes."
+4. **Wait for Block B's DB initialization to complete** — the join point for parallel execution. If in Block B-1 `.state/state.db` was absent and `importer --rebuild` ran, `StateWriter.update_session()` will fail until schema construction is complete, so Block B must finish before Block D-5's DB write. If Block B is incomplete (waiting on SUSPENDED briefing), wait for briefing to finish -> confirm DB schema health -> then proceed here.
+5. **Record identities by batching DB transactions into one** (via `StateWriter.transaction()`; do not edit markdown directly. The post-commit hook regenerates `.state/org-state.md`). **If both roles succeeded, write all four**. **If one role failed at D-2 / D-3 (boot impossible, already `close_pane`'d, etc.), write only the successful role; for the failed role, explicitly clear the stale `*_pane_id` / `*_peer_id` carried over from the previous SUSPENDED with `StateWriter.CLEAR`** (`StateWriter.update_session()` is contracted to interpret `None` as "unspecified = preserve", so explicit clear is mandatory):
    ```bash
    python -c "
    from pathlib import Path
@@ -212,27 +184,116 @@ Follow the pane layout in `org-delegate/references/pane-layout.md` (renga versio
    from tools.state_db.writer import StateWriter
    conn = connect('.state/state.db')
    with StateWriter(conn, claude_org_root=Path('.')).transaction() as w:
-       w.update_session(curator_pane_id='<pane_id>', curator_peer_id='<peer_id>')
+       # Example for the both-success case (for a failed role, pass StateWriter.CLEAR instead of a value)
+       w.update_session(
+           dispatcher_pane_id='<d_pane>', dispatcher_peer_id='<d_peer>',
+           curator_pane_id='<c_pane>', curator_peer_id='<c_peer>',
+       )
    "
    ```
-6. Regenerate the JSON snapshot (for the dashboard; separate path from the state-db cutover):
-   `py -3 dashboard/org_state_converter.py`
+6. Regenerate the JSON snapshot just once (for the dashboard; separate path from the state-db cutover. Since both identities can be reflected together, there is no need to call it twice):
+   `py -3 dashboard/org_state_converter.py`.
 
-## Step 4: Report Ready State
+### Appendix: details of spawn_claude_pane arguments
 
-Report concisely to the human:
+Meanings and pitfalls of the arguments shared by both spawns:
 
-**If there is a previous state**:
+- `target`: the pane to split. dispatcher uses `target="focused"` (splits the Lead pane). curator uses `target="dispatcher"` (resolves the stable name established at Block A-1 and takes the right half of the dispatcher pane).
+- `direction`: `"horizontal"` = top/bottom split (existing = top / new = bottom); `"vertical"` = left/right split (existing = left / new = right).
+- `role`: a label that lets `mcp__renga-peers__list_panes` identify the role.
+- `name`: a stable name referenced by later `send_message(to_id="dispatcher", ...)` / `close_pane(target="curator")` etc. **renga-peers interprets all-numeric names as ids, so always include letters in the name**.
+- `cwd`: resolved relative to the caller pane's (= Lead's) cwd. The old approach of embedding `cd X && claude ...` in `command` is forbidden (the auto-upgrade does not fire and channel push is lost — a known pitfall).
+- `permission_mode` / `model`: renga composes and runs `claude --permission-mode {mode} --model {model} --dangerously-load-development-channels server:renga-peers`.
+- Return value: the text `"Spawned pane id=N."`. Errors are in the form `[<code>] <msg>` (e.g., `[split_refused]` / `[pane_not_found]` / `[cwd_invalid]`). For the code list and branches, see `.claude/skills/org-delegate/references/renga-error-codes.md`.
+- `.dispatcher/CLAUDE.md` / `.curator/CLAUDE.md` hold the per-role instructions (separate from Secretary's CLAUDE.md).
+
+### Failure modes
+
+Parallel firing introduces failure patterns that differ from the old serial execution. Classify at Block A's spawn stage:
+
+- **dispatcher spawn failure (`[split_refused]` / `[cwd_invalid]` / other `[<code>]`)** — curator spawn will fail to resolve the name in `target="dispatcher"` and fail in succession with `[pane_not_found]`. **Report both failures to the user; after fixing the cause, re-run /org-start**. The half-done state (curator alone running) cannot occur.
+- **curator spawn failure / dispatcher spawn success** — keep dispatcher and report to the user. The core of org functionality (worker dispatch / state writes) is maintained by dispatcher alone, so **present the user with the options "dispatcher is up; respawn curator, or temporarily continue without curator"**. Drive Blocks B / C / D dispatcher-related steps to completion independent of curator failure. **The DB write should write only the dispatcher portion; explicitly clear the curator portion with `StateWriter.CLEAR`** (if stale `curator_pane_id` / `curator_peer_id` from the previous SUSPENDED remain, the dashboard and balanced-split target selection misjudge based on the premise that a live curator exists. `StateWriter.update_session()` is contracted to interpret `None` as "unspecified = preserve", so explicit clear is mandatory):
+  ```python
+  from tools.state_db.writer import StateWriter
+  ...
+  with StateWriter(conn, claude_org_root=Path('.')).transaction() as w:
+      w.update_session(
+          dispatcher_pane_id='<d_pane>', dispatcher_peer_id='<d_peer>',
+          curator_pane_id=StateWriter.CLEAR, curator_peer_id=StateWriter.CLEAR,
+      )
+  ```
+- **Both spawns succeed, but one fails to register as a peer during boot** — the Block D-2 poll times out on one side. Resend Enter to that pane -> re-poll. After 3 retries, discard the pane with `close_pane` and branch as follows:
+  - **Curator-only peer registration failure**: allow the same temporary continuation as "curator spawn failure / dispatcher spawn success" above (dispatcher alone maintains the core org functionality). Block D-5's DB write writes only dispatcher; curator gets `StateWriter.CLEAR`.
+  - **Dispatcher-only peer registration failure**: temporary continuation not allowed (fatal). Without dispatcher, org-delegate / SECRETARY_RELAY do not function, and keeping curator alone is useless, so also `close_pane` the curator, **clear both identities with `StateWriter.CLEAR`, report to the user**, and prompt for /org-start re-execution.
+  - **Both time out**: `close_pane` both panes, `StateWriter.CLEAR` both identities, report to the user + re-execute.
+- **Enter-timing skew** — if you send Enter before the "Load development channel?" prompt is displayed, it becomes a no-op. Block D-1 sends both in parallel so one side may be too early, but the Block D-2 peer-registration poll is ground truth. If a peer is not registered, return to Block D-1 and resend.
+
+### Wall-clock impact of Stage A / Stage B
+
+| stage | change | wall-clock |
+|---|---|---|
+| before | state restore -> dashboard start -> dispatcher start (spawn+Enter+poll+greet+DB+snapshot) -> curator start (same) in serial | ~180s |
+| after Stage A | dispatcher / curator startup batched into one parallel block; both spawn / Enter / poll / greet / DB write / snapshot bundled together | ~90s |
+| after Stage A+B | on top of the above, fire Block A's spawn right after Step 0 completes, overlapping Claude's boot wait with Block B (state restore) / Block C (dashboard startup) | ~35s |
+
+## Step 4: report ready
+
+Report concisely to the human. Depending on what was written in Block D-5's DB write, accurately enumerate the started roles (so as not to falsely report "curator started" when curator failed):
+
+**With previous state (both roles succeeded)**:
 ```
-組織を起動しました。
-前回の状態: {サマリー}
-ディスパッチャーとキュレーターを起動しました。
-何をしますか？
+Org started.
+Previous state: {summary}
+Dispatcher and curator are running.
+What would you like to do?
 ```
 
-**If this is the first startup**:
+**First launch (both roles succeeded)**:
 ```
-組織を起動しました。
-ディスパッチャーとキュレーターを起動しました。
-プロジェクトはまだ登録されていません。何をしましょうか？
+Org started.
+Dispatcher and curator are running.
+No projects are registered yet. What would you like to do?
 ```
+
+**curator spawn / boot failure, dispatcher only running**:
+```
+Org started (partial).
+Dispatcher is running, but curator startup failed (reason: {[<code>] / peer-registration timeout etc.}).
+Choose between respawning curator to recover, or temporarily continuing without curator.
+(Without curator, worker dispatch / state writes still work, but automatic knowledge curation (/loop 30m /org-curate) is disabled.)
+```
+
+## Appendix: Claude Code startup commands (per role)
+
+Per-role parameters for `spawn_claude_pane` used in Block A / org-delegate Step 3.
+On renga 0.18.0+, `mcp__renga-peers__spawn_claude_pane` accepts per-role structured fields (`cwd` / `permission_mode` / `model` / `args[]`) and auto-appends `--dangerously-load-development-channels server:renga-peers`. The old pattern of piping `cd X && claude ...` into `spawn_pane` is **forbidden** (it reintroduces the pitfall where renga's bare-`claude` auto-upgrade does not fire and channel push is lost).
+
+Common arguments:
+- `permission_mode`: literal `auto` written directly (except for dispatcher). CLAUDE.md has no variable-expansion mechanism, so values from `registry/org-config.md` cannot be substituted at runtime. If you change the value, see the sync-warning section at the top of `registry/org-config.md`.
+- `cwd`: relative path to each role's dedicated directory (resolved relative to the caller pane's cwd).
+
+> **Note**: The Secretary is launched via `renga --layout ops` and runs without `--permission-mode` specified (as the human-judgment Lead). See the "Per-role scope of application" section in `registry/org-config.md`.
+
+### Dispatcher
+
+- `cwd=".dispatcher"`
+- `permission_mode="bypassPermissions"` (fixed; not affected by `default_permission_mode`)
+- `model="sonnet"`
+
+Rationale: when launching workers, the dispatcher issues `mcp__renga-peers__spawn_claude_pane`. The safety classifier of auto mode judges this "child agent launch" as "Create Unsafe Agents" and blocks it, so worker dispatch does not succeed under auto.
+
+### Curator
+
+- `cwd=".curator"`
+- `permission_mode=auto`
+- `model="opus"`
+
+### Worker (used in org-delegate's Step 3)
+
+**`model="opus"` is required (sonnet forbidden).**
+Rationale: the worker's default permission_mode is `auto` (classifier-based). This safety classifier only operates stably on Opus. With sonnet, the classifier misjudges frequently, the approval flow breaks down, and work stalls. Only the dispatcher is fixed at `bypassPermissions` and thus bypasses the classifier, so sonnet operation is fine there (dispatcher is on sonnet for cost optimization; this does not apply to workers).
+
+Typical:
+- `cwd="{workers_dir}/{task_id}"` (absolute path recommended)
+- `permission_mode=auto`
+- `model="opus"`

--- a/.claude/skills/secretary-handover/SKILL.md
+++ b/.claude/skills/secretary-handover/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: secretary-handover
+description: >
+  To avoid continuing a session while the Secretary's context stays bloated,
+  write recent interactions, in-flight work, and org state to a handover file,
+  then prepare to start a fresh Secretary session via /clear → /secretary-resume.
+  Use when the user says "refresh", "I want to hand over the Secretary",
+  or "clean up the context", or when the Secretary itself judges that
+  context has grown long.
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(py -3 tools/journal_append.py:*)
+  - Bash(bash tools/journal_append.sh:*)
+---
+
+# secretary-handover: hand off the Secretary
+
+Without dragging the Secretary session on, produce a handover file that
+carries over org-member awareness and recent interactions to the next session.
+After writing, guide the user through `/clear` → `/secretary-resume`.
+
+> **Key preconditions**:
+> - Keep the Dispatcher / Curator / Worker panes alive. `/clear` only resets
+>   the Secretary Claude's context, so as long as the new session can recover
+>   from state.db and the handover file, the org continues uninterrupted.
+> - The state DB (`.state/state.db`) is the single SoT. Pane identities and
+>   work state can be drawn from there. The handover file is for things that
+>   do not fit into structured data — "the temperature of the conversation",
+>   human-side agreements, in-progress judgments, and so on.
+
+## Step 1: collect what to hand over
+
+Before writing, extract the following from the Secretary's (your) context:
+
+1. **Recent agreements / decisions with the human**
+   - Adopted directions, rejected options, items still under consideration.
+2. **In-flight work**
+   - Workers currently dispatched, their task_id, the latest progress status.
+3. **Pending Decisions (sent to the human, awaiting reply)**
+   - If `.state/pending_decisions.json` exists, read it alongside and note the
+     diff between the register and your context.
+4. **Next action (from the Secretary's POV)**
+   - What you should do next, whose reply you are waiting on.
+5. **Excerpts of recent important exchanges**
+   - About 3–6 items: a decisive line the user said, a proposal you made
+     that was agreed to, etc.
+
+## Step 2: pull structured info from state.db
+
+Embed as reference in the handover. Write the dump to a sandbox-writable
+location under `$TMPDIR` (falling back to `/tmp` if unset):
+
+```bash
+python3 -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json, os
+conn = connect('.state/state.db')
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'secretary-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
+```
+
+Shell redirection `> /tmp/...` would fail in sandbox environments where
+`/tmp` is read-only. Resolving `TMPDIR` on the Python side before
+`open(..., 'w')` is the safe form.
+
+Pull the following out of the result:
+- `session.status` / `session.objective`
+- `session.dispatcher_pane_id` / `session.dispatcher_peer_id`
+- `session.curator_pane_id` / `session.curator_peer_id`
+- `active_runs[]` (in-flight tasks)
+- `active_worker_dirs[]` (worker directories still alive)
+- The top 3–5 entries of `recent_events`
+
+## Step 3: write the handover file
+
+Destination: `.state/secretary-handover.md`.
+
+If a file already exists, back it up to `.state/secretary-handover.prev.md`
+before overwriting:
+
+```bash
+[ -f .state/secretary-handover.md ] && cp .state/secretary-handover.md .state/secretary-handover.prev.md
+```
+
+Format (YAML frontmatter + markdown):
+
+```markdown
+---
+created_at: <UTC ISO8601>
+session_status: <ACTIVE | IDLE | SUSPENDED>
+session_objective: <one-line summary or null>
+dispatcher_pane: <pane_id> / peer=<peer_id>
+curator_pane: <pane_id> / peer=<peer_id>
+---
+
+# Secretary Handover
+
+## Recent agreements / decisions with the human
+- ...
+
+## In-flight work
+- worker-<task_id> (<worker_dir>): <latest state / what it is waiting on>
+- ...
+
+## Pending Decisions (sent to the human, awaiting reply)
+- ...
+(If none, write "none" explicitly. Do not leave empty.)
+
+## Next action (Secretary's POV)
+- ...
+
+## Excerpts of recent important exchanges
+- user: "..."
+- secretary: "..."
+- ...
+
+## Reference: state.db snapshot
+(Briefly transcribe the active_runs / recent_events fetched in Step 2.
+ The full data still lives in `.state/state.db`, so keep this minimal.)
+```
+
+**Writing notes**:
+- Write as a "note to next-you", not a "past log". For example:
+  "user wants to proceed with option B", "waiting on retro-gate ack from the worker".
+- Never write secrets / tokens / passwords.
+- Assume humans will read the file too.
+
+## Step 4: record the event
+
+```bash
+py -3 tools/journal_append.py secretary_handover \
+    --json '{"reason": "context_compaction", "active_workers": [...]}' 2>/dev/null \
+    || echo "(journal_append unavailable; skipping)"
+```
+
+## Step 5: guide the user
+
+Close out with this message:
+
+```
+I've written the Secretary handover to `.state/secretary-handover.md`.
+Please run /clear now to reset the context.
+Once the new Secretary session starts, run /secretary-resume — it will
+load the handover file and resume with current situational awareness.
+
+The Dispatcher / Curator / Worker panes keep running as-is, so the
+organization is not interrupted.
+```
+
+**Things the Secretary must not do**:
+- Do not run `/clear` yourself (it is a Claude Code command typed by the user).
+- Do not send SHUTDOWN to the Dispatcher or Curator (this is not /org-suspend;
+  the panes stay alive).

--- a/.claude/skills/secretary-resume/SKILL.md
+++ b/.claude/skills/secretary-resume/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: secretary-resume
+description: >
+  Load the handover file written by /secretary-handover and resume the
+  Secretary in a fresh session. Use it on the very first turn after /clear.
+  Trigger phrases: "resume the Secretary", "resume", "pick up from the handover".
+  This is not /org-start (Dispatcher / Curator are assumed to still be alive).
+effort: low
+allowed-tools:
+  - Read
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__set_summary
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__set_pane_identity
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__check_messages
+---
+
+# secretary-resume: bring the Secretary back
+
+Load `.state/secretary-handover.md` (written by `/secretary-handover`) and
+restore the minimum Secretary awareness — your stance as an org member,
+recent exchanges with the human, and in-flight work.
+
+> **Preconditions**:
+> - Dispatcher / Curator / Worker panes are still alive from the previous
+>   session. Do not spawn new ones (this is not /org-start).
+> - The state DB (`.state/state.db`) is reused as-is. No need to re-record
+>   pane identities.
+> - If the handover file does not exist or is too stale, guide the user
+>   to use /org-start or /org-resume instead.
+
+## Step 0: confirm your own identity
+
+1. Set the summary to "Secretary: front desk (resumed)" via
+   `mcp__renga-peers__set_summary`.
+2. Check the focused pane's name/role with `mcp__renga-peers__list_panes`:
+   - Expected: `name == "secretary"` and `role == "secretary"`.
+   - On mismatch, fix with
+     `mcp__renga-peers__set_pane_identity(target="focused", name="secretary", role="secretary")`.
+
+## Step 1: load the handover file
+
+1. Check that `.state/secretary-handover.md` exists:
+   ```bash
+   ls -la .state/secretary-handover.md 2>&1
+   ```
+   - Does not exist → guide the user and stop:
+     "No handover file. Please run /org-start to bring the org up, or
+     /org-resume to pick up from a suspended state."
+2. Check freshness via the frontmatter `created_at`:
+   - Within 24 hours → use as-is.
+   - 24 hours to 7 days → warn the user ("the handover is stale, continue?").
+   - More than 7 days → do not adopt; recommend switching to `/org-start`.
+3. Read the file body. **Treat what is written as "fact" for next-session you**
+   (Step 3 will reconcile with state.db).
+
+## Step 2: re-fetch current state from state.db
+
+```bash
+python -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('.state/state.db')
+print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
+"
+```
+
+Verify:
+- `session.status` matches the handover frontmatter.
+- `dispatcher_pane_id` / `curator_pane_id` match what the handover recorded.
+- `active_runs[]` is consistent with the handover's "In-flight work" section.
+
+## Step 3: confirm panes are alive
+
+```
+mcp__renga-peers__list_peers
+```
+
+- Dispatcher / Curator names should be visible.
+- Workers listed in the handover should still exist (see below if missing).
+
+**If anything diverges, report it to the human** (e.g., "the handover says
+worker X is in progress, but the current pane list does not show it"). Do not
+re-spawn on your own.
+
+## Step 4: brief the human
+
+Synthesize the handover and the current state.db view, and report concisely
+in this shape:
+
+```
+The Secretary is resumed.
+
+[Session]
+- Objective: <session.objective>
+- Status: <session.status>
+
+[Panes]
+- dispatcher (pane=N, peer=M)
+- curator (pane=N, peer=M)
+- workers: <task_id list>
+
+[Recent agreements / decisions]
+- ...
+
+[Pending Decisions]
+- ... ("none" if empty)
+
+[Next action]
+- ...
+
+Please advise.
+```
+
+## Step 5: keep the handover file around
+
+- Do not delete it (kept for reference in case of next-time trouble).
+- `.state/secretary-handover.prev.md` is the previous one. Do not remove
+  it even after loading the current one.
+
+## Event record
+
+```bash
+py -3 tools/journal_append.py secretary_resumed \
+    --json '{"handover_age_hours": <number>}' 2>/dev/null \
+    || echo "(journal_append unavailable; skipping)"
+```
+
+## Things not to do
+
+- Do not spawn a new Dispatcher / Curator (they are already alive).
+- Do not send SUSPEND / SHUTDOWN to workers on your own.
+- When the handover content disagrees with state.db, do not silently align
+  one to the other — always report to the human and ask for a judgment.


### PR DESCRIPTION
## Summary

Translate skill files under `.claude/skills/` from Japanese to English to match claude-org-ja main. Includes both updated existing skills and two newly added skills (`secretary-handover`, `secretary-resume`) that were not yet present in this en mirror.

Files (8):
- `.claude/skills/org-delegate/SKILL.md`
- `.claude/skills/org-delegate/references/pane-layout.md`
- `.claude/skills/org-delegate/references/worker-claude-template.md`
- `.claude/skills/org-pull-request/SKILL.md`
- `.claude/skills/org-resume/SKILL.md`
- `.claude/skills/org-start/SKILL.md`
- `.claude/skills/secretary-handover/SKILL.md` (new)
- `.claude/skills/secretary-resume/SKILL.md` (new)

Closes #180.
Closes #187.
Closes #205.
Closes #230.
Closes #232.

## Test plan

- [ ] CI green
- [ ] Spot-check translated prose in 1-2 SKILL.md files; bash command blocks and frontmatter preserved verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)