### PR TITLE
docs: translate ja#467 add /org-attention-start and /org-attention-stop skills

### DIFF
--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: org-attention-start
+description: >
+  Start the attention notification watcher (active OS notification + sound for awaiting approval /
+  awaiting decision / CI failures, etc.) resident as a vertical split on the right side of the
+  dispatcher pane. If `.state/attention.json` is not in place yet, the ja default template is
+  auto-copied from `tools/templates/attention.example.json`. After startup, the pane id is recorded
+  in `.state/attention_pane.json` and consumed by `/org-attention-stop`.
+  Triggered by "start attention", "begin notification monitoring", "spin up the watcher", etc.
+  `/org-start` does **not** auto-start it (explicit-start policy).
+effort: low
+allowed-tools:
+  - Read
+  - Write
+  - Bash(mkdir:*)
+  - Bash(cp:*)
+  - Bash(copy:*)
+  - Bash(test:*)
+  - Bash(rm:*)
+  - Bash(del:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__*
+---
+
+# org-attention-start: launch the attention watcher resident
+
+Start `claude-org-runtime attention watch` resident as a vertical split on the right side of the
+dispatcher pane, and record the pane_id as a sidecar in `.state/attention_pane.json`. Use
+[`/org-attention-stop`](../org-attention-stop/SKILL.md) to stop it.
+
+> **Premise**: this skill is invoked from the Secretary's cwd (= the claude-org-ja repo root).
+> The attention watcher itself is a `claude-org-runtime` console_scripts entrypoint, and the
+> relative paths `--state-dir .state` / `--config .state/attention.json` must resolve from the
+> repo root. The dispatcher pane's cwd is `.dispatcher`, so explicitly set `cwd="."` on
+> `spawn_pane` to bind to the Secretary's cwd (= the repo root).
+>
+> **Design choice (sidecar)**: pane_id recording uses a sidecar JSON
+> (`.state/attention_pane.json`) instead of extending the `.state/state.db` schema. This matches
+> the same "auxiliary-process tracking" pattern as `.state/dashboard.pid` /
+> `.state/attention_notified.json`, and avoids ripple effects on
+> importer / writer / snapshotter / converter / drift_check. The attention watcher is an OS
+> subprocess (not a Claude peer), so it has no peer_id, and dashboard surfacing is currently
+> unnecessary (human judgment, 2026-05-17).
+
+## Step 1: double-start check
+
+Detecting a double-start requires looking at **both the sidecar presence and the live pane** (even
+when the sidecar is absent, an orphaned `name="attention"` pane from a past manual spawn / crash
+can still be live, and looking at the sidecar alone causes Step 3's
+`spawn_pane(..., name="attention")` to fail with `[name_in_use]`).
+
+1. Call `mcp__renga-peers__list_panes` and check whether a `name="attention"` / `role="attention"`
+   pane is live.
+2. Check whether `.state/attention_pane.json` exists:
+   ```bash
+   test -f .state/attention_pane.json && echo exists || echo absent
+   ```
+3. Branch:
+   - **live pane present + sidecar present + sidecar pane_id matches the live pane** → already
+     running normally. Report "the attention watcher is already running at pane id={N}. If you
+     want to restart it, run `/org-attention-stop` first" and **abort**.
+   - **live pane present + sidecar absent / pane_id mismatch** → orphaned pane or sidecar drift.
+     Report the situation to the user with "clean up the orphan pane with
+     `/org-attention-stop`, then retry" and **abort** (do not auto-close: the orphan's contents
+     are unknown).
+   - **live pane absent + sidecar present** → stale sidecar. Delete it and proceed to Step 2:
+     ```bash
+     rm .state/attention_pane.json
+     ```
+     Windows native: `del .state\attention_pane.json`.
+   - **live pane absent + sidecar absent** → clean state. Proceed to Step 2.
+
+## Step 2: place the config file (only if missing)
+
+1. Check whether `.state/attention.json` exists:
+   ```bash
+   test -f .state/attention.json && echo exists || echo absent
+   ```
+2. **If missing**: copy the ja default template (`.state/` is gitignored and may not exist on a
+   fresh clone, so run `mkdir` at the same time):
+   ```bash
+   mkdir -p .state
+   cp tools/templates/attention.example.json .state/attention.json
+   ```
+   On Windows native (PowerShell) you can also use `copy`:
+   ```powershell
+   if (!(Test-Path .state)) { mkdir .state }
+   copy tools\templates\attention.example.json .state\attention.json
+   ```
+3. **If already in place**: do not overwrite (respect the user's tuning). Proceed to Step 3.
+
+## Step 3: split the dispatcher and start the watcher
+
+Create a pane for the attention watcher on the right half (vertical split) of the dispatcher pane:
+
+```
+mcp__renga-peers__spawn_pane(
+  target="dispatcher",
+  direction="vertical",
+  role="attention",
+  name="attention",
+  cwd=".",
+  command="claude-org-runtime attention watch --state-dir .state --config .state/attention.json"
+)
+```
+
+- `target="dispatcher"`: resolved via the stable name established at org-start Block A-1.
+- `direction="vertical"`: dispatcher pane = left, attention pane = right.
+- `cwd="."`: relative resolution is anchored at the Secretary's cwd (= the repo root) so `.state/`
+  paths resolve correctly. Omitting it inherits the dispatcher's cwd (`.dispatcher`), making
+  `.state` resolve to `.dispatcher/.state` and the watcher ends up looking at empty state.
+- `name="attention"`: referenced by the later `/org-attention-stop` via
+  `close_pane(target="attention")` or the recorded pane_id.
+- Return value: text `"Spawned pane id=N."`. N is the attention watcher's pane_id.
+
+**Failure branches**:
+- `[split_refused]`: the dispatcher pane is below the split lower bound (MIN_PANE_WIDTH=20).
+  Report "the dispatcher pane is too small to split. Shrink the secretary side or widen the
+  terminal and retry" to the user and abort.
+- `[pane_not_found]`: the dispatcher pane does not exist (org-start was not run, or dispatcher
+  crashed). Report "dispatcher pane not found. Run `/org-start` first" to the user and abort.
+- `[name_in_use]`: a live pane that Step 1's double-start check missed (a race where it
+  re-appeared just before this call). Report "an attention pane came up in parallel just before
+  this. Clean it up with `/org-attention-stop`" to the user and abort.
+- Other `[<code>]`: see [`renga-error-codes.md`](../org-delegate/references/renga-error-codes.md).
+
+## Step 4: startup health check (negative-signal detection for immediate crashes only)
+
+`spawn_pane` success only guarantees up to "the shell came up and fired the command." If
+`claude-org-runtime` is not installed / config is invalid / there's an import error and the
+watcher process exits immediately, a stale pane_id ends up recorded in the sidecar and breaks all
+downstream checks. On the other hand, **what the watcher prints on a healthy startup** is not
+fixed by `claude-org-runtime`'s contract (an implementation that quietly enters the polling loop
+and waits is also valid). Treating "wait for the startup banner" / "no output = fail" as the
+criterion creates a path that **wrongly kills a healthy quiet start**. So this skill **only flags
+explicit failure signals as failures**; anything else (empty output / unknown output) is treated
+as "successful startup":
+
+```
+mcp__renga-peers__inspect_pane(target="attention", format="text", lines=60)
+```
+
+The inspect round trip itself (a few hundred ms) is enough for cases where the shell terminated
+immediately to leave a prompt or error captured in the pty buffer. **Treat the startup as a
+failure only if one of the following holds**:
+
+- The output ends with an exposed shell prompt (`PS C:\...> ` / `$ ` / `% ` / `> ` at the tail)
+  → the command exited immediately and returned to the shell.
+- The output contains one of:
+  - `command not found` / `is not recognized` / `not recognized as an internal or external command`
+  - `ModuleNotFoundError` / `ImportError` / `Traceback (most recent call last)`
+  - `[error]` / `[ERROR]` / `FATAL` / `fatal:`
+
+**If none of the above is detected** (empty output / startup banner / polling wait / unknown lines
+only, etc.) → **treat as successful startup** and proceed to Step 5. Do not introduce a fixed
+sleep + re-inspect path (so as not to create a path that wrongly kills a healthy quiet start).
+
+**On startup failure**:
+1. `mcp__renga-peers__close_pane(target="<pane_id returned from spawn>")` to clean up the dead pane.
+2. **Do not** write the sidecar.
+3. Record `attention_watch_start_failed` in the journal:
+   ```bash
+   bash tools/journal_append.sh attention_watch_start_failed pane_id=<N> reason=immediate_exit
+   ```
+4. Report to the user: "the watcher exited immediately after startup (output excerpt: <inspect
+   excerpt>). Verify the install with `claude-org-runtime --version`, and also check the syntax of
+   `.state/attention.json` with
+   `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json`."
+   Then abort.
+
+## Step 5: record the pane_id in the sidecar
+
+Write the parsed pane_id from the return value to `.state/attention_pane.json`:
+
+```json
+{
+  "pane_id": "<N>",
+  "name": "attention",
+  "started_at": "<ISO8601 UTC>",
+  "config_path": ".state/attention.json"
+}
+```
+
+Save with the `Write` tool, overwriting (any pre-existing file was deleted in Step 1).
+
+Append a single journal event line:
+
+```bash
+bash tools/journal_append.sh attention_watch_started pane_id=<N> config=.state/attention.json
+```
+
+On Windows native: `py -3 tools/journal_append.py attention_watch_started pane_id=<N> config=.state/attention.json`.
+
+## Step 6: report
+
+```
+Started the attention watcher (pane id={N}, on the right side of the dispatcher).
+Config: .state/attention.json
+Run /org-attention-stop to stop it.
+```
+
+For the Windows notification center integration (`wsl-notify-send.exe`), per-OS backend behavior,
+and troubleshooting, see [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md).

