### PR TITLE
auto-mirror: ja#479 fix(pattern-c-cleanup): delete leftover CLAUDE.local.md for Pattern C self-edit (Closes #478)

### DIFF
--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -67,6 +67,86 @@ RESULT_NO_RUN = "no_run"        # No matching run row; nothing written.
 RESULT_MERGED_PENDING_CLEANUP = RESULT_MERGED
 
 
+# --- Pattern C (gitignored_repo_root) post-completion cleanup (Issue #478) --
+# The brief filename the secretary writes into a claude-org self-edit worker's
+# dir (per .claude/skills/org-delegate/references/claude-org-self-edit.md §2).
+# For Pattern B (live_repo_worktree) the worktree removal at close reclaims it;
+# for Pattern C gitignored_repo_root the worker_dir *is* the claude-org repo
+# root, so there is no directory to remove and the brief must be deleted
+# file-by-file or it lingers and overwrites the secretary's role identity on
+# the next /org-start.
+PATTERN_C_BRIEF_FILENAME = "CLAUDE.local.md"
+
+# Return codes for :func:`cleanup_pattern_c_local_md`.
+CLEANUP_REMOVED = "removed"          # file existed and was deleted; event mode=auto.
+CLEANUP_ABSENT = "absent"            # Pattern C @ root but file already gone; event mode=skip.
+CLEANUP_NOT_APPLICABLE = "not_applicable"  # not Pattern C, or worker_dir != root; no event.
+
+
+def cleanup_pattern_c_local_md(
+    conn,
+    *,
+    task_id: str,
+    claude_org_root: Path,
+) -> str:
+    """Remove a leftover ``CLAUDE.local.md`` from the claude-org repo root
+    for a Pattern C ``gitignored_repo_root`` self-edit run (Issue #478).
+
+    Detection (design judgment 1 of Issue #478): ``runs.pattern == 'C'`` AND
+    the run's ``worker_dirs.abs_path`` equals ``claude_org_root``. This needs
+    no schema change — Pattern C *ephemeral* has ``worker_dir`` at
+    ``{workers_dir}/{task_id}`` (≠ root), so it is reclaimed by ordinary dir
+    removal and naturally falls through here as ``not_applicable``.
+
+    Idempotent: ``Path.unlink(missing_ok=True)`` never raises on a missing
+    file, and a re-call after the brief is gone returns
+    :data:`CLEANUP_ABSENT`. An audit row (``kind='pattern_c_cleanup'``) is
+    appended whenever the run qualifies — ``mode='auto'`` when the file was
+    actually removed, ``mode='skip'`` when it was already absent — so the
+    hook firing is observable in the events table. Non-qualifying runs
+    (Pattern A/B, or Pattern C ephemeral) write nothing.
+
+    Returns one of :data:`CLEANUP_REMOVED`, :data:`CLEANUP_ABSENT`,
+    :data:`CLEANUP_NOT_APPLICABLE`.
+    """
+    row = conn.execute(
+        "SELECT r.pattern, d.abs_path "
+        "FROM runs r LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id "
+        "WHERE r.task_id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return CLEANUP_NOT_APPLICABLE
+    pattern = (row["pattern"] or "").upper()
+    worker_dir = row["abs_path"]
+    if pattern != "C" or not worker_dir:
+        return CLEANUP_NOT_APPLICABLE
+
+    root = Path(claude_org_root).resolve()
+    if Path(worker_dir).resolve() != root:
+        # Pattern C ephemeral: worker_dir is {workers_dir}/{task_id}, a
+        # disposable dir whose CLAUDE.md is reclaimed by dir removal.
+        return CLEANUP_NOT_APPLICABLE
+
+    target = root / PATTERN_C_BRIEF_FILENAME
+    existed = target.exists()
+    target.unlink(missing_ok=True)  # OS-level idempotent
+
+    from tools.state_db.writer import StateWriter
+    with StateWriter(conn).transaction() as w:
+        w.append_event(
+            kind="pattern_c_cleanup",
+            actor="run_complete_on_merge",
+            payload={
+                "task": task_id,
+                "removed_path": str(target),
+                "mode": "auto" if existed else "skip",
+            },
+            run_task_id=task_id,
+        )
+    return CLEANUP_REMOVED if existed else CLEANUP_ABSENT
+
+
 def _ensure_gh_installed() -> None:
     if shutil.which("gh") is None:
         sys.stderr.write(
@@ -321,6 +401,18 @@ def complete_on_merge(
             "CLOSE_PANE / remove_worker_dir and call "
             "update_run_status('<task>', 'completed') (Step 5 2b-ii / "
             "delegation-lifecycle-contract §T5).\n"
+        )
+        # Issue #478: a Pattern C gitignored_repo_root self-edit run keeps
+        # its CLAUDE.local.md inside the claude-org repo root (worker_dir ==
+        # root), so the worktree-remove path the secretary runs at close has
+        # no directory to reclaim it. Delete the brief here while we have the
+        # connection. No-op for every other pattern/variant. The non-PR
+        # close path (gitignored tasks rarely produce a merged PR) must call
+        # this helper from the runbook too — see org-pull-request 2b-ii.
+        cleanup_pattern_c_local_md(
+            conn,
+            task_id=resolved_task_id,
+            claude_org_root=db_path.parent.parent,
         )
         return RESULT_MERGED
     finally:

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -56,6 +56,30 @@ def _seed_run(db_path: Path, *, pr_url: str = PR_URL, branch: str = BRANCH,
         conn.close()
 
 
+def _seed_pattern_c_run(db_path: Path, *, worker_dir: str, pattern: str = "C",
+                        task_id: str = TASK_ID) -> None:
+    """Seed a run linked to a worker_dir, for the Issue #478 cleanup tests.
+
+    ``worker_dir`` is registered first so ``upsert_run`` can resolve it to a
+    ``worker_dir_id`` within the same transaction.
+    """
+    apply_schema(connect(db_path))
+    conn = connect(db_path)
+    try:
+        with StateWriter(conn).transaction() as w:
+            w.register_worker_dir(abs_path=worker_dir, is_git_repo=True)
+            w.upsert_run(
+                task_id=task_id,
+                project_slug="claude-org-ja",
+                pattern=pattern,
+                title="pattern C self-edit",
+                status="review",
+                worker_dir_abs_path=worker_dir,
+            )
+    finally:
+        conn.close()
+
+
 def _make_pr_view(*, merged_at=MERGED_AT, merge_oid=MERGE_OID) -> dict:
     return {
         "number": PR,
@@ -323,6 +347,125 @@ class CLITests(unittest.TestCase):
                     "--db-path", str(db),
                 ])
             self.assertEqual(rc, 3)
+
+
+class CleanupPatternCTests(unittest.TestCase):
+    """Issue #478: Pattern C gitignored_repo_root CLAUDE.local.md cleanup."""
+
+    def _brief_path(self, root: Path) -> Path:
+        return root / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME
+
+    def test_pattern_c_at_root_removes_brief_and_records_event(self) -> None:
+        """Case 1: Pattern C + worker_dir == claude_org_root → delete + event."""
+        with TempDB() as db:
+            root = db.parent
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(root.resolve()))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(result, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertFalse(brief.exists())
+            evts = _events_of_kind(db, "pattern_c_cleanup")
+            self.assertEqual(len(evts), 1)
+            payload = json.loads(evts[0]["payload_json"])
+            self.assertEqual(payload["task"], TASK_ID)
+            self.assertEqual(payload["mode"], "auto")
+            self.assertEqual(
+                payload["removed_path"],
+                str(root.resolve() / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME),
+            )
+
+    def test_pattern_c_ephemeral_does_nothing(self) -> None:
+        """Case 2: Pattern C ephemeral (worker_dir != root) → no-op, no event."""
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(ephemeral.resolve()))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_pattern_a_and_b_do_nothing(self) -> None:
+        """Case 3: even with worker_dir == root, non-C patterns are no-ops."""
+        for pattern in ("A", "B"):
+            with self.subTest(pattern=pattern), TempDB() as db:
+                root = db.parent
+                brief = self._brief_path(root)
+                brief.write_text("untouched\n", encoding="utf-8")
+                _seed_pattern_c_run(
+                    db, worker_dir=str(root.resolve()), pattern=pattern,
+                )
+                conn = connect(db)
+                try:
+                    result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                        conn, task_id=TASK_ID, claude_org_root=root,
+                    )
+                finally:
+                    conn.close()
+                self.assertEqual(
+                    result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+                )
+                self.assertTrue(brief.exists())
+                self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_idempotent_second_call_when_absent(self) -> None:
+        """Case 4: re-call after the brief is gone does not raise."""
+        with TempDB() as db:
+            root = db.parent
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=str(root.resolve()))
+            conn = connect(db)
+            try:
+                first = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+                second = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(first, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertEqual(second, run_complete_on_merge.CLEANUP_ABSENT)
+            self.assertFalse(brief.exists())
+            modes = [
+                json.loads(e["payload_json"])["mode"]
+                for e in _events_of_kind(db, "pattern_c_cleanup")
+            ]
+            self.assertEqual(modes, ["auto", "skip"])
+
+    def test_no_run_row_is_not_applicable(self) -> None:
+        """A task_id with no run row resolves cleanly to not_applicable."""
+        with TempDB() as db:
+            apply_schema(connect(db))
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id="ghost-task", claude_org_root=db.parent,
+                )
+            finally:
+                conn.close()
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#479](https://github.com/suisya-systems/claude-org-ja/pull/479)

Merge SHA: `ee44054c21045a69c2284f5b25ab3f54d8cbdd6a`

Source: ja PR [#479](https://github.com/suisya-systems/claude-org-ja/pull/479)
Merge SHA: `ee44054c21045a69c2284f5b25ab3f54d8cbdd6a`

| class | count |
|---|---|
| runtime | 2 |
| translation | 3 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tools/run_complete_on_merge.py`
- `tools/test_run_complete_on_merge.py`

</details>
<details><summary>translation (3)</summary>

- `.claude/skills/org-delegate/references/claude-org-self-edit.md`
- `.claude/skills/org-pull-request/SKILL.md`
- `docs/contracts/role-pattern-sandbox-contract.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
