### PR TITLE
auto-mirror: ja#473 feat(org-start): detect claude-org-runtime version drift at startup

### DIFF
--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Runtime version drift check for /org-start (Issue #472).
+
+Compares the installed ``claude-org-runtime`` version against the
+latest release on PyPI that still satisfies ja's pin window
+(declared in ``pyproject.toml`` dependencies). If they differ,
+prints a single warning line to stdout so /org-start can splice it
+into its Step 4 readiness report. In all other cases — versions
+match, package not installed, PyPI unreachable, parse failure, no
+pin-compatible release found, ``packaging`` import failure — the
+script stays silent.
+
+The pin window matters because /org-start's warning must not steer
+users into an upgrade that breaks ja's compatibility contract: when
+ja's upper bound is exclusive and PyPI ships a release past it, we
+still want to bring users up to the latest in-window release but
+never recommend the out-of-window one. No specific version is
+hard-coded anywhere — installed comes from ``importlib.metadata``,
+latest from the PyPI JSON API, and the pin spec from a regex over
+``pyproject.toml`` at read time.
+
+The script never auto-upgrades and never exits non-zero — drift is
+informational, and skipping silently is the correct behavior when the
+machine is offline or in a sandboxed CI lane.
+
+Used by ``.claude/skills/org-start/SKILL.md`` Block C2.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except (AttributeError, OSError):
+    pass
+
+PACKAGE = "claude-org-runtime"
+PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE}/json"
+TIMEOUT_SEC = 3.0
+PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Sentinel so callers can pass ``pin=None`` to *opt out* of the pin
+# window, while leaving the default unspecified branch free to
+# auto-discover the pin from pyproject.toml.
+_AUTO_PIN = object()
+
+
+def _installed_version() -> str | None:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return None
+    try:
+        return version(PACKAGE)
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _read_pin_spec() -> str | None:
+    """Return the version specifier string for PACKAGE from
+    pyproject.toml, or None when it can't be located. We grep with a
+    regex rather than parse TOML so the script keeps its
+    zero-runtime-dependency contract (Python 3.10 has no stdlib
+    tomllib)."""
+    try:
+        text = PYPROJECT_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(
+        rf'["\']{re.escape(PACKAGE)}\s*([^"\']*?)["\']',
+        text,
+    )
+    if not m:
+        return None
+    spec = m.group(1).strip()
+    return spec or None
+
+
+def _fetch_pypi_payload() -> dict | None:
+    try:
+        req = urllib.request.Request(
+            PYPI_JSON_URL,
+            headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            payload = json.load(resp)
+    except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
+        return None
+    except (json.JSONDecodeError, ValueError):
+        return None
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _latest_version(pin=_AUTO_PIN) -> str | None:
+    """Return the newest stable release of PACKAGE on PyPI that
+    satisfies ``pin``. Pass ``pin=None`` to disable the pin window;
+    omit the argument to auto-discover the pin from pyproject.toml.
+    Returns None on any failure path so the caller stays silent."""
+    payload = _fetch_pypi_payload()
+    if payload is None:
+        return None
+
+    if pin is _AUTO_PIN:
+        pin = _read_pin_spec()
+
+    releases = payload.get("releases")
+    if isinstance(releases, dict) and releases:
+        try:
+            from packaging.specifiers import InvalidSpecifier, SpecifierSet
+            from packaging.version import InvalidVersion, Version
+        except ImportError:
+            return _fallback_info_version(payload, pin)
+        if pin:
+            try:
+                spec: SpecifierSet | None = SpecifierSet(pin)
+            except InvalidSpecifier:
+                # Pin parse failure: prefer silence over recommending an
+                # out-of-window upgrade (the docstring guarantees silent
+                # skip on parse failure).
+                return None
+        else:
+            spec = None
+        candidates: list[Version] = []
+        for raw, files in releases.items():
+            if _release_is_yanked(files):
+                continue
+            try:
+                ver = Version(raw)
+            except InvalidVersion:
+                continue
+            if ver.is_prerelease or ver.is_devrelease:
+                continue
+            if spec is not None and ver not in spec:
+                continue
+            candidates.append(ver)
+        if candidates:
+            return str(max(candidates))
+        return None
+
+    return _fallback_info_version(payload, pin)
+
+
+def _release_is_yanked(files) -> bool:
+    """A PyPI release version is considered yanked when every uploaded
+    file under it is marked yanked. Conservatively treat an empty file
+    list as "not yanked" so we don't drop legitimate releases that
+    simply lack file metadata in the JSON snapshot."""
+    if not isinstance(files, list) or not files:
+        return False
+    for entry in files:
+        if not isinstance(entry, dict):
+            return False
+        if not entry.get("yanked"):
+            return False
+    return True
+
+
+def _fallback_info_version(payload: dict, pin: str | None) -> str | None:
+    """Last-resort path when releases dict is missing or packaging is
+    unavailable. Trusts info.version only when no pin window applies
+    — silent skip otherwise to avoid recommending an out-of-window
+    upgrade."""
+    info = payload.get("info") if isinstance(payload, dict) else None
+    if not isinstance(info, dict):
+        return None
+    latest = info.get("version")
+    if not isinstance(latest, str) or not latest:
+        return None
+    if pin:
+        return None
+    return latest
+
+
+def main() -> int:
+    installed = _installed_version()
+    if installed is None:
+        return 0
+    pin = _read_pin_spec()
+    latest = _latest_version(pin)
+    if latest is None:
+        return 0
+    if installed == latest:
+        return 0
+    # Bare ``pip install --upgrade claude-org-runtime`` would fetch the
+    # PyPI maximum, which may be out of ja's pin window. Bake the pin
+    # spec into the recommended command so the user never gets steered
+    # to an unsupported version.
+    spec_suffix = pin if pin else ""
+    upgrade_target = f"{PACKAGE}{spec_suffix}"
+    print(
+        f"[runtime drift] {PACKAGE}: installed={installed} latest={latest} "
+        f"-- `python -m pip install --upgrade '{upgrade_target}'` で更新できます"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -1,0 +1,269 @@
+"""Unit tests for tools/check_runtime_version.py (Issue #472).
+
+The script is invoked by /org-start Block C2. It must:
+
+* print one warning line when installed != latest-in-pin-window
+* print nothing (and exit 0) when installed == latest
+* print nothing on every "can't tell" branch — package missing,
+  PyPI unreachable, JSON parse failure, no pin-compatible release
+* respect ja's pin window declared in pyproject.toml so the warning
+  never steers users to an out-of-window upgrade (Codex review,
+  Issue #472)
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_runtime_version  # noqa: E402
+
+try:  # noqa: SIM105
+    import packaging  # type: ignore  # noqa: F401
+
+    _HAS_PACKAGING = True
+except ImportError:
+    _HAS_PACKAGING = False
+
+requires_packaging = unittest.skipUnless(
+    _HAS_PACKAGING,
+    "packaging not installed — pin-window resolution falls back to "
+    "silent skip, so the pin-aware paths are untestable here",
+)
+
+
+def _fake_urlopen(payload: dict):
+    body = json.dumps(payload).encode("utf-8")
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            self.close()
+            return False
+
+    return lambda *a, **kw: _Resp(body)
+
+
+def _payload(*versions: str, yanked: tuple[str, ...] = ()) -> dict:
+    """Build a minimally-PyPI-shaped JSON payload from the given
+    release versions (newest last, as PyPI usually sorts). Versions
+    listed in ``yanked`` are emitted with every file marked yanked."""
+    releases = {}
+    for v in versions:
+        releases[v] = [{"yanked": v in yanked}]
+    return {
+        "info": {"version": versions[-1] if versions else ""},
+        "releases": releases,
+    }
+
+
+class MainCliTest(unittest.TestCase):
+    def _run_main(self) -> tuple[int, str]:
+        buf = io.StringIO()
+        with mock.patch.object(sys, "stdout", buf):
+            code = check_runtime_version.main()
+        return code, buf.getvalue()
+
+    def test_drift_prints_one_warning_line(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        lines = [ln for ln in out.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        self.assertIn("[runtime drift]", lines[0])
+        self.assertIn("installed=0.1.2", lines[0])
+        self.assertIn("latest=0.1.11", lines[0])
+
+    def test_match_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.11"
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_package_not_installed_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value=None
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version"
+        ) as latest_mock:
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+        latest_mock.assert_not_called()
+
+    def test_offline_is_silent(self):
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            code, out = self._run_main()
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+
+class LatestVersionTest(unittest.TestCase):
+    """Direct tests for _latest_version() and the pin-window logic."""
+
+    @requires_packaging
+    def test_picks_latest_within_pin_window(self):
+        payload = _payload("0.1.9", "0.1.11", "0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.11",
+            )
+
+    @requires_packaging
+    def test_no_pin_picks_global_max(self):
+        payload = _payload("0.1.9", "0.1.11", "0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=None),
+                "0.2.1",
+            )
+
+    @requires_packaging
+    def test_skips_prereleases(self):
+        payload = _payload("0.1.9", "0.1.11", "0.1.12a1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.11",
+            )
+
+    @requires_packaging
+    def test_no_pin_compatible_release_is_silent(self):
+        payload = _payload("0.2.0", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2")
+            )
+
+    @requires_packaging
+    def test_invalid_pin_is_silent(self):
+        """When the pin string fails to parse we can no longer enforce
+        the window, so prefer silence over recommending an
+        out-of-window upgrade (Codex round 2 Major)."""
+        payload = _payload("0.1.9", "0.1.11", "0.2.1")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin="garbage")
+            )
+
+    @requires_packaging
+    def test_yanked_release_is_excluded(self):
+        """If the only in-window release newer than installed is
+        yanked, _latest_version must not surface it as ``latest`` —
+        pip wouldn't pick it either (Codex round 2 Minor)."""
+        payload = _payload(
+            "0.1.9", "0.1.10", "0.1.11", yanked=("0.1.11",)
+        )
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2"),
+                "0.1.10",
+            )
+
+    def test_pypi_returns_empty_payload_is_silent(self):
+        with mock.patch(
+            "urllib.request.urlopen", _fake_urlopen({"info": {"version": ""}})
+        ):
+            self.assertIsNone(check_runtime_version._latest_version(pin=None))
+
+    def test_pypi_json_parse_failure_is_silent(self):
+        class _Resp(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self.close()
+                return False
+
+        with mock.patch(
+            "urllib.request.urlopen", lambda *a, **kw: _Resp(b"not-json")
+        ):
+            self.assertIsNone(check_runtime_version._latest_version(pin=None))
+
+    def test_fallback_to_info_version_when_releases_missing_and_no_pin(self):
+        payload = {"info": {"version": "1.2.3"}}
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertEqual(
+                check_runtime_version._latest_version(pin=None),
+                "1.2.3",
+            )
+
+    def test_fallback_is_silent_when_pin_present_but_releases_missing(self):
+        """Without a releases dict we can't enforce a pin window, so
+        prefer silence over recommending an out-of-window upgrade."""
+        payload = {"info": {"version": "1.2.3"}}
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            self.assertIsNone(
+                check_runtime_version._latest_version(pin=">=0.1.9,<0.2")
+            )
+
+
+class ReadPinSpecTest(unittest.TestCase):
+    def test_reads_pin_from_real_pyproject(self):
+        """The script lives next to ja's pyproject.toml; sanity-check
+        the actual file has a pin we recognise."""
+        spec = check_runtime_version._read_pin_spec()
+        self.assertIsNotNone(spec)
+        self.assertTrue(
+            spec.startswith(">=") or spec.startswith("=="),
+            f"unexpected pin shape: {spec!r}",
+        )
+
+
+class UpgradeCommandShapeTest(unittest.TestCase):
+    """Warning text must bake the pin spec into the recommended
+    upgrade command so users never get steered to an out-of-window
+    release (Codex round 2 Major)."""
+
+    def _drive_main_with_pin(self, pin):
+        buf = io.StringIO()
+        with mock.patch.object(
+            check_runtime_version, "_installed_version", return_value="0.1.2"
+        ), mock.patch.object(
+            check_runtime_version, "_read_pin_spec", return_value=pin
+        ), mock.patch.object(
+            check_runtime_version, "_latest_version", return_value="0.1.11"
+        ), mock.patch.object(sys, "stdout", buf):
+            check_runtime_version.main()
+        return buf.getvalue()
+
+    def test_command_includes_pin_when_pin_known(self):
+        out = self._drive_main_with_pin(">=0.1.9,<0.2")
+        self.assertIn(
+            "'claude-org-runtime>=0.1.9,<0.2'",
+            out,
+            "upgrade command must carry the pin spec",
+        )
+
+    def test_command_is_bare_when_pin_missing(self):
+        out = self._drive_main_with_pin(None)
+        self.assertIn("'claude-org-runtime'", out)
+        self.assertNotIn("<", out.split("install --upgrade")[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#473](https://github.com/suisya-systems/claude-org-ja/pull/473)

Merge SHA: `f52aed47b6073f3596349db25062d9e2dadf1f8f`

Source: ja PR [#473](https://github.com/suisya-systems/claude-org-ja/pull/473)
Merge SHA: `f52aed47b6073f3596349db25062d9e2dadf1f8f`

| class | count |
|---|---|
| runtime | 2 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tools/check_runtime_version.py`
- `tools/test_check_runtime_version.py`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-start/SKILL.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
