### PR TITLE
docs: translate ja#466 dispatcher handover/resume protocol

### DIFF
--- a/.claude/skills/dispatcher-handover/SKILL.md
+++ b/.claude/skills/dispatcher-handover/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: dispatcher-handover
+description: >
+  To avoid continuing the Dispatcher session while its context stays bloated,
+  write the monitoring state (active workers / latest polling cursor /
+  pending escalations) to a handover file, then — on the Secretary's
+  instruction — prepare a fresh Dispatcher session via /clear →
+  /dispatcher-resume.
+  Use when a DISPATCHER_HANDOVER peer message arrives from the Secretary,
+  or when the Dispatcher itself judges that context has grown long.
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(py -3 ../tools/journal_append.py:*)
+  - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(python3 -c:*)
+  - Bash(py -3 -c:*)
+  - Bash(ls:*)
+  - Bash(cp:*)
+  - mcp__renga-peers__send_message
+---
+
+# dispatcher-handover: hand off the Dispatcher
+
+Without dragging the Dispatcher session on, produce a handover file that
+carries the current monitoring state and the Dispatcher's standing as an
+org member into the next session. After writing, notify the Secretary
+to "once you ack, send_keys `/clear` → `/dispatcher-resume`".
+
+> **Key preconditions**:
+> - This skill is run by the **Dispatcher itself** (cwd `.dispatcher/`).
+>   It is not invoked directly from the Secretary.
+> - Keep the Worker / Secretary / Curator panes alive. `/clear` only resets
+>   the Dispatcher Claude's context, so as long as state.db and the handover
+>   file allow recovery, monitoring stays uninterrupted.
+> - Keep the Dispatcher pane (name=`dispatcher`) alive too. Closing the pane
+>   itself changes `pane_id` / `peer_id` and forces the `/loop 3m` hook to
+>   be re-registered. The Secretary takes the canonical path of merely
+>   sending `/clear` and `/dispatcher-resume` keystrokes via
+>   `mcp__renga-peers__send_keys(target="dispatcher", ...)` so that the pane
+>   is preserved.
+> - The state DB (`.state/state.db`) is the single SoT. Pane / peer identity
+>   is written into the handover as a reference value, but on resume the
+>   ground truth is the live observation from `list_panes` / `list_peers`.
+> - To avoid creating a gap in the monitoring loop, the following files must
+>   **never be deleted or edited**:
+>   - `.state/dispatcher-event-cursor.txt` (next cycle's `poll_events` cursor)
+>   - `.state/dispatcher/worker-idle-state.json` (idle streak for stall detection)
+>   - `.state/pending_decisions.json` (pending-decisions register)
+>   - `.state/workers/worker-*.md` (per-worker run state)
+>   The handover file is restricted to the **additional** context above
+>   (no human-conversation temperature, but in-flight dispatch context and
+>   recent anomaly observations).
+
+## Step 1: collect what to hand over
+
+Before writing, extract the following from the Dispatcher's (your) context:
+
+1. **Recent dispatch context**
+   - DELEGATE received → spawn success/failure, and task IDs that have moved
+     onto the escalation path
+2. **Workers under monitoring**
+   - Pane names whose `Status` in `.state/workers/worker-*.md` is `active`,
+     plus the latest Progress Log excerpt
+3. **Recent anomaly observations summary**
+   - Out of the past cycle's `journal_append`'d `anomaly_observed` /
+     `notify_sent`, the ones still unresolved
+4. **Undelivered / failed sends**
+   - Things escalated to the Secretary as `[pane_not_found]` /
+     `[split_refused]` etc., or awaiting retry
+5. **Next actions (Dispatcher's view)**
+   - Workers to re-confirm next cycle, judgments waiting to be relayed
+
+## Step 2: pull structured info from state.db
+
+Embed it in the handover as reference. Write to a sandbox-writable
+`$TMPDIR` (falling back to `/tmp` if unset):
+
+```bash
+python3 -c "
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json, os
+conn = connect('.state/state.db')
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'dispatcher-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
+```
+
+From this, extract:
+- `session.dispatcher_pane_id` / `session.dispatcher_peer_id` (current identity)
+- `active_runs[]` (in-flight tasks)
+- `active_worker_dirs[]` (live worker directories)
+- The most recent `recent_events` — top ~5 of `worker_spawned` /
+  `worker_reported` / `worker_escalation`
+
+The Dispatcher's cwd is `.dispatcher/`, so resolve relative paths one
+level up:
+
+```bash
+# When run from .dispatcher/
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('../.state/state.db')
+out_path = os.path.join(os.environ.get('TMPDIR', '/tmp'), 'dispatcher-handover-state.json')
+with open(out_path, 'w') as f:
+    json.dump(get_org_state_summary(conn), f, ensure_ascii=False, indent=2, default=str)
+print(out_path)
+"
+```
+
+## Step 3: write the handover file
+
+Destination: `.state/dispatcher-handover.md` (rooted at the repo root;
+from the Dispatcher cwd `.dispatcher/`, that is
+`../.state/dispatcher-handover.md`).
+
+If a previous file exists, back it up to `.prev.md` before overwriting:
+
+```bash
+[ -f ../.state/dispatcher-handover.md ] && \
+  cp ../.state/dispatcher-handover.md ../.state/dispatcher-handover.prev.md
+```
+
+Format (YAML frontmatter + markdown):
+
+```markdown
+---
+created_at: <UTC ISO8601>
+dispatcher_pane: <pane_id> / peer=<peer_id>
+active_worker_count: <int>
+event_cursor_present: <true | false>
+idle_state_present: <true | false>
+pending_decisions_count: <int>
+---
+
+# Dispatcher Handover
+
+## Workers under monitoring
+- worker-<task_id> (<worker_dir>): Status=<active|...>, one-line Progress Log excerpt
+- ...
+
+## Recent anomaly / notify_sent summary
+- worker-<task_id>: kind=<approval_blocked|stall_suspected|relay_gap_suspected> ...
+(If none, write "none" explicitly.)
+
+## Undelivered / failed sends
+- ...
+(If none, write "none".)
+
+## Next actions (Dispatcher's view)
+- Re-confirm next cycle: worker-<task_id> due to <reason>
+- ...
+
+## Files to bridge the monitoring gap (read-only; this skill must not touch)
+- `.state/dispatcher-event-cursor.txt`: next `poll_events` cursor (use as-is on resume)
+- `.state/dispatcher/worker-idle-state.json`: idle streak for stall detection
+- `.state/pending_decisions.json`: pending-decisions register
+- `.state/workers/worker-*.md`: per-worker run state
+
+## Reference: state.db snapshot
+(Briefly transcribe session / active_runs / recent_events captured in Step 2.)
+```
+
+**Writing notes**:
+- Write as "a memo to your next self", not as "past logs".
+- Never write secrets / tokens / passwords.
+- Assume the Secretary / human may also read this file.
+
+## Step 4: record the event
+
+The Dispatcher cwd is `.dispatcher/`, so call one level up:
+
+```bash
+bash ../tools/journal_append.sh dispatcher_handover \
+    active_workers=<int> pending_decisions=<int> \
+    note=context_compaction
+```
+
+## Step 5: notify the Secretary
+
+Via `mcp__renga-peers__send_message(to_id="secretary", message=...)`,
+convey the following:
+
+```
+DISPATCHER_HANDOVER_READY: written to ../.state/dispatcher-handover.md.
+Once you ack, please use mcp__renga-peers__send_keys(target="dispatcher")
+to issue /clear and then /dispatcher-resume in order.
+Do not close the pane (preserving pane_id keeps the monitoring gap minimal).
+active workers: <count>, pending decisions: <count>.
+```
+
+The Secretary receives this message and — without escalating to the
+human (a routine handover is not a decision request) — uses `send_keys`
+to issue `/clear` and `/dispatcher-resume`. Once the Secretary's ack
+returns, this skill is complete; do nothing further (the assumption is
+that `/clear` will reset your context).
+
+**What the Dispatcher must NOT do**:
+- Issue `/clear` itself (it is the recipient of an external `send_keys`)
+- Send SHUTDOWN to Workers or the Curator (keep panes alive)
+- Edit / delete `.state/dispatcher-event-cursor.txt` /
+  `worker-idle-state.json` / `pending_decisions.json` (resume continuity breaks)
+- Stop `/loop 3m` itself (the design resumes it after resume; the current
+  cycle continues)

--- a/.claude/skills/dispatcher-resume/SKILL.md
+++ b/.claude/skills/dispatcher-resume/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: dispatcher-resume
+description: >
+  Read the handover file written by /dispatcher-handover and bring the
+  Dispatcher back in a fresh session. Use it on the very first turn after
+  /clear. Atomically update `dispatcher_pane_id` / `dispatcher_peer_id` in
+  state.db, and resume the `/loop 3m` worker monitoring loop.
+  Use when the Secretary instructs "resume the Dispatcher" / "resume" /
+  "pick up from the handover". This is not /org-start (the Worker /
+  Secretary / Curator are assumed to still be alive).
+effort: low
+allowed-tools:
+  - Read
+  - Bash(py -3 ../tools/journal_append.py:*)
+  - Bash(bash ../tools/journal_append.sh:*)
+  - Bash(python3 -c:*)
+  - Bash(py -3 -c:*)
+  - Bash(ls:*)
+  - Bash(mv:*)
+  - mcp__renga-peers__set_summary
+  - mcp__renga-peers__list_panes
+  - mcp__renga-peers__set_pane_identity
+  - mcp__renga-peers__list_peers
+  - mcp__renga-peers__check_messages
+  - mcp__renga-peers__send_message
+---
+
+# dispatcher-resume: bring the Dispatcher back
+
+Read `.state/dispatcher-handover.md` written by `/dispatcher-handover` and
+restore the Dispatcher's minimum self-awareness (its standing as an org
+member, in-flight dispatches, workers under monitoring), then resume the
+`/loop 3m` worker monitoring loop.
+
+> **Preconditions**:
+> - The Worker / Secretary / Curator panes are still alive from the previous
+>   session. Do not spawn new ones (this is not `/org-start`).
+> - Your own pane (name=`dispatcher`) is alive too. You are right after the
+>   Secretary issued `/clear` → `/dispatcher-resume` via `send_keys`. The
+>   `pane_id` / `peer_id` should not have changed, but you must observe them
+>   and **atomically update state.db**.
+> - The state DB (`.state/state.db`) is used as-is.
+> - The internal state files that bridge the monitoring gap
+>   (`.state/dispatcher-event-cursor.txt` /
+>   `.state/dispatcher/worker-idle-state.json` /
+>   `.state/pending_decisions.json`) survive from the previous session.
+>   Do not re-create or re-initialize (continue from existing values).
+> - If the handover file does not exist or is too old, point at `/org-start`
+>   and stop.
+
+## Step 0: confirm your identity
+
+1. Use `mcp__renga-peers__set_summary` to set "Dispatcher: monitoring (resumed)".
+2. Use `mcp__renga-peers__list_panes` to check the focused pane's name/role:
+   - Expected: `name == "dispatcher"` and `role == "dispatcher"`
+   - If mismatched, repair with
+     `mcp__renga-peers__set_pane_identity(target="focused", name="dispatcher", role="dispatcher")`
+3. Get your own `pane_id` from `list_panes` (the id where `focused: true`).
+4. Get the `peer_id` for `name == "dispatcher"` from
+   `mcp__renga-peers__list_peers`.
+
+## Step 1: read the handover file
+
+The Dispatcher's cwd is `.dispatcher/`, so resolve repo-root paths one
+level up.
+
+1. Check that `.state/dispatcher-handover.md` exists:
+   ```bash
+   ls -la ../.state/dispatcher-handover.md 2>&1
+   ```
+   - Missing → notify the Secretary and stop:
+     ```
+     DISPATCHER_RESUME_FAILED: handover file not found.
+     Cold-start the Dispatcher with /org-start.
+     ```
+2. Look at frontmatter `created_at` to judge freshness:
+   - Within 24h → adopt as-is
+   - 24h < … ≤ 7d → warn the Secretary ("handover is stale; continuing anyway")
+   - More than 7d → do not adopt; recommend switching to `/org-start` and stop
+3. Read the body via Read. Treat its contents as "fact" for your next-session
+   self (Step 3 reconciles against state.db).
+
+## Step 2: atomically update Dispatcher identity in state.db
+
+Write the `pane_id` / `peer_id` observed in Step 0 through
+`StateWriter.transaction()` **in a single transaction** (the post-commit
+hook will regenerate `.state/org-state.md`). This is the substance of the
+acceptance requirement that "state.db identity is updated atomically".
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from pathlib import Path
+from tools.state_db import connect
+from tools.state_db.writer import StateWriter
+conn = connect('../.state/state.db')
+with StateWriter(conn, claude_org_root=Path('..')).transaction() as w:
+    w.update_session(
+        dispatcher_pane_id='<observed_pane_id>',
+        dispatcher_peer_id='<observed_peer_id>',
+    )
+"
+```
+
+- Write `dispatcher_pane_id` / `dispatcher_peer_id` as **strings** (the
+  schema is TEXT and existing `/org-start` writes strings; keep types aligned)
+- Inside `transaction()`, even if one half fails the DB will not be left in
+  a half-written state
+- If the observed values differ from the handover frontmatter, treat the
+  current observation (`list_panes` / `list_peers`) as ground truth and
+  prefer it. Include the diff in the message you send to the Secretary.
+
+## Step 3: re-fetch the current state from state.db and reconcile with the handover
+
+```bash
+python3 -c "
+import sys, os
+sys.path.insert(0, os.path.abspath('..'))
+from tools.state_db import connect
+from tools.state_db.queries import get_org_state_summary
+import json
+conn = connect('../.state/state.db')
+print(json.dumps(get_org_state_summary(conn), ensure_ascii=False, indent=2, default=str))
+"
+```
+
+Items to check:
+- Whether `active_runs[]` lines up with the handover's "Workers under monitoring" section
+- Whether the worker directories in `active_worker_dirs[]` exist
+
+If a worker is `active` in state.db but not in the handover, or is in the
+handover but missing from state.db / `list_panes`, **report to the
+Secretary** for a decision (do not respawn or change status on your own).
+
+## Step 4: pane liveness check
+
+Call `mcp__renga-peers__list_peers` again and confirm that the worker
+names recorded in the handover still exist. If any are gone, notify the
+Secretary with `WORKER_PANE_EXITED: worker-{task_id} (missing at resume
+time)`. Reconciliation is the Secretary's responsibility.
+
+## Step 5: resume the monitoring loop
+
+If the handover's `active_worker_count > 0`, or the active worker dirs in
+state.db are non-empty, resume worker monitoring with `/loop 3m`:
+
+```
+/loop 3m
+```
+
+- On the first cycle of the monitoring loop, `mcp__renga-peers__poll_events`
+  resumes from the previous cursor (the moment the previous session ended)
+  in `.state/dispatcher-event-cursor.txt`. This preserves the semantics that
+  "any `pane_exited` that arrived while the pane was closed is still
+  guaranteed to be picked up at the next poll" (renga 0.5.7+ cursor spec).
+- On the first cycle, `mcp__renga-peers__check_messages` drains any
+  worker → dispatcher peer messages queued during the previous session.
+- `.state/dispatcher/worker-idle-state.json` retains the previous session's
+  `idle_streak_cycles`, so stall-detection continuity is preserved as well.
+
+If there is nothing to monitor (active worker dirs is 0 and `active_runs`
+is 0), do not start `/loop`; notify the Secretary that you are idle and
+wait:
+
+```
+DISPATCHER_RESUMED_IDLE: resume complete with no monitoring targets. Awaiting DELEGATE.
+```
+
+## Step 6: brief the Secretary
+
+Combine the handover + current state.db and report concisely to the
+Secretary:
+
+```
+DISPATCHER_RESUMED: Dispatcher resume complete.
+- pane=<observed_pane_id> / peer=<observed_peer_id> (state.db updated)
+- workers under monitoring: <task_id list>
+- pending decisions: <count>
+- diff vs. handover: <one line if any, else "none">
+- monitoring loop: /loop 3m resumed (or idle)
+```
+
+## Step 7: switch the handover file to consumed state
+
+Once resume succeeds, **rename** `.state/dispatcher-handover.md` to
+`.state/dispatcher-handover.consumed.md`. This:
+
+- Prevents the auto-branch in `.dispatcher/CLAUDE.md` at startup
+  (resume if a handover file is present within the last 7 days) from
+  mistakenly branching to resume on the next `/org-start` cold-start after
+  the resume has been consumed once
+- Keeps the most recent one for reference in `.consumed.md` form (when the
+  next `/dispatcher-handover` writes a new `.md`, the prior one is rotated
+  to `.prev.md` backup or overwritten)
+
+```bash
+mv ../.state/dispatcher-handover.md ../.state/dispatcher-handover.consumed.md
+```
+
+- If `.consumed.md` already exists, overwrite is fine (keep only the most
+  recent one)
+- `.state/dispatcher-handover.prev.md` is the backup written by the previous
+  `/dispatcher-handover`. Even if it has been read, do not delete it.
+
+## Event recording
+
+The Dispatcher cwd is `.dispatcher/`, so call one level up:
+
+```bash
+bash ../tools/journal_append.sh dispatcher_resumed \
+    pane_id=<observed_pane_id> peer_id=<observed_peer_id> \
+    active_workers=<count> note=resumed_from_handover
+```
+
+## What you must not do
+
+- Spawn a new Dispatcher / Curator (they are already alive)
+- Send SUSPEND / SHUTDOWN to Workers on your own
+- Initialize / delete `.state/dispatcher-event-cursor.txt` /
+  `worker-idle-state.json` / `pending_decisions.json` (monitoring continuity
+  from the previous session breaks)
+- When the handover content disagrees with the current state.db, take it
+  upon yourself to favor one side (always report to the Secretary for a
+  decision)
+- Split the atomic update across multiple writes (it must always complete
+  within a single `StateWriter.transaction()` block)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ You are the Lead for this organization. The only point of contact with humans.
   - [`.claude/skills/org-delegate/SKILL.md`](./.claude/skills/org-delegate/SKILL.md) (`/org-delegate`) — Delegating work (assembling Worker instructions and dispatching them via the Dispatcher)
   - [`.claude/skills/org-escalation/SKILL.md`](./.claude/skills/org-escalation/SKILL.md) (`/org-escalation`) — The canonical flow for escalating Worker decision requests to a human (includes updating the pending-decisions register)
   - [`.claude/skills/org-pull-request/SKILL.md`](./.claude/skills/org-pull-request/SKILL.md) (`/org-pull-request`) — After explicit user approval: `git push` / PR creation / CI monitoring / review feedback loop / close-out after merge
+- The canonical path the Secretary uses to refresh the Dispatcher session when its context grows long (Issue #464):
+  1. Send the kickoff with `mcp__renga-peers__send_message(to_id="dispatcher", message="DISPATCHER_HANDOVER: please refresh context. Run /dispatcher-handover.")`
+  2. Receive the `DISPATCHER_HANDOVER_READY` peer message back from the Dispatcher (by the time this reaches you without loss, the handover file has already been written)
+  3. Issue `mcp__renga-peers__send_keys(target="dispatcher", text="/clear", enter=true)`. **Do not insert a fixed sleep right after; instead poll `mcp__renga-peers__inspect_pane(target="dispatcher", lines=10)` at 1-second intervals until the `/` prompt is empty (welcome screen / empty input), up to 15 seconds.** Advancing to the next keystroke without confirming the prompt becomes a no-op and creates a monitoring gap.
+  4. After the prompt is confirmed, issue `mcp__renga-peers__send_keys(target="dispatcher", text="/dispatcher-resume", enter=true)`. After sending, poll `mcp__renga-peers__check_messages` for up to 30 seconds and wait for `DISPATCHER_RESUMED` or `DISPATCHER_RESUME_FAILED`. On timeout, observe the pane state with `inspect_pane` and resend `/dispatcher-resume` if needed (idempotent: resume Step 7 renames the handover file to `.consumed.md`, so on the second-and-later startup branches a `check_messages` re-drain is enough before falling through to the cold-start side).
+  5. Receipt of `DISPATCHER_RESUMED` from the Dispatcher concludes the handover. The `/loop 3m` monitoring loop has already been resumed inside the resume itself.
+  - Do not close the pane (keeping the same `pane_id` minimizes the monitoring gap). This is not `/org-suspend`; it only resets the Dispatcher Claude's context.
+  - For details, see [`/dispatcher-handover`](./.claude/skills/dispatcher-handover/SKILL.md) and [`/dispatcher-resume`](./.claude/skills/dispatcher-resume/SKILL.md).
 - Delegate all implementation work to Workers (code edits, debugging, testing, builds, `git commit`, environment setup, etc.)
 - If a problem is reported, do not investigate it yourself; hand it to a Worker
 

--- a/docs/journal-events.md
+++ b/docs/journal-events.md
@@ -180,6 +180,8 @@ itself errored — see the fallback rules in `tools/pr_watch.py`);
 | `resume`                       | `restored_workers[]`, `note`            | secretary | secretary  | —            |
 | `task_completed`               | `task`                                  | secretary | secretary  | —            |
 | `secretary_identity_restored`  | `note`                                  | org-start | secretary  | —            |
+| `dispatcher_handover`          | `active_workers`, `pending_decisions`, `note` | dispatcher | dispatcher | —      |
+| `dispatcher_resumed`           | `pane_id`, `peer_id`, `active_workers`, `note` | dispatcher | dispatcher | —     |
 
 ## Adding a new event type
 


### PR DESCRIPTION
## Summary
Translates the ja#466 dispatcher handover/resume protocol introduced in claude-org-ja (merge SHA 1c86bd5) into the en mirror.

Translated files (4):
- .claude/skills/dispatcher-handover/SKILL.md (new)
- .claude/skills/dispatcher-resume/SKILL.md (new)
- CLAUDE.md (dispatcher canonical-path bullet)
- docs/journal-events.md (dispatcher_handover / dispatcher_resumed event rows)

.dispatcher/CLAUDE.md is classified as divergence-allowed and is not touched.

Source ja PR: suisya-systems/claude-org-ja#466

Closes #261.

## Test plan
- [x] ja-en consistency check (sibling translated SKILL.md tone)
- [x] markdown link sanity

🤖 Generated with [Claude Code](https://claude.com/claude-code)