--- a/.claude/skills/org-attention-start/SKILL.md
+++ b/.claude/skills/org-attention-start/SKILL.md
@@ -29,7 +29,7 @@ Start `claude-org-runtime attention watch` resident as a vertical split on the r
 dispatcher pane, and record the pane_id as a sidecar in `.state/attention_pane.json`. Use
 [`/org-attention-stop`](../org-attention-stop/SKILL.md) to stop it.
 
-> **Premise**: this skill is invoked from the Secretary's cwd (= the claude-org-ja repo root).
+> **Premise**: this skill is invoked from the Secretary's cwd (= the repo root).
 > The attention watcher itself is a `claude-org-runtime` console_scripts entrypoint, and the
 > relative paths `--state-dir .state` / `--config .state/attention.json` must resolve from the
 > repo root. The dispatcher pane's cwd is `.dispatcher`, so explicitly set `cwd="."` on

--- a/.claude/skills/org-attention-stop/SKILL.md
+++ b/.claude/skills/org-attention-stop/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: org-attention-stop
+description: >
+  Stop the attention watcher pane started by `/org-attention-start`. It reads the pane_id recorded
+  in `.state/attention_pane.json`, closes the pane via `mcp__renga-peers__close_pane`, and deletes
+  the sidecar.
+  Triggered by "stop attention", "halt notification monitoring", "shut down the watcher", etc.
+effort: low
+allowed-tools:
+  - Read
+  - Bash(rm:*)
+  - Bash(del:*)
+  - Bash(bash tools/journal_append.sh:*)
+  - Bash(py -3 tools/journal_append.py:*)
+  - mcp__renga-peers__*
+---
+
+# org-attention-stop: stop the attention watcher
+
+Close the watcher pane started by [`/org-attention-start`](../org-attention-start/SKILL.md) and
+clear the sidecar (`.state/attention_pane.json`).
+
+## Step 1: check sidecar and live-pane state
+
+1. Call `mcp__renga-peers__list_panes`. If a live pane with `name="attention"` or
+   `role="attention"` exists, record its pane_id (**check both name and role**: an orphaned pane
+   from a manual start may have only the role without a name).
+2. If `.state/attention_pane.json` can be opened with `Read`, read `pane_id` from it. If it does
+   not exist, skip.
+3. Branch:
+   - **sidecar present** → go to 2-a.
+   - **sidecar absent + orphan pane detected** → go to 2-b.
+   - **sidecar absent + no orphan pane** → report "the attention watcher is already stopped" and
+     exit.
+
+## Step 2: close the pane
+
+### 2-a: close using the recorded pane_id
+
+```
+mcp__renga-peers__close_pane(target="<sidecar pane_id>")
+```
+
+- On success: text `"Closed pane id=N."` returns.
+- `[pane_not_found]` / `[pane_vanished]`: already closed. The sidecar is stale. Proceed to Step 3.
+- `[last_pane]`: the attention pane was the tab's only remaining pane (does not normally happen —
+  dispatcher / secretary should still be alive). Report the situation to the user and abort
+  (defer to manual handling).
+
+If the "attention pane visible in list_panes" obtained in Step 1 does not match the sidecar's
+pane_id, **close using the sidecar's id first**, then re-fetch `list_panes`. If something
+remains, proceed to 2-b (extra cleanup for drift / orphans).
+
+### 2-b: cleaning up an orphan pane (no sidecar / drift)
+
+Close using the **pane_id (the numeric id, not the name)** obtained from `list_panes` in Step 1:
+
+```
+mcp__renga-peers__close_pane(target="<numeric pane_id from list_panes>")
+```
+
+Do not use a name target like `target="attention"`: it would not hit an orphan pane that has only
+the role and no name. Treat `[pane_not_found]` / `[pane_vanished]` as skip.
+
+## Step 3: delete the sidecar
+
+```bash
+rm -f .state/attention_pane.json
+```
+
+Windows native: `del .state\attention_pane.json` (already-deleted is harmless — suppress with
+`2>nul` etc.).
+
+Append a single journal event line:
+
+```bash
+bash tools/journal_append.sh attention_watch_stopped pane_id=<N>
+```
+
+On Windows native: `py -3 tools/journal_append.py attention_watch_stopped pane_id=<N>`.
+
+## Step 4: report
+
+```
+Stopped the attention watcher (pane id={N}).
+Run /org-attention-start to start it again.
+```
+
+If there was no sidecar and no orphan pane:
+
+```
+The attention watcher is already stopped.
+```

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -139,7 +139,7 @@ In parallel with Block A's spawn firing. The dashboard server is a separate proc
 >
 > You can run a separate resident watcher that actively notifies via OS notifications + sound + terminal bell for things like awaiting approval / awaiting decision / CI failure / silent stop / PR merged. **`/org-start` does not start it automatically** (OS notification backends are highly environment-dependent, and unsolicited sound is easily annoying. Design [`docs/design/attention-notification.md`](../../../docs/design/attention-notification.md) §11 Q1).
 >
