### PR TITLE
auto-mirror: ja#488 fix(close-phase): make Pattern C CLAUDE.local.md cleanup order-independent of remove_worker_dir (Closes #486)

### DIFF
--- a/tools/run_complete_on_merge.py
+++ b/tools/run_complete_on_merge.py
@@ -88,15 +88,32 @@ def cleanup_pattern_c_local_md(
     *,
     task_id: str,
     claude_org_root: Path,
+    worker_dir_abs: Optional[str] = None,
 ) -> str:
     """Remove a leftover ``CLAUDE.local.md`` from the claude-org repo root
     for a Pattern C ``gitignored_repo_root`` self-edit run (Issue #478).
 
     Detection (design judgment 1 of Issue #478): ``runs.pattern == 'C'`` AND
-    the run's ``worker_dirs.abs_path`` equals ``claude_org_root``. This needs
-    no schema change — Pattern C *ephemeral* has ``worker_dir`` at
+    the run's worker_dir equals ``claude_org_root``. This needs no schema
+    change — Pattern C *ephemeral* has ``worker_dir`` at
     ``{workers_dir}/{task_id}`` (≠ root), so it is reclaimed by ordinary dir
     removal and naturally falls through here as ``not_applicable``.
+
+    The worker_dir is resolved from the live ``runs.worker_dir_id`` →
+    ``worker_dirs`` join, which stays authoritative whenever the row is
+    present, and only falls back to the explicit ``worker_dir_abs`` argument
+    when that join yields ``NULL``. Issue #486: the close-phase runbook calls
+    ``StateWriter.remove_worker_dir()`` which DELETEs the ``worker_dirs`` row,
+    and ``runs.worker_dir_id`` is ``ON DELETE SET NULL`` (schema.sql:84), so a
+    cleanup invoked *after* the removal would see ``abs_path = NULL`` through
+    the join and no-op even for a genuine gitignored_repo_root run. Callers
+    that are about to (or just did) drop the worker_dirs row pass the path they
+    hold via ``worker_dir_abs`` so detection stays order-independent. The
+    fallback is deliberately *not* an override: while the row is live the DB
+    value wins, so a caller that mistakenly passes ``root`` for a Pattern C
+    *ephemeral* run cannot trick the helper into deleting ``root``'s brief. The
+    in-process PR-merge path (:func:`complete_on_merge`) leaves the row in
+    place and so always uses the join value.
 
     Idempotent: ``Path.unlink(missing_ok=True)`` never raises on a missing
     file, and a re-call after the brief is gone returns
@@ -118,7 +135,11 @@ def cleanup_pattern_c_local_md(
     if row is None:
         return CLEANUP_NOT_APPLICABLE
     pattern = (row["pattern"] or "").upper()
-    worker_dir = row["abs_path"]
+    # The live join is authoritative; only fall back to the caller-supplied
+    # path when the worker_dirs row is already gone (Issue #486:
+    # remove_worker_dir() NULLs the join via ON DELETE SET NULL). Keeping the
+    # DB value in front means a stray worker_dir_abs cannot override a live row.
+    worker_dir = row["abs_path"] if row["abs_path"] is not None else worker_dir_abs
     if pattern != "C" or not worker_dir:
         return CLEANUP_NOT_APPLICABLE
 

--- a/tools/test_run_complete_on_merge.py
+++ b/tools/test_run_complete_on_merge.py
@@ -468,5 +468,156 @@ class CleanupPatternCTests(unittest.TestCase):
             )
 
 
+class CleanupPatternCCloseOrderTests(unittest.TestCase):
+    """Issue #486: cleanup must fire even after remove_worker_dir().
+
+    The org-pull-request close-phase StateWriter block runs
+    ``remove_worker_dir()`` (DELETE on worker_dirs), and ``runs.worker_dir_id``
+    is ``ON DELETE SET NULL``. A cleanup that resolves the worker_dir via the
+    live join therefore sees ``abs_path = NULL`` and no-ops, leaving the
+    Pattern C gitignored_repo_root ``CLAUDE.local.md`` behind. The fix is the
+    explicit ``worker_dir_abs`` argument, which survives the row removal.
+    """
+
+    def _brief_path(self, root: Path) -> Path:
+        return root / run_complete_on_merge.PATTERN_C_BRIEF_FILENAME
+
+    def _close_remove_worker_dir(self, db: Path, abs_path: str) -> None:
+        """Mimic the SKILL StateWriter close block: status flip + row delete."""
+        conn = connect(db)
+        try:
+            with StateWriter(conn).transaction() as w:
+                w.update_run_status(TASK_ID, "completed")
+                w.remove_worker_dir(abs_path)
+        finally:
+            conn.close()
+
+    def test_cleanup_after_remove_with_worker_dir_abs_fires(self) -> None:
+        """The fix: passing worker_dir_abs keeps cleanup firing post-removal."""
+        with TempDB() as db:
+            root = db.parent
+            abs_path = str(root.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=abs_path)
+
+            # Close-phase ordering: worker_dirs row is gone before cleanup.
+            self._close_remove_worker_dir(db, abs_path)
+
+            conn = connect(db)
+            try:
+                # Sanity: the join no longer resolves the worker_dir.
+                row = conn.execute(
+                    "SELECT d.abs_path FROM runs r "
+                    "LEFT JOIN worker_dirs d ON d.id = r.worker_dir_id "
+                    "WHERE r.task_id = ?",
+                    (TASK_ID,),
+                ).fetchone()
+                self.assertIsNone(row["abs_path"])
+
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=abs_path,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(result, run_complete_on_merge.CLEANUP_REMOVED)
+            self.assertFalse(brief.exists())
+            evts = _events_of_kind(db, "pattern_c_cleanup")
+            self.assertEqual(len(evts), 1)
+            self.assertEqual(json.loads(evts[0]["payload_json"])["mode"], "auto")
+
+    def test_cleanup_after_remove_without_abs_regresses_to_noop(self) -> None:
+        """Root cause: the join-only path no-ops once the row is deleted.
+
+        Without ``worker_dir_abs`` the helper falls back to the live join,
+        which returns NULL after remove_worker_dir() — exactly the Issue #486
+        bug this test pins. The brief is (incorrectly) left behind.
+        """
+        with TempDB() as db:
+            root = db.parent
+            abs_path = str(root.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("worker brief\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=abs_path)
+
+            self._close_remove_worker_dir(db, abs_path)
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_worker_dir_abs_ephemeral_stays_noop(self) -> None:
+        """worker_dir_abs for an ephemeral C run (≠ root) must not delete."""
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            eph_abs = str(ephemeral.resolve())
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            _seed_pattern_c_run(db, worker_dir=eph_abs)
+
+            self._close_remove_worker_dir(db, eph_abs)
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=eph_abs,
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+    def test_live_row_wins_over_stray_worker_dir_abs(self) -> None:
+        """Codex Major: a stray worker_dir_abs must not override a live row.
+
+        While the worker_dirs row is still present (ephemeral C: abs_path
+        != root), a caller that mistakenly passes root via worker_dir_abs
+        must NOT delete root's brief — the DB value stays authoritative.
+        """
+        with TempDB() as db:
+            root = db.parent
+            ephemeral = root / "ephemeral_worker"
+            ephemeral.mkdir()
+            brief = self._brief_path(root)
+            brief.write_text("untouched\n", encoding="utf-8")
+            # Row is left in place (no remove_worker_dir): join resolves to
+            # the ephemeral dir, so root must be ignored.
+            _seed_pattern_c_run(db, worker_dir=str(ephemeral.resolve()))
+
+            conn = connect(db)
+            try:
+                result = run_complete_on_merge.cleanup_pattern_c_local_md(
+                    conn, task_id=TASK_ID, claude_org_root=root,
+                    worker_dir_abs=str(root.resolve()),  # stray override attempt
+                )
+            finally:
+                conn.close()
+
+            self.assertEqual(
+                result, run_complete_on_merge.CLEANUP_NOT_APPLICABLE
+            )
+            self.assertTrue(brief.exists())
+            self.assertEqual(_events_of_kind(db, "pattern_c_cleanup"), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#488](https://github.com/suisya-systems/claude-org-ja/pull/488)

Merge SHA: `222b94213d06bfc1e101a4bb08e0676275832495`

Source: ja PR [#488](https://github.com/suisya-systems/claude-org-ja/pull/488)
Merge SHA: `222b94213d06bfc1e101a4bb08e0676275832495`

| class | count |
|---|---|
| runtime | 2 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tools/run_complete_on_merge.py`
- `tools/test_run_complete_on_merge.py`

</details>
<details><summary>translation (2)</summary>

- `.claude/skills/org-delegate/references/claude-org-self-edit.md`
- `.claude/skills/org-pull-request/SKILL.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
