### PR TITLE
auto-mirror: ja#483 fix(delegate): fetch origin before Pattern B worktree creation so it branches off latest main (Closes #480)

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -1331,6 +1331,19 @@ class TestPatternBClaudeOrgRepoWorktreePlan(unittest.TestCase):
             claude_org_root=self.sb.claude_org_root,
             state_db_path=self.sb.db_path,
         )
+        # Issue #480: apply now `git fetch origin` before branching. Detection
+        # above needed the github origin URL, but the fetch must stay offline —
+        # repoint origin at a local (empty) bare repo. The synthesized
+        # origin/main remote-tracking ref survives the no-op fetch and is what
+        # the worktree branches off (this test asserts registration, not fetch
+        # freshness — see TestPatternBWorktreeFetchesStaleOrigin for that).
+        upstream = Path(self._td.name) / "claude-org-upstream.git"
+        _sp.run(["git", "init", "-q", "--bare", str(upstream)], check=True)
+        _sp.run(
+            ["git", "-C", str(self.clone), "remote", "set-url", "origin",
+             str(upstream)],
+            check=True,
+        )
         gdp.apply_delegate_plan(
             plan,
             state_db_path=self.sb.db_path,
@@ -1735,6 +1748,194 @@ class TestPatternOverrideCLI(unittest.TestCase):
                 *self._common_args(slug="claude-org-ja"),
                 "--pattern", "A",
             ])