-> For users who want to enable it, alongside the Step 4 startup-complete report, present them with running [`/org-attention-start`](../org-attention-start/SKILL.md). The skill handles the following in one shot:
+> For users who want to enable it, alongside the Step 4 startup-complete report, suggest running [`/org-attention-start`](../org-attention-start/SKILL.md). The skill handles the following in one shot:
 >
 > - If `.state/attention.json` is not in place, auto-copy it from `tools/templates/attention.example.json`.
 > - Vertical-split the right side of the dispatcher pane and start `claude-org-runtime attention watch ...` resident.

--- a/.claude/skills/org-start/SKILL.md
+++ b/.claude/skills/org-start/SKILL.md
@@ -139,18 +139,13 @@ In parallel with Block A's spawn firing. The dashboard server is a separate proc
 >
 > You can run a separate resident watcher that actively notifies via OS notifications + sound + terminal bell for things like awaiting approval / awaiting decision / CI failure / silent stop / PR merged. **`/org-start` does not start it automatically** (OS notification backends are highly environment-dependent, and unsolicited sound is easily annoying. Design [`docs/design/attention-notification.md`](../../../docs/design/attention-notification.md) §11 Q1).
 >
-> For users who want to enable it, present the following alongside the Step 4 startup-complete report:
+> For users who want to enable it, alongside the Step 4 startup-complete report, present them with running [`/org-attention-start`](../org-attention-start/SKILL.md). The skill handles the following in one shot:
 >
