### PR TITLE
auto-mirror: ja#474 feat(secretary): allow force-with-lease on non-protected branches

### DIFF
--- a/.hooks/block-dangerous-git.sh
+++ b/.hooks/block-dangerous-git.sh
@@ -3,7 +3,20 @@
 # 方式: exit 2 + stderr メッセージ でブロック
 #
 # ブロック対象:
-#   - git push --force / -f / --force-with-lease   （履歴書き換え）
+#   - git push --force / -f                         （履歴書き換え、無条件 deny）
+#   - git push --force-with-lease （protected branch / ambiguous のみ deny / Issue #470）
+#       protected = main / master / develop / release/* / production
+#       非保護 branch への --force-with-lease は許容（PR rebase 後の安全な再 push）
+#       下記いずれかに該当する場合は安全側で deny:
+#         - refspec を解決できない（remote のみ / 引数無し）
+#         - target が HEAD / @ （実行時の current branch 依存）
+#         - target が wildcard（refs/heads/* / : 等の matching/delete-all）
+#         - --all / --mirror / --tags（upstream 全体に作用）
+#         - refspec トークンに引用符 / $展開 / `...` 等を含み静的解析不能
+#         - destination が refs/heads/ 以外の namespace（refs/tags/* 等の
+#           tag / notes / replace 等の任意 ref。--force-with-lease の本来の
+#           用途は branch のみ）
+#         - `git push origin tag <name>` の "tag" キーワード形式
 #   - git reset --hard                              （未コミット変更の消失）
 #   - git branch -D / --delete --force              （未マージブランチ削除）
 #   - git clean -f / -fd / -fx / -dfx 等            （ワークツリー破壊）
@@ -16,8 +29,10 @@
 # 補足:
 #   - git push そのものはワーカーでは block-git-push.sh が先に止める。
 #     本フックは「窓口側でうっかり叩いた場合の最後の壁」も兼ねる。
-#   - --force-with-lease は --force より安全だが、本フェーズでは
-#     workflow から外す方針で一律ブロックする（Phase 2 で再検討）。
+#   - --force-with-lease の条件付き許可は Issue #470 で導入。
+#     上流 ref を確認してから強制 push するため --force より安全であり、
+#     PR レビュー指摘の rebase / squash 後の再 push 等で正当な需要がある。
+#     ただし protected branch への適用は引き続き禁止（共有履歴の保護）。
 #   - Phase 2 (Refs claude-org-ja#379): clean -fd / checkout -- . / tag -d /
 #     update-ref -d / reflog expire 等のカバレッジを追加した。
 #     詳細は docs/contracts/worker-git-guardrails-design.md §5.2.2 参照。
@@ -73,6 +88,148 @@ if [[ -z "$COMMAND" ]]; then
   exit 0
 fi
 