+
+
+# ---------------------------------------------------------------------------
+# Issue #480: apply must fetch origin before branching the Pattern B worktree
+# ---------------------------------------------------------------------------
+
+
+class TestFetchBaseOrigin(unittest.TestCase):
+    """Unit coverage for :func:`gen_delegate_payload._fetch_base_origin`
+    (Issue #480): refresh the base clone's remote-tracking refs before a
+    Pattern B worktree branches off them, best-effort."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.repo = Path(self._td.name) / "repo"
+        self.repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.repo), "init", "-q", "-b", "main"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_skips_quietly_when_no_origin_remote(self):
+        """No origin remote (local-only repo / synthetic-ref fixture) → no
+        fetch attempt, no raise, no output."""
+        import contextlib
+        import io
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            # Must not raise even though there is nothing to fetch.
+            gdp._fetch_base_origin(self.repo)
+        self.assertEqual(err.getvalue(), "")
+
+    def test_raises_when_fetch_fails(self):
+        """An origin pointing at an unreachable (local, nonexistent) path must
+        abort with WorktreeApplyError — branching off a possibly-stale
+        origin/main is exactly the Issue #480 bug, so apply fails closed
+        instead of silently proceeding."""
+        bogus = Path(self._td.name) / "does-not-exist.git"
+        subprocess.run(
+            ["git", "-C", str(self.repo), "remote", "add", "origin",
+             str(bogus)],
+            check=True,
+        )
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp._fetch_base_origin(self.repo)
+        self.assertIn("git fetch origin", str(cm.exception))
+        self.assertIn("480", str(cm.exception))
+
+
+class TestPatternBWorktreeFetchesStaleOrigin(unittest.TestCase):
+    """Issue #480: apply must ``git fetch origin`` before branching the
+    Pattern B worktree, so a base clone that has fallen behind origin still
+    branches off the *latest* remote default-branch tip — not the stale local
+    ``origin/main`` captured at the last fetch."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        # A local non-bare repo plays the role of the GitHub remote; we commit
+        # directly in its working tree to "advance origin" mid-test.
+        self.upstream = Path(self._td.name) / "upstream"
+        self.upstream.mkdir()
+        self._git(self.upstream, "init", "-q", "-b", "main")
+        (self.upstream / "trunk.txt").write_text("v1", encoding="utf-8")
+        self._git(self.upstream, "add", "trunk.txt")
+        self._git(self.upstream, "commit", "-q", "-m", "c1")
+        self.c1 = self._rev(self.upstream, "main")
+        # claude_org_root is a clone of upstream: a real origin remote,
+        # origin/main + origin/HEAD set, local main == c1.
+        base = self.sb.claude_org_root
+        self._git(base, "init", "-q", "-b", "main")
+        self._git(base, "remote", "add", "origin", str(self.upstream))
+        self._git(base, "fetch", "-q", "origin")
+        self._git(base, "symbolic-ref", "refs/remotes/origin/HEAD",
+                  "refs/remotes/origin/main")
+        self._git(base, "reset", "-q", "--hard", "origin/main")
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, env=self._git_env,
+        )
+
+    def _rev(self, repo: Path, ref: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(repo), "rev-parse", ref],
+        ).decode().strip()
+
+    def _build_self_edit_b(self, *, task_id: str):
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="claude-org-ja",
+            description="self-edit pattern B",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={
+                "pattern": "B",
+                "pattern_variant": "live_repo_worktree",
+                "role": "claude-org-self-edit",
+                "self_edit": True,
+            },
+        )
+
+    def test_apply_fetches_so_worktree_branches_off_latest_origin(self):
+        # Advance the upstream trunk to c2 AFTER the base clone last fetched,
+        # so the base's local origin/main is now stale (still c1).
+        (self.upstream / "trunk.txt").write_text("v2", encoding="utf-8")
+        self._git(self.upstream, "add", "trunk.txt")
+        self._git(self.upstream, "commit", "-q", "-m", "c2")
+        c2 = self._rev(self.upstream, "main")
+        self.assertNotEqual(self.c1, c2)
+        # Precondition: the base clone is stale — origin/main still points at c1.
+        self.assertEqual(
+            self._rev(self.sb.claude_org_root, "refs/remotes/origin/main"),
+            self.c1,
+        )
+
+        plan = self._build_self_edit_b(task_id="stale-origin-task")
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+
+        worker_dir = Path(plan.layout.worker_dir)
+        self.assertEqual(
+            self._rev(worker_dir, "HEAD"), c2,
+            "apply must `git fetch origin` and branch the worktree off the "
+            "latest origin tip (c2), not the base clone's stale origin/main "
+            "(c1)",
+        )
+        # The worktree reflects c2's content, not c1's.
+        self.assertEqual(
+            (worker_dir / "trunk.txt").read_text(encoding="utf-8"), "v2",
+        )
+        # The fetch also advanced the base clone's own origin/main.
+        self.assertEqual(
+            self._rev(self.sb.claude_org_root, "refs/remotes/origin/main"), c2,
+        )
+
+    def test_apply_aborts_when_fetch_fails_without_leaking_db_row(self):
+        """Fail-closed: an origin that cannot be fetched aborts apply rather
+        than branching off a possibly-stale ref (Issue #480). The abort runs
+        before the DB reservation, so no queued run row leaks (which would
+        otherwise steer the next delegation onto another Pattern B branch)."""
+        # Repoint origin at a nonexistent path so the pre-branch fetch fails.
+        self._git(self.sb.claude_org_root, "remote", "set-url", "origin",
+                  str(Path(self._td.name) / "gone.git"))
+        plan = self._build_self_edit_b(task_id="fetch-fail-task")
+        with self.assertRaises(gdp.WorktreeApplyError) as cm:
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        self.assertIn("480", str(cm.exception))
+        self.assertFalse(
+            any(r["task_id"] == "fetch-fail-task" for r in self.sb.list_runs()),
+            "queued row leaked after fetch-failure abort",
+        )
+        # No worktree was created.
+        self.assertFalse(Path(plan.layout.worker_dir).exists())
 
 
 if __name__ == "__main__":

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -478,6 +478,10 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
 
     Returns ``None`` when ``origin/HEAD`` is not set — apply then aborts
     with a recovery hint pointing to ``git remote set-head origin --auto``.