-> ```bash
-> # First time only: copy the ja default template into .state/ (.state/ is gitignored and absent on fresh clones)
-> mkdir -p .state
-> cp tools/templates/attention.example.json .state/attention.json
+> - If `.state/attention.json` is not in place, auto-copy it from `tools/templates/attention.example.json`.
+> - Vertical-split the right side of the dispatcher pane and start `claude-org-runtime attention watch ...` resident.
+> - Record the pane_id in the `.state/attention_pane.json` sidecar (referenced from [`/org-attention-stop`](../org-attention-stop/SKILL.md) for stopping).
 >
-> # Run resident in a separate terminal or in the background
-> claude-org-runtime attention watch --state-dir .state --config .state/attention.json
-> ```
->
-> For a one-shot smoke test, use `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json` (omit `--config` and you get the runtime-neutral English default, so always pass it when validating the ja template path). For per-OS backend behavior and troubleshooting, see [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md).
+> For a one-shot smoke test, use `claude-org-runtime attention scan --state-dir .state --config .state/attention.json --dry-run --json` (omit `--config` and you get the runtime-neutral English default, so always pass it when validating the ja template path). For per-OS backend behavior, troubleshooting, and bare-CLI startup from a separate terminal, see [`docs/operations/attention-watch.md`](../../../docs/operations/attention-watch.md).
 
 ### Block D: join both panes (Enter / list_peers poll / greeting / DB write / snapshot)
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -17,9 +17,22 @@
 
 ## 2. Enable / disable
 