+# Issue #470: protected branch（共有履歴）への --force-with-lease は引き続き
+# deny する。非保護 branch（feature/* 等）への --force-with-lease は許容。
+# protected branch 名は本ファイル内で完結（環境変数経由の override は意図的に
+# 提供しない: hook の振る舞いを env で動的に変えると drift 検出が難しくなるため）。
+# master は git の歴史的デフォルト名で main の同義として扱う組織が多いため保護
+# 対象に含める（task brief の main/develop/release/*/production を超える保護
+# 拡張だが、誤検知に倒すリスクの方が小さい）。
+PROTECTED_BRANCH_PATTERNS=(
+  "main"
+  "master"
+  "develop"
+  "production"
+  # release/* は別途 case でマッチ
+)
+
+# git push の引数群を解析し、deny が必要かを判定する。
+#
+# 入力: flat（コマンド置換等が展開済みの 1 セグメント文字列）
+# 戻り値: 0 = deny 推奨（protected branch を含む / refspec を決定できない / 不審
+#               な refspec が混在 / wildcard・matching push 等の広域 push）
+#         1 = 明確に非保護 branch のみへの push（allow 可）
+#
+# 安全側方針: allow と判断するためには「全 positional refspec が確実に非保護
+# branch を指している」ことが必要。少しでも曖昧さがあれば deny に倒す。
+push_target_requires_deny() {
+  local flat="$1"
+
+  # --all / --mirror / --tags は upstream 全体に作用するため protected branch を
+  # 含み得る → 無条件 deny
+  if echo "$flat" | grep -qE '(^|[[:space:]])--(all|mirror|tags)([[:space:]=]|$)'; then
+    return 0
+  fi
+
+  # `git ... push <args...>` の <args> 部分を切り出す（awk でトークン化）。
+  # awk は引用符を理解しないため "..."/'...' を含む refspec は次の段で
+  # 個別に ambiguous deny に倒す。
+  local args_str
+  args_str=$(printf '%s\n' "$flat" | awk '
+    {
+      found=0
+      out=""
+      for(i=1;i<=NF;i++){
+        if(!found){
+          if($i=="push") { found=1 }
+        } else {
+          out = out " " $i
+        }
+      }
+      print substr(out,2)
+    }')
+
+  # 非フラグの positional トークンを収集。--force-with-lease=<ref> 等の attached
+  # value はフラグ側に属するため positional には数えない。
+  local positional=()
+  local tok
+  for tok in $args_str; do
+    case "$tok" in
+      -*) continue ;;
+      *) positional+=("$tok") ;;
+    esac
+  done
+
+  # 0 positional → `git push` のみ（upstream of HEAD を使用）→ ambiguous
+  # 1 positional → remote のみ・refspec 無し → ambiguous（push.default 依存）
+  if (( ${#positional[@]} < 2 )); then
+    return 0
+  fi
+
+  # positional[0] = remote、それ以降が refspec
+  local refspec target pat dst
+  local idx
+  for (( idx=1; idx<${#positional[@]}; idx++ )); do
+    refspec="${positional[$idx]}"
+    # 先頭の '+' force prefix を剥がす（refspec 内 force 指定の慣習）
+    refspec="${refspec#+}"
+
+    # 引用符・$ 展開・`...`・コマンド置換の残骸を含むトークンは
+    # シェル構文を再解釈しないと安全に判定できない → ambiguous deny
+    case "$refspec" in
+      *\"*|*\'*|*\$*|*\`*) return 0 ;;
+    esac
+
+    # `git push origin tag <name>` 形式の "tag" キーワード → ambiguous deny
+    # （branch 以外の namespace、--force-with-lease の本来の用途外）
+    if [[ "$refspec" == "tag" ]]; then
+      return 0
+    fi
+
+    # `<src>:<dst>` 形式 → dst が destination。`:<dst>` (delete) や
+    # `<src>:<dst>` も最後の `:` 以降を採用
+    dst="${refspec##*:}"
+
+    # 空 destination（`:` で matching push / delete 全件等）→ ambiguous deny
+    if [[ -z "$dst" ]]; then
+      return 0
+    fi
+
+    # wildcard を含む destination は protected branch を含み得る → ambiguous deny
+    if [[ "$dst" == *\** || "$dst" == *\?* || "$dst" == *\[* ]]; then
+      return 0
+    fi
+
+    # HEAD / @ は実行時の current branch 依存 → ambiguous deny
+    if [[ "$dst" == "HEAD" || "$dst" == "@" ]]; then
+      return 0
+    fi
+
+    # destination の namespace 判定
+    # --force-with-lease の正当な用途は branch (refs/heads/) のみ。
+    # refs/tags/* / refs/notes/* / refs/remotes/* / refs/replace/* /
+    # refs/pull/* 等の任意 ref は共有 namespace の改変リスクがあるため
+    # ambiguous deny。
+    case "$dst" in
+      refs/heads/*)
+        # branch namespace、prefix を剥がして name のみで protected 判定
+        target="${dst#refs/heads/}"
+        ;;
+      refs/*)
+        # branch 以外の任意 ref → deny
+        return 0
+        ;;
+      *)
+        # prefix 無しの bare name → git のデフォルト解決で
+        # refs/heads/<name> へ push される branch shorthand
+        target="$dst"
+        ;;
+    esac
+
+    # protected branch 一致判定
+    for pat in "${PROTECTED_BRANCH_PATTERNS[@]}"; do
+      if [[ "$target" == "$pat" ]]; then
+        return 0
+      fi
+    done
+    if [[ "$target" == release/* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 # セグメントの中に git の特定サブコマンドが含まれるか判定するヘルパ
 segment_has_git_subcmd() {
   local segment="$1"
@@ -118,16 +275,38 @@ for segment in "${SEGMENTS[@]}"; do
   # コマンド置換 $(...) / `...` 内のフラグも検査対象に含める
   flat=$(printf '%s' "$expanded" | flatten_substitutions)
 
-  # 1) git push の force 系
+  # 1) git push の force 系（Issue #470 で --force-with-lease を条件付き許可）
   if segment_has_git_subcmd "$flat" "push"; then
-    if echo "$flat" | grep -qE '(^|[[:space:]])--force(-with-lease)?([[:space:]=]|$)'; then
-      deny_with_reason "git push の force 系フラグは禁止です。履歴の書き換えはレビュー後に窓口経由で実施してください。"
+    has_force_with_lease=0
+    has_plain_force=0
+
+    # --force-with-lease は --force より先に判定する（部分一致回避）
+    if echo "$flat" | grep -qE '(^|[[:space:]])--force-with-lease([[:space:]=]|$)'; then
+      has_force_with_lease=1
     fi
+    # 素の --force（--force-with-lease は除外: 後続文字が '-' で regex 不一致）
+    if echo "$flat" | grep -qE '(^|[[:space:]])--force([[:space:]=]|$)'; then
+      has_plain_force=1
+    fi
+    # 短縮形 -f 単独
     if echo "$flat" | grep -qE '(^|[[:space:]])-f([[:space:]]|$)'; then
-      deny_with_reason "git push の短縮 force フラグは禁止です。履歴の書き換えはレビュー後に窓口経由で実施してください。"
+      has_plain_force=1
     fi
+    # バンドル短オプション内に 'f' を含む（-uf 等）
     if echo "$flat" | grep -qE '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)'; then
-      deny_with_reason "git push のバンドル短オプションに force フラグが含まれています。履歴の書き換えはレビュー後に窓口経由で実施してください。"
+      has_plain_force=1
+    fi
+
+    # 素の force は無条件 deny。Issue #470 でも維持。
+    if (( has_plain_force == 1 )); then
+      deny_with_reason "git push の素の force フラグ（--force / -f / バンドル短オプション）は禁止です。--force-with-lease（非保護 branch のみ許可）を使ってください。protected branch への履歴書き換えはレビュー後に窓口経由で実施してください。"
+    fi
+
+    # --force-with-lease は protected branch にのみ deny
+    if (( has_force_with_lease == 1 )); then
+      if push_target_requires_deny "$flat"; then
+        deny_with_reason "git push --force-with-lease は protected branch (main / master / develop / release/* / production) や refspec 未指定 / HEAD / wildcard / --all / --mirror / --tags など宛先が曖昧なケースでは禁止です。push 先 branch を明示し、非保護 branch のみに使用してください。"
+      fi
     fi
   fi
 

--- a/.hooks/test-block-dangerous-git.sh
+++ b/.hooks/test-block-dangerous-git.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# block-dangerous-git.sh のテスト（Issue #470）
+# 実行: bash .hooks/test-block-dangerous-git.sh
+#
+# 主な確認観点:
+#   - 素の git push --force / -f / バンドル短オプション → deny
+#   - protected branch (main / develop / release/* / production) への
+#     --force-with-lease → deny
+#   - 非保護 branch への --force-with-lease → allow
+#   - refspec 未指定など ambiguous な --force-with-lease → 安全側 deny
+#   - その他の既存破壊的コマンド（reset --hard / branch -D / clean -f /
+#     checkout -- . / restore --source / tag -d / update-ref -d /
+#     reflog expire --all）が引き続き deny されること
+
+set -euo pipefail
+
+HOOK=".hooks/block-dangerous-git.sh"
+PASS=0
+FAIL=0
+
+run_test() {
+  local description="$1"
+  local input_json="$2"
+  local expected_exit="$3"  # 0=許可, 2=ブロック
+
+  actual_exit=0
+  echo "$input_json" | bash "$HOOK" >/dev/null 2>&1 || actual_exit=$?
+
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+mk_bash_json() {
+  # JSON エスケープを jq に任せる（バックスラッシュ・引用符を安全に扱う）
+  local cmd="$1"
+  jq -n --arg cmd "$cmd" '{"tool_name":"Bash","tool_input":{"command":$cmd}}'
+}
+
+echo "=== block-dangerous-git.sh tests ==="
+echo ""
+
+# =====================================================================
+# [素の force は無条件 deny]
+# =====================================================================
+echo "[素の --force / -f は protected/非保護を問わず deny]"
+
+run_test "git push --force origin feat/foo (素 force, 非保護でも deny)" \
+  "$(mk_bash_json "git push --force origin feat/foo")" 2
+
+run_test "git push --force origin main (素 force, protected)" \
+  "$(mk_bash_json "git push --force origin main")" 2
+
+run_test "git push -f origin feat/foo (短縮 force)" \
+  "$(mk_bash_json "git push -f origin feat/foo")" 2
+
+run_test "git push -uf origin feat/foo (バンドル短オプション f 含む)" \
+  "$(mk_bash_json "git push -uf origin feat/foo")" 2
+
+run_test "git push --force (refspec 無し)" \
+  "$(mk_bash_json "git push --force")" 2
+
+echo ""
+
+# =====================================================================
+# [protected branch への --force-with-lease は deny]
+# =====================================================================
+echo "[protected branch (main/develop/release/*/production) への --force-with-lease は deny]"
+
+run_test "git push --force-with-lease origin main" \
+  "$(mk_bash_json "git push --force-with-lease origin main")" 2
+
+run_test "git push --force-with-lease origin develop" \
+  "$(mk_bash_json "git push --force-with-lease origin develop")" 2
+
+run_test "git push --force-with-lease origin production" \
+  "$(mk_bash_json "git push --force-with-lease origin production")" 2
+
+run_test "git push --force-with-lease origin release/v1.0" \
+  "$(mk_bash_json "git push --force-with-lease origin release/v1.0")" 2
+
+run_test "git push --force-with-lease origin release/2026-05" \
+  "$(mk_bash_json "git push --force-with-lease origin release/2026-05")" 2
+
+run_test "git push --force-with-lease origin master (alias of main)" \
+  "$(mk_bash_json "git push --force-with-lease origin master")" 2
+
+run_test "git push --force-with-lease origin HEAD:master (refspec)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD:master")" 2
+
+run_test "git push --force-with-lease origin refs/heads/master (full ref)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/heads/master")" 2
+
+run_test "git push --force-with-lease origin feat/foo:master (cross-name master)" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo:master")" 2
+
+# 引用符は split_segments で空白へ正規化される（lib/segment-split.sh 内部実装）
+# ため、quoted refspec はクオート無しと同じ判定経路を通る。protected 名は
+# 引用符の有無に関わらず deny できることを回帰確認する。
+run_test "git push --force-with-lease origin \"main\" (quoted protected → deny via 正規化後の name 一致)" \
+  "$(mk_bash_json 'git push --force-with-lease origin "main"')" 2
+
+run_test "git push --force-with-lease origin \$BRANCH (未展開の変数 → ambiguous deny)" \
+  "$(mk_bash_json 'git push --force-with-lease origin $BRANCH')" 2
+
+run_test "git push --force-with-lease origin HEAD:main (refspec)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD:main")" 2
+
+run_test "git push --force-with-lease origin feat/foo:main (cross-name refspec)" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo:main")" 2
+
+run_test "git push --force-with-lease origin refs/heads/main (full ref)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/heads/main")" 2
+
+run_test "git push --force-with-lease origin feat/foo main (複数 refspec, main 含む)" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo main")" 2
+
+run_test "git push --force-with-lease=feat/foo origin main (--force-with-lease=<ref> with main destination)" \
+  "$(mk_bash_json "git push --force-with-lease=feat/foo origin main")" 2
+
+echo ""
+
+# =====================================================================
+# [非保護 branch への --force-with-lease は allow]
+# =====================================================================
+echo "[非保護 branch への --force-with-lease は allow]"
+
+run_test "git push --force-with-lease origin feat/foo" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo")" 0
+
+run_test "git push --force-with-lease origin feat/issue-470" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/issue-470")" 0
+
+run_test "git push --force-with-lease origin fix/bug-123" \
+  "$(mk_bash_json "git push --force-with-lease origin fix/bug-123")" 0
+
+run_test "git push --force-with-lease origin HEAD:feat/foo (refspec で非保護)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD:feat/foo")" 0
+
+run_test "git push --force-with-lease=feat/foo origin feat/foo (--force-with-lease=<ref>)" \
+  "$(mk_bash_json "git push --force-with-lease=feat/foo origin feat/foo")" 0
+
+run_test "git push --force-with-lease origin feat/foo feat/bar (複数 refspec, 全て非保護)" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo feat/bar")" 0
+
+run_test "git -C /some/repo push --force-with-lease origin feat/foo" \
+  "$(mk_bash_json "git -C /some/repo push --force-with-lease origin feat/foo")" 0
+
+echo ""
+
+# =====================================================================
+# [ambiguous（refspec 未指定）の --force-with-lease は安全側 deny]
+# =====================================================================
+echo "[ambiguous な --force-with-lease は安全側 deny]"
+
+run_test "git push --force-with-lease (引数無し)" \
+  "$(mk_bash_json "git push --force-with-lease")" 2
+
+run_test "git push --force-with-lease origin (remote のみ, refspec 無し)" \
+  "$(mk_bash_json "git push --force-with-lease origin")" 2
+
+run_test "git push --force-with-lease origin HEAD (current branch 依存)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD")" 2
+
+run_test "git push --force-with-lease origin @ (HEAD alias)" \
+  "$(mk_bash_json "git push --force-with-lease origin @")" 2
+
+run_test "git push --force-with-lease origin : (matching push 全件)" \
+  "$(mk_bash_json "git push --force-with-lease origin :")" 2
+
+run_test "git push --force-with-lease origin refs/heads/*:refs/heads/* (wildcard refspec)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/heads/*:refs/heads/*")" 2
+
+run_test "git push --force-with-lease --all origin (--all flag)" \
+  "$(mk_bash_json "git push --force-with-lease --all origin")" 2
+
+run_test "git push --force-with-lease --mirror origin" \
+  "$(mk_bash_json "git push --force-with-lease --mirror origin")" 2
+
+run_test "git push --force-with-lease --tags origin" \
+  "$(mk_bash_json "git push --force-with-lease --tags origin")" 2
+
+run_test "git push --force-with-lease origin HEAD:refs/heads/* (wildcard 部分含む)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD:refs/heads/*")" 2
+
+run_test "git push --force-with-lease origin refs/tags/v1.0 (tag namespace)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/tags/v1.0")" 2
+
+run_test "git push --force-with-lease origin tag v1.0 (tag keyword)" \
+  "$(mk_bash_json "git push --force-with-lease origin tag v1.0")" 2
+
+run_test "git push --force-with-lease origin refs/notes/commits (notes namespace)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/notes/commits")" 2
+
+run_test "git push --force-with-lease origin refs/replace/abc (replace namespace)" \
+  "$(mk_bash_json "git push --force-with-lease origin refs/replace/abc")" 2
+
+run_test "git push --force-with-lease origin HEAD:refs/tags/v1.0 (dst=tag namespace)" \
+  "$(mk_bash_json "git push --force-with-lease origin HEAD:refs/tags/v1.0")" 2
+
+run_test "git push --force-with-lease origin feat/foo:refs/tags/v1.0 (cross-ns to tag)" \
+  "$(mk_bash_json "git push --force-with-lease origin feat/foo:refs/tags/v1.0")" 2
+
+echo ""
+
+# =====================================================================
+# [既存の破壊的コマンドは引き続き deny（regression check）]
+# =====================================================================
+echo "[既存の破壊的コマンド deny の回帰確認]"
+
+run_test "git reset --hard HEAD" \
+  "$(mk_bash_json "git reset --hard HEAD")" 2
+
+run_test "git branch -D feat/foo" \
+  "$(mk_bash_json "git branch -D feat/foo")" 2
+
+run_test "git branch --delete --force feat/foo" \
+  "$(mk_bash_json "git branch --delete --force feat/foo")" 2
+
+run_test "git clean -fd" \
+  "$(mk_bash_json "git clean -fd")" 2
+
+run_test "git clean --force" \
+  "$(mk_bash_json "git clean --force")" 2
+
+run_test "git checkout -- ." \
+  "$(mk_bash_json "git checkout -- .")" 2
+
+run_test "git restore --source=HEAD~1 src/foo" \
+  "$(mk_bash_json "git restore --source=HEAD~1 src/foo")" 2
+
+run_test "git tag -d v1.0" \
+  "$(mk_bash_json "git tag -d v1.0")" 2
+
+run_test "git update-ref -d refs/heads/foo" \
+  "$(mk_bash_json "git update-ref -d refs/heads/foo")" 2
+
+run_test "git reflog expire --all" \
+  "$(mk_bash_json "git reflog expire --all")" 2
+
+echo ""
+
+# =====================================================================
+# [良性コマンドは allow]
+# =====================================================================
+echo "[良性コマンドは allow]"
+
+run_test "git push origin feat/foo (force 無し)" \
+  "$(mk_bash_json "git push origin feat/foo")" 0
+
+run_test "git push origin main (force 無し protected でも push 自体は OK)" \
+  "$(mk_bash_json "git push origin main")" 0
+
+run_test "git push (引数無し, force 無し)" \
+  "$(mk_bash_json "git push")" 0
+
+run_test "git status" \
+  "$(mk_bash_json "git status")" 0
+
+run_test "git diff" \
+  "$(mk_bash_json "git diff")" 0
+
+run_test "git restore --staged src/foo (staged 単独は安全)" \
+  "$(mk_bash_json "git restore --staged src/foo")" 0
+
+run_test "git checkout feat/foo (-- 無しの branch 切替)" \
+  "$(mk_bash_json "git checkout feat/foo")" 0
+
+run_test "git reset HEAD~1 (--hard 無し)" \
+  "$(mk_bash_json "git reset HEAD~1")" 0
+
+run_test "git branch -d feat/foo (-D ではない小文字 -d)" \
+  "$(mk_bash_json "git branch -d feat/foo")" 0
+
+run_test "Edit ツール (Bash ではない)" \
+  '{"tool_name":"Edit","tool_input":{"file_path":"src/foo.txt"}}' 0
+
+run_test "空コマンド" \
+  '{"tool_name":"Bash","tool_input":{"command":""}}' 0
+
+echo ""
+
+# =====================================================================
+# [複合コマンド / セグメント分割の確認]
+# =====================================================================
+echo "[複合コマンド / セグメント分割]"
+
+run_test "echo --force ; git push origin feat/foo (別セグメントの --force は無視)" \
+  "$(mk_bash_json "echo --force ; git push origin feat/foo")" 0
+
+run_test "git status && git push --force origin main (後続セグメントの素 force)" \
+  "$(mk_bash_json "git status && git push --force origin main")" 2
+
+run_test "git status && git push --force-with-lease origin feat/foo (後続セグメントの with-lease 非保護)" \
+  "$(mk_bash_json "git status && git push --force-with-lease origin feat/foo")" 0
+
+run_test "git status && git push --force-with-lease origin main (後続セグメントの with-lease protected)" \
+  "$(mk_bash_json "git status && git push --force-with-lease origin main")" 2
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/tests/test-block-pretooluse-hooks.sh
+++ b/tests/test-block-pretooluse-hooks.sh
@@ -135,6 +135,37 @@ echo "=== block-dangerous-git.sh ==="
 substitute_run "$DG_HOOK" 'g_it p_ush --force' block
 substitute_run "$DG_HOOK" 'g_it p_ush -f' block
 substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease' block