+
+    Freshness of the returned ref is the caller's job: :func:`_ensure_worktree`
+    runs :func:`_fetch_base_origin` immediately before this, so ``origin/HEAD``
+    reflects the live remote tip rather than a stale local clone (Issue #480).
     """
     proc = subprocess.run(
         ["git", "-C", str(base_repo), "symbolic-ref", "--short",
@@ -489,6 +493,52 @@ def _resolve_base_ref(base_repo: Path) -> Optional[str]:
         if ref:
             return ref
     return None
+
+
+def _fetch_base_origin(base_repo: Path) -> None:
+    """Refresh ``base_repo``'s remote-tracking refs before a Pattern B
+    worktree is branched off them (Issue #480).
+
+    :func:`_resolve_base_ref` branches the new worktree off ``origin/HEAD``
+    (i.e. ``origin/main``) — a *remote-tracking* ref only as fresh as the base
+    clone's last ``git fetch``. A stale clone (e.g. another PR merged into the
+    trunk after the last local fetch) would silently branch off an out-of-date
+    commit, so the worker starts from a trunk missing already-merged work — the
+    logical conflict / rework this fix eliminates. Fetching here makes the
+    start ref the live remote tip.
+
+    Fail-closed: the freshness guarantee only holds if the fetch actually
+    succeeds, so a configured ``origin`` whose fetch fails aborts apply with a
+    recovery hint (consistent with :func:`_resolve_base_ref` aborting on an
+    unset ``origin/HEAD``) rather than silently branching off a possibly-stale
+    ref — that silent path is exactly the Issue #480 bug. ``_ensure_worktree``
+    runs before any DB reservation, so the abort leaks no ``queued`` run row.
+
+    The only quiet path is "no ``origin`` remote configured": purely local
+    repos (and the test fixtures that synthesize ``refs/remotes/origin/*``
+    without a real remote) have nothing to fetch.
+    """
+    probe = subprocess.run(
+        ["git", "-C", str(base_repo), "remote", "get-url", "origin"],
+        capture_output=True,
+    )
+    if probe.returncode != 0:
+        return  # no origin remote — nothing to refresh
+    proc = subprocess.run(
+        ["git", "-C", str(base_repo), "fetch", "origin"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise WorktreeApplyError(
+            f"`git fetch origin` failed (rc={proc.returncode}) in {base_repo} "
+            f"before creating the Pattern B worktree: {stderr}. Refusing to "
+            "branch off a possibly-stale origin/main (Issue #480). Fix the "
+            f"network / remote and retry apply (or run `git -C {base_repo} "
+            "fetch origin` manually first). If this base is intentionally "
+            "offline / local-only, remove its `origin` remote so apply skips "
+            "the fetch."
+        )
 
 
 def _worktree_branch(worker_dir: Path) -> Optional[str]:
@@ -540,6 +590,13 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
     of ``base_repo``. Aborts with :class:`WorktreeApplyError` when the dir
     exists with unrelated content (Secretary judgment call to clean up,
     per Issue #309).
+
+    The Issue #480 origin fetch gates *creation* only. A reused worktree
+    keeps the start ref it was created from — re-fetching here would not move
+    its already-committed branch tip, and force-resetting it could clobber
+    work a worker has already committed on a partial-retry. To re-base a stale
+    reused worktree the Secretary removes it so apply recreates it (which then
+    fetches). See the reuse branch below.
     """
     if plan.layout.pattern != "B":
         return
@@ -555,7 +612,11 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
         # branch the brief / DB will pin. A stale partial-retry worktree on
         # a different branch (or in detached-HEAD state) would otherwise
         # silently dispatch on the wrong ref (Codex Round 2 + Round 3
-        # Majors 2026-05-06).
+        # Majors 2026-05-06). We deliberately do NOT fetch / re-base here
+        # (Issue #480): the worktree already has a committed branch tip, so a
+        # fetch can't advance it and a reset could discard a worker's
+        # in-progress commits. Refresh = remove the worktree so the creation
+        # path below recreates it off a freshly fetched origin/HEAD.
         expected = plan.layout.planned_branch
         if expected:
             actual = _worktree_branch(worker_dir)
@@ -590,6 +651,9 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
             f"Pattern B requires a planned_branch but layout produced None "
             f"(task_id={plan.task_id!r})."
         )
+    # Issue #480: refresh remote-tracking refs first so we branch off the
+    # *current* origin/HEAD, not a stale local clone's old origin/main.
+    _fetch_base_origin(plan.base_repo)
     base_ref = _resolve_base_ref(plan.base_repo)
     if base_ref is None:
         raise WorktreeApplyError(


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#483](https://github.com/suisya-systems/claude-org-ja/pull/483)

Merge SHA: `58b3de4a38fe647be53e5a77a2bf60c79121c14c`

Source: ja PR [#483](https://github.com/suisya-systems/claude-org-ja/pull/483)
Merge SHA: `58b3de4a38fe647be53e5a77a2bf60c79121c14c`

| class | count |
|---|---|
| runtime | 2 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_gen_delegate_payload.py`
- `tools/gen_delegate_payload.py`

</details>
<details><summary>translation (2)</summary>

- `.claude/skills/org-delegate/SKILL.md`
- `.claude/skills/org-delegate/references/release-pre-fetch.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