-### 2.1 Placing the config file
+### 2.1 Recommended: start / stop via skills
 
-`tools/templates/attention.example.json` is a tracked example containing the ja default template set. In real use, copy it to `.state/attention.json` (since `.state/` is gitignored, it does not exist in a fresh clone or before `/org-start`):
+From inside the renga tab (the Secretary session), the recommended path is the **two skills** that handle config auto-placement, splitting the dispatcher pane, and pane_id recording in one shot:
+
+| Operation | Skill | Side effects |
+|---|---|---|
+| Start | [`/org-attention-start`](../../.claude/skills/org-attention-start/SKILL.md) | If `.state/attention.json` is missing, auto-copy from `tools/templates/attention.example.json` → vertical-split the right side of the dispatcher pane → start `claude-org-runtime attention watch ...` resident → record the pane_id in the `.state/attention_pane.json` sidecar |
+| Stop | [`/org-attention-stop`](../../.claude/skills/org-attention-stop/SKILL.md) | Read the sidecar, discard the pane via `mcp__renga-peers__close_pane` → delete the sidecar |
+
+It does not auto-start from `/org-start` (OS notification backends are strongly environment-dependent, and unsolicited sound is easily annoying. Design [`docs/design/attention-notification.md`](../design/attention-notification.md) §11 Q1). After `/org-start` completes, either fire `/org-attention-start` explicitly, or place it manually only when needed (§2.2).
+
+The sidecar (`.state/attention_pane.json`) follows the same "auxiliary-process tracking" pattern as `.state/dashboard.pid` / `.state/attention_notified.json`, and `.state/state.db` schema is not extended (to avoid ripple effects on importer / writer / snapshotter / converter / drift_check). Since `.state/` is gitignored, the sidecar is not committed either.
+
+### 2.2 Manual placement (outside renga / starting from a separate terminal)
+
+`tools/templates/attention.example.json` is a tracked example containing the ja default template set. If you want to run it resident from a separate terminal without using the renga tab, or to hand-edit the template before placement, do the following:
 
 ```bash
 mkdir -p .state
@@ -28,7 +41,7 @@ cp tools/templates/attention.example.json .state/attention.json
 
 To change OS-notification or sound behavior, edit `.state/attention.json` (override template strings, switch `sound`, adjust `cooldown_sec`, etc.). The template placeholder allowlist is the 6 placeholders `{task_id}` / `{worker}` / `{kind}` / `{status}` / `{pr}` / `{summary}`; unknown placeholders are either left as literals or filled by the runtime's fallback template (see design §6).
 
-### 2.2 One-shot verification (`scan`)
+### 2.3 One-shot verification (`scan`)
 
 Before keeping `watch` resident, confirm that attention events are extracted from the current `.state/` as expected:
 
@@ -38,17 +51,19 @@ claude-org-runtime attention scan --state-dir .state --config .state/attention.j
 
 Always pass `--config .state/attention.json` (without it, the runtime-neutral English defaults appear in title/body, and you cannot tell whether the ja templates are actually taking effect). `--dry-run` does not invoke OS-notification subprocesses, so it is safe in CI environments or during quiet hours. The output is in the form `{ "events": [{ "key": ..., "kind": ..., "severity": ..., "title": ..., "body": ...}, ...] }` (for details, see [the attention scan verification block in `docs/verification.md`](../verification.md)).
 
-### 2.3 Resident mode (`watch`)
+### 2.4 Resident mode (`watch`) — manual start
+
+For the raw CLI when you want to start the watcher directly from outside the renga tab (separate terminal / background):
 
 ```bash
 claude-org-runtime attention watch --state-dir .state --config .state/attention.json
 ```
 
-Start it in another terminal or in the background. It does not auto-start from `/org-start` (since it is strongly environment-dependent, explicit start is recommended; see design §11 Q1 / §7 "org-start guidance"). Stopping is the usual Ctrl-C (the dedup state is written via atomic replace, so even a forced kill can be recovered on next startup — see §5).
+In normal operation, use `/org-attention-start` from §2.1 (the skill handles pane_id recording / sidecar management / double-start checks). Stopping is Ctrl-C (the dedup state is written via atomic replace, so even a forced kill can be recovered on next startup — see §5).
 
-### 2.4 Disabling
+### 2.5 Disabling
 
-To stop it permanently, just terminate the `watch` process. There is no need to delete the config file (`.state/attention.json`). To temporarily suppress notifications, set `"desktop": false` / `"sound": "off"` in `.state/attention.json`, or demote individual-kind severities from `"urgent"` to `"normal"` (the value of `notify.<kind>` only accepts `"urgent"` / `"normal"`; there is no per-kind `off`. To stop completely, use the global `desktop: false`).
+When started from inside the renga tab, use [`/org-attention-stop`](../../.claude/skills/org-attention-stop/SKILL.md) to clean up the sidecar and the pane in one shot. A manually started watcher can just be terminated with Ctrl-C. There is no need to delete the config file (`.state/attention.json`). To temporarily suppress notifications, set `"desktop": false` / `"sound": "off"` in `.state/attention.json`, or demote individual-kind severities from `"urgent"` to `"normal"` (the value of `notify.<kind>` only accepts `"urgent"` / `"normal"`; there is no per-kind `off`. To stop completely, use the global `desktop: false`).
 
 ## 3. OS-specific notification backend behavior
 

--- a/docs/operations/attention-watch.md
+++ b/docs/operations/attention-watch.md
@@ -59,7 +59,7 @@ For the raw CLI when you want to start the watcher directly from outside the ren
 claude-org-runtime attention watch --state-dir .state --config .state/attention.json
 ```
 