+# Issue #470: --force-with-lease 条件付き許可
+#   - protected branch (main / develop / release/* / production) は引き続き deny
+#   - 非保護 branch は allow
+#   - ambiguous (refspec 無し / remote のみ) は安全側 deny
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin main' block 'fwl-protected-main'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin develop' block 'fwl-protected-develop'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin production' block 'fwl-protected-production'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin release/v1.0' block 'fwl-protected-release-slash'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin HEAD:main' block 'fwl-protected-refspec-head'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin refs/heads/main' block 'fwl-protected-full-ref'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease=feat/foo origin main' block 'fwl-with-ref-protected-dest'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin' block 'fwl-ambiguous-remote-only'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin master' block 'fwl-protected-master'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin HEAD' block 'fwl-ambiguous-head'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin @' block 'fwl-ambiguous-at'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin :' block 'fwl-ambiguous-matching-colon'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin refs/heads/*:refs/heads/*' block 'fwl-wildcard-refspec'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease --all origin' block 'fwl-all-flag'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease --mirror origin' block 'fwl-mirror-flag'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease --tags origin' block 'fwl-tags-flag'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin refs/tags/v1.0' block 'fwl-tag-namespace'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin tag v1.0' block 'fwl-tag-keyword'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin refs/notes/commits' block 'fwl-notes-namespace'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin HEAD:refs/tags/v1.0' block 'fwl-dst-tag-namespace'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin feat/foo' pass 'fwl-non-protected-feat'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin fix/bug-123' pass 'fwl-non-protected-fix'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin HEAD:feat/foo' pass 'fwl-non-protected-refspec-head'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease=feat/foo origin feat/foo' pass 'fwl-with-ref-non-protected'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin feat/foo feat/bar' pass 'fwl-multi-refspec-all-non-protected'
+substitute_run "$DG_HOOK" 'g_it p_ush --force-with-lease origin feat/foo main' block 'fwl-multi-refspec-one-protected'
+substitute_run "$DG_HOOK" 'g_it -C /tmp/repo p_ush --force-with-lease origin feat/foo' pass 'fwl-with-C-non-protected'
 substitute_run "$DG_HOOK" 'g_it p_ush -fu origin main' block 'bundled-short-opt'
 substitute_run "$DG_HOOK" 'g_it p_ush -uf origin main' block 'bundled-short-opt'
 substitute_run "$DG_HOOK" 'g_it p_ush --force origin main' block


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#474](https://github.com/suisya-systems/claude-org-ja/pull/474)

Merge SHA: `e2da675f349b24aec86ba1c4e91a9c3c17daa103`

Source: ja PR [#474](https://github.com/suisya-systems/claude-org-ja/pull/474)
Merge SHA: `e2da675f349b24aec86ba1c4e91a9c3c17daa103`

| class | count |
|---|---|
| runtime | 3 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `.hooks/block-dangerous-git.sh`
- `.hooks/test-block-dangerous-git.sh`
- `tests/test-block-pretooluse-hooks.sh`

</details>
<details><summary>translation (1)</summary>

- `.claude/skills/org-setup/references/permissions.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