-In normal operation, use `/org-attention-start` from §2.1 (the skill handles pane_id recording / sidecar management / double-start checks). Stopping is Ctrl-C (the dedup state is written via atomic replace, so even a forced kill can be recovered on next startup — see §5).
+In normal operation, use `/org-attention-start` from §2.1 (the skill handles pane_id recording / sidecar management / double-start checks). For this manual-start path, stop with Ctrl-C (the dedup state is written via atomic replace, so even a forced kill can be recovered on next startup — see §5). To stop a skill-started watcher, use `/org-attention-stop` instead (§2.5) so the sidecar is also cleaned up.
 
 ### 2.5 Disabling
 


### PR DESCRIPTION
Translates the ja#467 attention watcher skill split introduced in claude-org-ja (merge SHA `e9b08f9`) into the en mirror.

## Summary

- New `.claude/skills/org-attention-start/SKILL.md` (198-line ja file, full translation)
- New `.claude/skills/org-attention-stop/SKILL.md` (89-line ja file, full translation)
- `.claude/skills/org-start/SKILL.md` Sidebar: selective merge of the ja#467 hunk (Block C attention watcher guidance now points to `/org-attention-start` with side-effect bullets). en-side prior text outside the ja#467 hunk is preserved.
- `docs/operations/attention-watch.md` §2: renumbering (§2.1 = recommended skill path with side-effect table, §2.2 = manual placement, §2.3 = scan, §2.4 = manual resident watch, §2.5 = disabling)

## Known limitations (ja SoT-side bugs, filed as follow-ups)

Codex round 2 self-review during this translation found 2 design issues in the ja-canonical SKILLs. Because they originate in ja (the SoT), they are not fixed in this translation-class mirror PR; fixes land via the next ja PR + auto-mirror cycle:

- `/org-attention-stop`: sidecar→close_pane sequence may close an unrelated pane if pane_id was recycled by renga after the watcher crashed. Tracking: suisya-systems/claude-org-ja#468
- `/org-attention-start`: the Step 4 single inspect_pane health check misses watcher crashes that happen after the snapshot but before sidecar write. Tracking: suisya-systems/claude-org-ja#469

## Test plan

- [x] ja-en consistency check (sibling translated SKILL.md tone)
- [x] markdown link sanity
- [x] selective merge boundaries on org-start/SKILL.md and attention-watch.md verified against the ja#467 diff

Closes #264
Source ja PR: suisya-systems/claude-org-ja#467
Merge SHA: `e9b08f9`