### PR TITLE
auto-mirror: ja#490 fix(claude): unify Pattern A/B worker_dir + atomic apply + _repo_clone fallback (Closes #489)

### DIFF
--- a/tests/test_gen_delegate_payload.py
+++ b/tests/test_gen_delegate_payload.py
@@ -25,6 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from tools import gen_delegate_payload as gdp  # noqa: E402
+from tools import gen_worker_brief as gwb  # noqa: E402
 from tools.state_db import apply_schema, connect  # noqa: E402
 from tools.state_db.writer import StateWriter  # noqa: E402
 
@@ -184,6 +185,63 @@ class TestBuildDelegatePlan(unittest.TestCase):
         # audit on Pattern A worker dir (which is outside claude-org).
         # (claude-org-ja audit uses Pattern A → workers/claude-org-ja/.)
         self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+
+
+class TestIssue484AliasRemoteRow(unittest.TestCase):
+    """End-to-end (``build_delegate_plan``) coverage for the Issue #484 repro:
+    a remote project registered under the alias *name* ``claude-org-en`` with
+    a clone URL, dispatched on the first delegation (no local mirror clone, no
+    state-DB run). Both bugs must be fixed together:
+
+    - bug 2: resolves to Pattern A (clone the URL), not Pattern C ephemeral.
+    - bug 1: renders the *normal* brief (CLAUDE.md) with no self-edit
+      ``直接編集すること`` directive — the worker clones the EN upstream rather
+      than being told to edit the live claude-org-ja repo in place.
+    """
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # Replace the default registry with an alias-named remote URL row.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計アプリ | clock-app | - | Web 時計 | デザイン |\n"
+            "| claude-org-en | claude-org-en | "
+            "https://github.com/suisya-systems/claude-org | EN upstream | 翻訳同期 |\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_alias_remote_row_pattern_a_normal_brief(self):
+        plan = gdp.build_delegate_plan(
+            task_id="en-translation-sync-v2",
+            project_slug="claude-org-en",
+            description="translation sync",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        # bug 2: Pattern A, anchored on the registered alias name.
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNone(plan.layout.pattern_variant)
+        self.assertFalse(plan.layout.self_edit)
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+        # The DELEGATE body advertises a clone source (Pattern A label).
+        self.assertIn("clone or reuse:", plan.delegate_body)
+        self.assertIn(
+            "https://github.com/suisya-systems/claude-org", plan.delegate_body
+        )
+        # bug 1: non-self-edit brief, no in-place-edit directive.
+        self.assertEqual(plan.brief_out_path.name, "CLAUDE.md")
+        brief = gwb.render(plan.config)
+        self.assertNotIn("直接編集すること", brief)
+        self.assertNotIn("ルート CLAUDE.md", brief)
 
 
 # ---------------------------------------------------------------------------
@@ -1936,6 +1994,624 @@ class TestPatternBWorktreeFetchesStaleOrigin(unittest.TestCase):
         )
         # No worktree was created.
         self.assertFalse(Path(plan.layout.worker_dir).exists())
+
+
+# ---------------------------------------------------------------------------
+# Issue #489: preview warnings/blocking_warnings surface + atomic apply
+# rollback when post-reservation steps fail (Codex review (d) + Blocker 2)
+# ---------------------------------------------------------------------------
+
+
+class TestIssue489PreviewWarnings(unittest.TestCase):
+    """Issue #489 (d): preview must surface
+
+    - ``warnings``: non-blocking notes (legacy ``_repo_clone`` layout in use).
+    - ``blocking_warnings``: layout integrity refused apply (non-git
+      ``workers/<slug>/`` with Pattern A residue and no usable base).
+
+    Both are exposed in the preview JSON at the top level (and mirrored
+    in ``summary``); the human preview emits them to stderr and exits
+    nonzero on blocking_warnings. ``apply`` raises
+    :class:`gdp.BlockingPreviewWarningError` rather than touching the
+    DB / filesystem.
+    """
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # URL-only registry for renga — the Issue #489 motivating shape.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| renga | renga | https://github.com/suisya-systems/renga.git "
+            "| Renga | dev |\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _clone(self, path: Path, origin: str) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "-C", str(path), "init", "-q"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(path), "remote", "add", "origin", origin],
+            check=True,
+        )
+
+    def test_non_git_workers_slug_with_residue_emits_blocking_warning(self):
+        """``workers/renga/`` is a plain directory holding leftover
+        Pattern-A artifacts (CLAUDE.md / send_plan.json), and no
+        ``_repo_clone`` fallback exists — apply would be ambiguous, so
+        preview refuses."""
+        slug_dir = self.sb.workers / "renga"
+        slug_dir.mkdir()
+        (slug_dir / "CLAUDE.md").write_text("old brief", encoding="utf-8")
+        (slug_dir / "send_plan.json").write_text("{}", encoding="utf-8")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-blocked-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertTrue(plan.blocking_warnings)
+        self.assertTrue(
+            any("Pattern-A residue" in w for w in plan.blocking_warnings)
+        )
+        # Summary mirrors top-level + base_repo is None for this shape.
+        self.assertIsNone(plan.base_repo)
+        summary = plan.to_summary_dict()
+        self.assertEqual(summary["blocking_warnings"], plan.blocking_warnings)
+
+    def test_legacy_repo_clone_emits_non_blocking_deprecation_warning(self):
+        """``_repo_clone`` legacy fallback resolved → preview ships a
+        non-blocking deprecation warning so the deployment can migrate
+        to the canonical ``workers/<slug>/`` layout. Apply still
+        proceeds (warnings, not blocking_warnings)."""
+        slug_dir = self.sb.workers / "renga"
+        slug_dir.mkdir()
+        (slug_dir / "README.md").write_text("loose note", encoding="utf-8")
+        legacy = slug_dir / "_repo_clone"
+        self._clone(legacy, "https://github.com/suisya-systems/renga.git")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-legacy-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertFalse(plan.blocking_warnings)
+        self.assertTrue(plan.warnings)
+        self.assertTrue(any("_repo_clone" in w for w in plan.warnings))
+        # Codex Round 1 follow-up: Pattern A now carries ``base_repo`` when
+        # routed through the new unified ``<base>/.worktrees/<task>/``
+        # layout — without it, apply's ``_ensure_worktree`` would skip
+        # ``git worktree add`` for Pattern A entirely.
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(Path(plan.base_repo).resolve(), legacy.resolve())
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (legacy / ".worktrees" / "renga-legacy-task").resolve(),
+        )
+
+    def test_preview_json_exposes_warnings_at_top_level(self):
+        """JSON consumers (jq pipelines, dispatcher previews) read
+        ``warnings`` / ``blocking_warnings`` at the top level."""
+        slug_dir = self.sb.workers / "renga"
+        slug_dir.mkdir()
+        (slug_dir / "CLAUDE.md").write_text("old brief", encoding="utf-8")
+        from contextlib import redirect_stdout, redirect_stderr
+        from io import StringIO
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = gdp.main([
+                "preview",
+                "--task-id", "renga-blocked-cli",
+                "--project-slug", "renga",
+                "--description", "alt+p ux fix",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+                "--json",
+            ])
+        self.assertEqual(rc, 3, msg=f"stderr={err.getvalue()!r}")
+        data = json.loads(out.getvalue())
+        self.assertIn("blocking_warnings", data)
+        self.assertTrue(data["blocking_warnings"])
+        # Mirrored in summary too.
+        self.assertEqual(
+            data["blocking_warnings"], data["summary"]["blocking_warnings"]
+        )
+        # JSON path keeps stderr clean — the warning content is already in
+        # the JSON body. The human path (no ``--json``) separately writes
+        # a ``BLOCKING:`` marker to stderr; covered by
+        # :meth:`test_human_preview_writes_blocking_marker_to_stderr`.
+        self.assertEqual(err.getvalue(), "")
+
+    def test_human_preview_writes_blocking_marker_to_stderr(self):
+        """Human preview path (no ``--json``) emits a ``BLOCKING:`` line
+        per blocking_warning to stderr so a wrapper script can grep for
+        the marker. Exit code is 3, matching the JSON path."""
+        slug_dir = self.sb.workers / "renga"
+        slug_dir.mkdir()
+        (slug_dir / "CLAUDE.md").write_text("old brief", encoding="utf-8")
+        from contextlib import redirect_stdout, redirect_stderr
+        from io import StringIO
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = gdp.main([
+                "preview",
+                "--task-id", "renga-blocked-human",
+                "--project-slug", "renga",
+                "--description", "alt+p ux fix",
+                "--claude-org-root", str(self.sb.claude_org_root),
+                "--state-db-path", str(self.sb.db_path),
+            ])
+        self.assertEqual(rc, 3)
+        self.assertIn("BLOCKING:", err.getvalue())
+
+    def test_apply_refuses_when_plan_has_blocking_warnings(self):
+        """``apply_delegate_plan`` must not touch DB / filesystem when
+        the plan carries blocking_warnings — raise
+        :class:`BlockingPreviewWarningError` BEFORE the DB reservation
+        so no queued row leaks."""
+        slug_dir = self.sb.workers / "renga"
+        slug_dir.mkdir()
+        (slug_dir / "CLAUDE.md").write_text("old brief", encoding="utf-8")
+        plan = gdp.build_delegate_plan(
+            task_id="renga-blocked-apply",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        with self.assertRaises(gdp.BlockingPreviewWarningError):
+            gdp.apply_delegate_plan(
+                plan,
+                state_db_path=self.sb.db_path,
+                claude_org_root=self.sb.claude_org_root,
+                skip_settings=True,
+            )
+        runs = self.sb.list_runs()
+        self.assertFalse(
+            any(r["task_id"] == "renga-blocked-apply" for r in runs),
+            f"queued row leaked after blocking-warning abort: {runs}",
+        )
+
+    def test_local_path_registry_with_residue_is_not_blocking(self):
+        """Codex Round 3 Major regression: a project registered with a
+        real local clone path (``project.path = /repos/clock-app``) gets
+        ``base_repo`` derived from the registered path, NOT from
+        ``find_workers_dir_clone``. The blocking_warning logic must use
+        ``base_repo`` as the authoritative "is there a usable base?"
+        signal — otherwise leftover residue in ``workers/<slug>/`` would
+        false-positive even though apply could safely run worktree-add
+        from the registered local clone."""
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        local_repo = Path(self._td.name) / "registered-clock-app"
+        local_repo.mkdir()
+        subprocess.run(
+            ["git", "-C", str(local_repo), "init", "-q"], check=True
+        )
+        # Registry row points at the registered local clone (NOT at
+        # workers/<slug>/). This is the existing
+        # "test_apply_creates_plain_pattern_b_worktree_for_project_repo"
+        # shape with the extra wrinkle that workers/clock-app/ has
+        # leftover Pattern-A residue from an earlier dispatch.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            f"| 時計 | clock-app | {local_repo} | Demo clock | - |\n",
+            encoding="utf-8",
+        )
+        # Force Pattern B so the registered local path drives base_repo.
+        self.sb.add_active_run(
+            task_id="prev-clock-task",
+            project_slug="clock-app",
+            worker_dir=str(self.sb.workers / "clock-app"),
+        )
+        # Leftover Pattern-A residue in workers/clock-app/.
+        residue_dir = self.sb.workers / "clock-app"
+        residue_dir.mkdir(exist_ok=True)
+        (residue_dir / "CLAUDE.md").write_text("old", encoding="utf-8")
+        plan = gdp.build_delegate_plan(
+            task_id="clock-with-residue",
+            project_slug="clock-app",
+            description="non-blocking residue regression",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "B")
+        self.assertEqual(Path(plan.base_repo).resolve(), local_repo.resolve())
+        # Residue + leftover workers/<slug>/ exists, but base_repo is
+        # the registered local clone — no blocking_warning fires.
+        self.assertEqual(plan.blocking_warnings, [])
+
+    def test_no_warnings_when_canonical_clone_present(self):
+        """The clean Issue #489 canonical layout — clone at
+        ``workers/renga/`` directly — emits neither a deprecation
+        warning nor a blocker."""
+        self._clone(
+            self.sb.workers / "renga",
+            "https://github.com/suisya-systems/renga.git",
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="renga-canonical-task",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.warnings, [])
+        self.assertEqual(plan.blocking_warnings, [])
+
+
+class TestIssue489PatternAWorktreeCreation(unittest.TestCase):
+    """Issue #489 Codex Round 1 Blocker follow-up: when Pattern A resolves
+    to the unified ``<base>/.worktrees/<task>/`` layout (i.e. a real base
+    clone is detected at ``workers/<slug>/`` or its legacy ``_repo_clone``
+    subdir), ``apply`` must actually run ``git worktree add`` against
+    that base — not just mkdir an empty directory. ``base_repo`` is
+    populated on the plan so :func:`_ensure_worktree` fires for Pattern A
+    too."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        # Suppress sandbox-level git init so the per-test seed picks the
+        # ``main`` branch deterministically.
+        self.sb = _Sandbox(Path(self._td.name), with_claude_org_origin=False)
+        import os
+        self._git_env = os.environ.copy()
+        self._git_env.update(
+            {
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+        # Replace the auto-seeded registry with a renga URL-only row.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| renga | renga | https://github.com/suisya-systems/renga.git "
+            "| Renga | dev |\n",
+            encoding="utf-8",
+        )
+        # Build a local upstream whose filesystem path *contains* a
+        # ``github.com/suisya-systems/renga.git`` suffix so that the
+        # origin URL passes :func:`_origin_matches_registered`'s github
+        # gate AND ``git fetch origin`` succeeds locally. The gate uses
+        # a non-anchored regex search so the leading directory prefix
+        # is harmless; the trailing path is what matters.
+        self.upstream = (
+            Path(self._td.name)
+            / "github.com"
+            / "suisya-systems"
+            / "renga.git"
+        )
+        self.upstream.mkdir(parents=True)
+        self._git(self.upstream, "init", "-q", "-b", "main")
+        (self.upstream / "trunk.txt").write_text("v1", encoding="utf-8")
+        self._git(self.upstream, "add", "trunk.txt")
+        self._git(self.upstream, "commit", "-q", "-m", "c1")
+        # Clone (canonical layout) lives at workers/renga/. Point its
+        # origin at the github-named local upstream so the gate accepts
+        # AND the fetch can refresh remote-tracking refs.
+        self.clone = self.sb.workers / "renga"
+        self._git_init_match_origin(self.clone, str(self.upstream))
+        self._git(self.clone, "fetch", "-q", "origin")
+        self._git(self.clone, "symbolic-ref", "refs/remotes/origin/HEAD",
+                  "refs/remotes/origin/main")
+        self._git(self.clone, "reset", "-q", "--hard", "origin/main")
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, env=self._git_env,
+        )
+
+    def _git_init_match_origin(self, repo: Path, origin_url: str) -> None:
+        repo.mkdir(parents=True, exist_ok=True)
+        self._git(repo, "init", "-q", "-b", "main")
+        self._git(repo, "remote", "add", "origin", origin_url)
+
+    def test_apply_creates_pattern_a_worktree_when_base_clone_present(self):
+        """Plan must populate ``base_repo`` for Pattern A so apply runs
+        ``git worktree add`` against the canonical clone — without this
+        the worker lands in an empty ``<base>/.worktrees/<task>/``
+        directory rather than a real git checkout (Codex Round 1
+        Blocker)."""
+        plan = gdp.build_delegate_plan(
+            task_id="renga-pattern-a",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNotNone(plan.base_repo)
+        self.assertEqual(Path(plan.base_repo).resolve(), self.clone.resolve())
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.clone / ".worktrees" / "renga-pattern-a").resolve(),
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        worker_dir = Path(plan.layout.worker_dir)
+        self.assertTrue(worker_dir.exists())
+        # A real worktree has a ``.git`` entry (file or directory).
+        self.assertTrue((worker_dir / ".git").exists())
+        # The clone treats it as a registered worktree.
+        out = subprocess.check_output(
+            ["git", "-C", str(self.clone),
+             "worktree", "list", "--porcelain"],
+        ).decode("utf-8", errors="replace")
+        registered = {
+            Path(line[len("worktree "):].strip()).resolve()
+            for line in out.splitlines() if line.startswith("worktree ")
+        }
+        self.assertIn(worker_dir.resolve(), registered)
+        # Brief lands inside the worktree (not in workers/renga/ root).
+        self.assertTrue((worker_dir / "CLAUDE.md").exists())
+        self.assertFalse((self.sb.workers / "renga" / "CLAUDE.md").is_file())
+
+    def test_pattern_a_worktree_surfaces_sandbox_pattern_b_to_runtime(self):
+        """Codex Round 3 Blocker: ``settings_args["pattern"]`` is what
+        ``claude-org-runtime settings generate`` keys ``sandbox_by_pattern``
+        off. Pattern A's unified worktree layout needs Pattern B's
+        Git-metadata carve-outs (``<base>/.git/worktrees/<task>/``,
+        objects, branch ref, packed-refs) — without the override the
+        runtime selects A's sandbox and git commits inside the worktree
+        fail under bwrap. ``layout.pattern`` stays at ``A`` (first-run
+        label / DB row), only ``settings_args["pattern"]`` flips to B."""
+        plan = gdp.build_delegate_plan(
+            task_id="renga-sandbox-flip",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertEqual(plan.settings_args["pattern"], "B")
+        # base-clone is surfaced too so the runtime can substitute
+        # ``{base_clone}`` in B's sandbox body.
+        self.assertEqual(
+            plan.settings_args["base-clone"], str(self.clone.resolve())
+        )
+        # The cmd builder honors the override.
+        cmd = gdp._build_settings_generate_cmd(
+            plan.settings_args, runtime_cmd="claude-org-runtime"
+        )
+        self.assertEqual(cmd[cmd.index("--pattern") + 1], "B")
+        self.assertEqual(
+            cmd[cmd.index("--base-clone") + 1], str(self.clone.resolve())
+        )
+
+    def test_apply_skips_worktree_for_pattern_a_legacy_direct(self):
+        """When no base clone is detected (e.g. ``-`` placeholder
+        registry row, or a clone is simply missing), Pattern A keeps the
+        legacy ``workers/<slug>/`` direct layout and apply must NOT try
+        to ``git worktree add`` — ``base_repo`` stays None and
+        ``_ensure_worktree`` returns early."""
+        # Reset registry to a `-` placeholder so find_workers_dir_clone
+        # cannot resolve the renga clone we set up in setUp.
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| 時計 | clock-app | - | Demo clock | - |\n",
+            encoding="utf-8",
+        )
+        plan = gdp.build_delegate_plan(
+            task_id="clock-legacy",
+            project_slug="clock-app",
+            description="legacy direct",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(plan.layout.pattern, "A")
+        self.assertIsNone(plan.base_repo)
+        self.assertEqual(
+            Path(plan.layout.worker_dir),
+            (self.sb.workers / "clock-app").resolve(),
+        )
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        # Brief landed in the direct workers/<slug>/ — no worktree
+        # was created (no .git in workers/clock-app), but apply also
+        # did not fail.
+        wd = Path(plan.layout.worker_dir)
+        self.assertTrue((wd / "CLAUDE.md").exists())
+        self.assertFalse((wd / ".git").exists())
+
+
+class TestIssue489OverrideWorkerDirAlignment(unittest.TestCase):
+    """Issue #489 Codex Round 1 Major follow-up: ``--pattern A``/``B``
+    override must consult :func:`find_workers_dir_clone` so the
+    override-driven worker_dir lands on the same base the auto-derive
+    would pick (canonical ``workers/<slug>/`` OR legacy
+    ``workers/<slug>/_repo_clone/``). Previously the override
+    hardcoded ``workers/<slug>/.worktrees/`` which diverged whenever
+    the base lived under the legacy subdir."""
+
+    def setUp(self) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        (self.sb.claude_org_root / "registry" / "projects.md").write_text(
+            "# Projects\n\n"
+            "| 通称 | プロジェクト名 | パス | 説明 | よくある作業例 |\n"
+            "|---|---|---|---|---|\n"
+            "| renga | renga | https://github.com/suisya-systems/renga.git "
+            "| Renga | dev |\n",
+            encoding="utf-8",
+        )
+        # Legacy layout: clone parked under workers/renga/_repo_clone/.
+        (self.sb.workers / "renga").mkdir()
+        (self.sb.workers / "renga" / "README.md").write_text(
+            "loose note", encoding="utf-8"
+        )
+        self.legacy_clone = self.sb.workers / "renga" / "_repo_clone"
+        self.legacy_clone.mkdir()
+        subprocess.run(
+            ["git", "-C", str(self.legacy_clone), "init", "-q"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", str(self.legacy_clone), "remote", "add",
+             "origin", "https://github.com/suisya-systems/renga.git"],
+            check=True,
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_force_pattern_b_override_uses_repo_clone_base_path(self):
+        from tools import resolve_worker_layout as rwl
+
+        layout = rwl.resolve(
+            task_id="override-legacy-b",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "B"},
+        )
+        self.assertEqual(layout.pattern, "B")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.legacy_clone / ".worktrees" / "override-legacy-b").resolve(),
+        )
+
+    def test_force_pattern_a_override_uses_repo_clone_base_path(self):
+        from tools import resolve_worker_layout as rwl
+
+        layout = rwl.resolve(
+            task_id="override-legacy-a",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+            layout_overrides={"pattern": "A"},
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.legacy_clone / ".worktrees" / "override-legacy-a").resolve(),
+        )
+
+
+class TestIssue489AtomicApplyRollback(unittest.TestCase):
+    """Issue #489 Blocker 2: ``_reserve_in_db`` commits the queued run
+    row before ``_write_brief`` / ``_run_settings_generate`` /
+    ``_write_send_plan`` run. A failure in any of those post-reservation
+    steps leaves the queued row in place; resolver then sees Pattern A
+    as occupied on the next dispatch and silently flips to Pattern B.
+    The atomic-rollback layer wraps the post-reservation block and
+    compensates with ``status='abandoned'`` on failure so the leak is
+    closed."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _build_plain_a(self, task_id: str = "atomic-task") -> gdp.DelegatePlan:
+        return gdp.build_delegate_plan(
+            task_id=task_id,
+            project_slug="clock-app",
+            description="atomic apply",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+
+    def test_write_brief_failure_compensates_queued_run(self):
+        """Patch ``_write_brief`` to raise after the DB reservation
+        commits. Expect: the exception propagates, and the queued run
+        row is flipped to ``abandoned`` so a follow-up dispatch sees
+        Pattern A as free."""
+        plan = self._build_plain_a()
+        boom = RuntimeError("simulated disk failure during brief write")
+        from unittest.mock import patch
+
+        with patch.object(gdp, "_write_brief", side_effect=boom):
+            with self.assertRaises(RuntimeError) as cm:
+                gdp.apply_delegate_plan(
+                    plan,
+                    state_db_path=self.sb.db_path,
+                    claude_org_root=self.sb.claude_org_root,
+                    skip_settings=True,
+                )
+        self.assertIs(cm.exception, boom)
+        runs = self.sb.list_runs()
+        match = [r for r in runs if r["task_id"] == "atomic-task"]
+        self.assertEqual(len(match), 1, runs)
+        self.assertEqual(match[0]["status"], "abandoned")
+
+    def test_send_plan_write_failure_compensates_queued_run(self):
+        """Same contract for ``_write_send_plan`` — the last
+        post-reservation side effect must also be guarded."""
+        plan = self._build_plain_a(task_id="send-plan-fail")
+        boom = OSError("permission denied")
+        from unittest.mock import patch
+
+        with patch.object(gdp, "_write_send_plan", side_effect=boom):
+            with self.assertRaises(OSError):
+                gdp.apply_delegate_plan(
+                    plan,
+                    state_db_path=self.sb.db_path,
+                    claude_org_root=self.sb.claude_org_root,
+                    skip_settings=True,
+                )
+        match = [r for r in self.sb.list_runs() if r["task_id"] == "send-plan-fail"]
+        self.assertEqual(match[0]["status"], "abandoned")
+
+    def test_successful_apply_leaves_queued_run_intact(self):
+        """Sanity guard: on the happy path the queued row stays queued
+        (the rollback layer must be a no-op when nothing fails). The
+        next dispatcher T2 promotes it to ``in_use``."""
+        plan = self._build_plain_a(task_id="happy-task")
+        gdp.apply_delegate_plan(
+            plan,
+            state_db_path=self.sb.db_path,
+            claude_org_root=self.sb.claude_org_root,
+            skip_settings=True,
+        )
+        match = [r for r in self.sb.list_runs() if r["task_id"] == "happy-task"]
+        self.assertEqual(match[0]["status"], "queued")
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve_worker_layout.py
+++ b/tests/test_resolve_worker_layout.py
@@ -867,13 +867,20 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
         )
         self.assertEqual(layout.pattern, "A")
         self.assertIsNone(layout.pattern_variant)
-        self.assertEqual(Path(layout.worker_dir), self.clone.resolve())
+        # Issue #489 (Codex Round 2 Major): mirror Pattern A also routes
+        # into the unified ``<clone>/.worktrees/<task>/`` layout so it
+        # cannot collide with a concurrent Pattern B over the clone root.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.clone / ".worktrees" / "en-task-a").resolve(),
+        )
         self.assertEqual(layout.planned_branch, "feat/en-task-a")
 
     def test_pattern_a_for_claude_org_en_slug_anchors_on_clone(self):
         """slug=claude-org-en (registry-style alias) must still land on the
         same physical clone — the resolver overrides worker_dir off the
-        clone path, not the slug."""
+        clone path, not the slug. Issue #489 mirror Pattern A: under
+        ``.worktrees/<task>/`` rather than the clone root."""
         layout = rwl.resolve(
             task_id="en-task-en",
             project_slug="claude-org-en",
@@ -881,7 +888,10 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
             state_db_path=self.sb.db_path,
         )
         self.assertEqual(layout.pattern, "A")
-        self.assertEqual(Path(layout.worker_dir), self.clone.resolve())
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.clone / ".worktrees" / "en-task-en").resolve(),
+        )
 
     def test_pattern_b_for_claude_org_slug_emits_claude_org_repo_worktree(self):
         """Issue #370 repro 1: slug=claude-org with active concurrent run
@@ -1121,6 +1131,174 @@ class TestPatternBClaudeOrgRepoWorktree(unittest.TestCase):
         self.assertEqual(
             Path(layout.worker_dir),
             (self.sb.workers / "clock-app").resolve(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #484: a remote project registered under an alias *name* (e.g.
+# ``claude-org-en``) with a clone URL must resolve to Pattern A on the first
+# delegation, not fall through to Pattern C ephemeral. The alias normalization
+# (``claude-org-en`` → ``claude-org``) is for the local mirror's 通称; it must
+# not hide a registry row keyed by the alias name itself.
+# ---------------------------------------------------------------------------
+
+
+class TestAliasNamedRemoteRow(unittest.TestCase):
+    """Issue #484 bug 2: ``registry/projects.md`` carries
+    ``| … | claude-org-en | https://github.com/suisya-systems/claude-org | … |``
+    (the row's プロジェクト名/slug column is the alias). With no local
+    ``{workers_dir}/claude-org`` mirror clone present, the slug alias
+    normalization used to rewrite ``claude-org-en`` → ``claude-org`` *before*
+    the registry lookup, so ``find_project`` missed the row and the resolver
+    dropped to Pattern C ephemeral. The fix retries the lookup with the
+    original (un-normalized) slug and adopts the registered row."""
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_alias_named_url_row_resolves_pattern_a_first_delegation(self):
+        # No local mirror clone, empty state.db (no projects/runs rows) —
+        # the "first delegation" scenario from the Issue #484 repro.
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-translation-sync-v2",
+            project_slug="claude-org-en",
+            description="translation sync",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        # worker_dir keeps the registered alias name (not the mirror's
+        # canonical ``claude-org``) — this row is a distinct remote project.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+        self.assertEqual(layout.role, "default")
+        self.assertFalse(layout.self_edit)
+        self.assertEqual(layout.planned_branch, "feat/en-translation-sync-v2")
+
+    def test_alias_named_url_row_without_state_db(self):
+        """The registry row alone must drive Pattern A — no pre-existing
+        state-DB ``projects`` row required (``state_db_path=None``)."""
+        self.sb.write_registry(
+            [
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-first",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=None,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org-en").resolve(),
+        )
+
+    def test_canonical_named_row_still_normalizes_via_alias(self):
+        """Regression guard: the canonical registry shape
+        ``| claude-org-en | claude-org | URL | … |`` (通称=alias, name=canonical)
+        must still resolve via the alias slug to Pattern A — the original-slug
+        fallback only fires when the canonical lookup misses."""
+        self.sb.write_registry(
+            [
+                (
+                    "claude-org-en",
+                    "claude-org",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-canonical",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        # canonical name → worker_dir anchored on the canonical slug.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (self.sb.workers / "claude-org").resolve(),
+        )
+
+    def test_unknown_alias_with_no_row_still_pattern_c(self):
+        """Regression guard for the no-clone / no-row deployment: an alias
+        slug with neither a mirror clone nor any registry row must still fall
+        to Pattern C ephemeral (the original-slug fallback finds nothing)."""
+        self.sb.write_registry([("時計", "clock-app", "-", "Demo clock")])
+        layout = rwl.resolve(
+            task_id="en-orphan",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "C")
+        self.assertEqual(layout.pattern_variant, "ephemeral")
+
+    def test_mirror_clone_wins_over_alias_named_row(self):
+        """Codex review guard: when a local mirror clone exists at
+        ``{workers_dir}/claude-org`` AND an alias-named row is also present,
+        the Issue #370 mirror machinery must win (anchor on the clone) so the
+        resolver stays consistent with ``gen_delegate_payload``'s own
+        canonical normalization. The alias-row fallback must NOT hijack the
+        slug back to ``claude-org-en`` in that case."""
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            self.skipTest("git not available")
+        clone = self.sb.workers / "claude-org"
+        clone.mkdir()
+        _Sandbox.init_git_with_origin(
+            clone, "https://github.com/suisya-systems/claude-org.git"
+        )
+        self.sb.write_registry(
+            [
+                ("時計", "clock-app", "-", "Demo clock"),
+                (
+                    "claude-org-en",
+                    "claude-org-en",
+                    "https://github.com/suisya-systems/claude-org",
+                    "EN upstream",
+                ),
+            ]
+        )
+        layout = rwl.resolve(
+            task_id="en-with-clone",
+            project_slug="claude-org-en",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        # Anchored on the canonical mirror clone, NOT workers/claude-org-en.
+        # Issue #489: under ``.worktrees/<task>/`` (unified mirror layout).
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (clone / ".worktrees" / "en-with-clone").resolve(),
         )
 
 
@@ -1476,7 +1654,13 @@ class TestPatternOverrideContract(unittest.TestCase):
             layout_overrides={"pattern": "A"},
         )
         self.assertEqual(layout.pattern, "A")
-        self.assertEqual(Path(layout.worker_dir), clone.resolve())
+        # Issue #489 Codex Round 2: ``--pattern A`` on the claude-org
+        # mirror also routes into ``<clone>/.worktrees/<task>/`` so
+        # auto-derive and override agree on the unified layout.
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (clone / ".worktrees" / "force-a-mirror").resolve(),
+        )
 
     def test_variant_live_repo_worktree_requires_self_edit_role(self):
         """Codex Round 3 Blocker: ``pattern_variant=live_repo_worktree``
@@ -1544,6 +1728,271 @@ class TestPatternOverrideContract(unittest.TestCase):
         self.assertEqual(
             Path(layout.worker_dir),
             (self.sb.workers / "local-app" / ".worktrees" / "ok-b-local").resolve(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #489: Pattern A も worktree 化 + _repo_clone legacy fallback +
+# origin-gate共通化 (Codex review (b) + (c))
+# ---------------------------------------------------------------------------
+
+
+class TestIssue489ResolverPatternAWorktree(unittest.TestCase):
+    """Issue #489: when ``workers/<slug>/`` is a usable base clone (Issue
+    #450 URL-only registry case), Pattern A's worker_dir lives at
+    ``<base>/.worktrees/<task>/`` instead of ``<base>/`` directly so it
+    cannot collide with Pattern B over the same directory. The new
+    ``_repo_clone`` legacy fallback is exercised here too (case (c) in
+    the design review) — when the canonical ``workers/<slug>/`` is
+    non-git but a matching-origin clone is parked under
+    ``workers/<slug>/_repo_clone/``, the resolver still adopts it as a
+    base."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            raise unittest.SkipTest("git not available")
+
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.sb = _Sandbox(Path(self._td.name))
+        # URL-only registry row — the motivating Issue #489 collision shape.
+        self.sb.write_registry(
+            [
+                (
+                    "Renga",
+                    "renga",
+                    "https://github.com/suisya-systems/renga.git",
+                    "Renga app",
+                ),
+            ]
+        )
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _clone_at(self, path: Path, origin: str) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        _Sandbox.init_git_with_origin(path, origin)
+
+    def test_pattern_a_routes_into_worktree_when_workers_slug_is_base_clone(self):
+        """Canonical Issue #489 layout: ``workers/renga/`` IS a usable
+        base clone → Pattern A worker_dir lands in
+        ``workers/renga/.worktrees/<task>/`` rather than the legacy
+        ``workers/renga/`` (no more collision with Pattern B)."""
+        clone = self.sb.workers / "renga"
+        self._clone_at(clone, "https://github.com/suisya-systems/renga.git")
+        layout = rwl.resolve(
+            task_id="renga-first",
+            project_slug="renga",
+            description="alt+p ux fix",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertIsNone(layout.pattern_variant)
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (clone / ".worktrees" / "renga-first").resolve(),
+        )
+
+    def test_repo_clone_legacy_fallback_resolves_when_canonical_is_non_git(self):
+        """Case (c) success path: ``workers/renga/`` is a non-git
+        directory with leftover files; ``workers/renga/_repo_clone/`` is
+        the actual clone with matching origin. find_workers_dir_clone
+        adopts the legacy subdir; resolver routes Pattern A's worktree
+        under it."""
+        (self.sb.workers / "renga").mkdir()
+        (self.sb.workers / "renga" / "README.md").write_text(
+            "loose note", encoding="utf-8"
+        )
+        legacy = self.sb.workers / "renga" / "_repo_clone"
+        self._clone_at(legacy, "https://github.com/suisya-systems/renga.git")
+        base = rwl.find_workers_dir_clone(
+            "renga",
+            "https://github.com/suisya-systems/renga.git",
+            self.sb.workers,
+        )
+        self.assertIsNotNone(base)
+        self.assertEqual(Path(base).resolve(), legacy.resolve())
+        layout = rwl.resolve(
+            task_id="renga-legacy",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(layout.pattern, "A")
+        self.assertEqual(
+            Path(layout.worker_dir),
+            (legacy / ".worktrees" / "renga-legacy").resolve(),
+        )
+
+    def test_repo_clone_with_no_origin_is_rejected(self):
+        """Case (c) gate: a bare ``git init`` under ``_repo_clone/`` with
+        no origin remote must NOT be adopted as a base for a github-URL
+        registry row (Issue #370 origin gate now shared via
+        :func:`_origin_matches_registered`)."""
+        (self.sb.workers / "renga").mkdir()
+        legacy = self.sb.workers / "renga" / "_repo_clone"
+        legacy.mkdir()
+        subprocess.run(
+            ["git", "-C", str(legacy), "init", "-q"], check=True
+        )
+        base = rwl.find_workers_dir_clone(
+            "renga",
+            "https://github.com/suisya-systems/renga.git",
+            self.sb.workers,
+        )
+        self.assertIsNone(base)
+
+    def test_repo_clone_with_mismatched_origin_is_rejected(self):
+        """Case (c) gate: a ``_repo_clone/`` with origin pointing at a
+        different github repo must be rejected — would otherwise silently
+        redirect dispatch at an unrelated repo (Issue #370 precedent)."""
+        (self.sb.workers / "renga").mkdir()
+        legacy = self.sb.workers / "renga" / "_repo_clone"
+        self._clone_at(
+            legacy, "https://github.com/some-other-org/not-renga.git"
+        )
+        base = rwl.find_workers_dir_clone(
+            "renga",
+            "https://github.com/suisya-systems/renga.git",
+            self.sb.workers,
+        )
+        self.assertIsNone(base)
+
+    def test_canonical_clone_preferred_when_both_layouts_present(self):
+        """Sanity: if both the canonical ``workers/<slug>/`` and the
+        legacy ``workers/<slug>/_repo_clone/`` clone are present and
+        matching, the resolver prefers the canonical (no deprecation
+        warning needed downstream)."""
+        canonical = self.sb.workers / "renga"
+        self._clone_at(
+            canonical, "https://github.com/suisya-systems/renga.git"
+        )
+        legacy = canonical / "_repo_clone"
+        self._clone_at(legacy, "https://github.com/suisya-systems/renga.git")
+        base = rwl.find_workers_dir_clone(
+            "renga",
+            "https://github.com/suisya-systems/renga.git",
+            self.sb.workers,
+        )
+        self.assertEqual(Path(base).resolve(), canonical.resolve())
+
+    def test_a_b_a_b_continuous_dispatch_lands_on_same_base(self):
+        """End-to-end: A → B → A → B continuous dispatch all use the same
+        base clone with distinct ``.worktrees/<task>/`` paths. This is
+        the regression Codex review (b) called out — previously Pattern A
+        on the same project would land at ``workers/<slug>/`` directly
+        and the second dispatch (Pattern B via the queued reservation)
+        would try to ``git worktree add`` from a directory the previous
+        task was actively using as a work dir."""
+        clone = self.sb.workers / "renga"
+        self._clone_at(clone, "https://github.com/suisya-systems/renga.git")
+
+        # First dispatch: no runs → Pattern A.
+        first = rwl.resolve(
+            task_id="renga-a-1",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(first.pattern, "A")
+        self.assertEqual(
+            Path(first.worker_dir),
+            (clone / ".worktrees" / "renga-a-1").resolve(),
+        )
+
+        # Second dispatch arriving while the first is in_use → Pattern B.
+        self.sb.add_run(
+            task_id="renga-a-1",
+            project_slug="renga",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(first.worker_dir),
+        )
+        second = rwl.resolve(
+            task_id="renga-b-2",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(second.pattern, "B")
+        self.assertEqual(
+            Path(second.worker_dir),
+            (clone / ".worktrees" / "renga-b-2").resolve(),
+        )
+
+        # First task completes → next dispatch falls back to Pattern A
+        # but STILL lands in .worktrees/ (the collision fix is durable,
+        # not just for the concurrent-run window).
+        self.sb.add_run(
+            task_id="renga-b-2",
+            project_slug="renga",
+            pattern="B",
+            status="in_use",
+            worker_dir_abs=str(second.worker_dir),
+        )
+        # Mark renga-a-1 as completed by re-upserting with status='completed'.
+        completed = connect(self.sb.db_path)
+        try:
+            cw = StateWriter(completed)
+            with cw.transaction() as tx:
+                tx.update_run_status("renga-a-1", "completed")
+        finally:
+            completed.close()
+        # Mark renga-b-2 completed too so the next round is Pattern A.
+        completed = connect(self.sb.db_path)
+        try:
+            cw = StateWriter(completed)
+            with cw.transaction() as tx:
+                tx.update_run_status("renga-b-2", "completed")
+        finally:
+            completed.close()
+
+        third = rwl.resolve(
+            task_id="renga-a-3",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(third.pattern, "A")
+        self.assertEqual(
+            Path(third.worker_dir),
+            (clone / ".worktrees" / "renga-a-3").resolve(),
+        )
+
+        # And the fourth concurrent dispatch lands on Pattern B again.
+        self.sb.add_run(
+            task_id="renga-a-3",
+            project_slug="renga",
+            pattern="A",
+            status="in_use",
+            worker_dir_abs=str(third.worker_dir),
+        )
+        fourth = rwl.resolve(
+            task_id="renga-b-4",
+            project_slug="renga",
+            claude_org_root=self.sb.claude_org_root,
+            state_db_path=self.sb.db_path,
+        )
+        self.assertEqual(fourth.pattern, "B")
+        self.assertEqual(
+            Path(fourth.worker_dir),
+            (clone / ".worktrees" / "renga-b-4").resolve(),
+        )
+        # All four worker_dirs are distinct .worktrees siblings of the
+        # same base clone — no collision over workers/renga/ itself.
+        self.assertEqual(
+            {first.worker_dir, second.worker_dir, third.worker_dir, fourth.worker_dir},
+            {
+                str((clone / ".worktrees" / t).resolve())
+                for t in (
+                    "renga-a-1", "renga-b-2", "renga-a-3", "renga-b-4",
+                )
+            },
         )
 
 

--- a/tools/gen_delegate_payload.py
+++ b/tools/gen_delegate_payload.py
@@ -74,6 +74,30 @@ class WorktreeApplyError(RuntimeError):
     """
 
 
+class BlockingPreviewWarningError(RuntimeError):
+    """Raised by ``apply`` when the plan carries one or more
+    ``blocking_warnings`` (Issue #489 surface). Distinct from
+    :class:`WorktreeApplyError` so callers can disambiguate "preview-time
+    layout integrity refused apply" from "git worktree creation failed
+    at apply time"; both classes always run before any DB / FS write so
+    neither leaks a queued run row.
+    """
+
+
+# Filenames whose presence in a non-git ``workers/<slug>/`` is treated as a
+# tell-tale leftover from an earlier Pattern A dispatch (the layout Issue
+# #489 sunsets). Used by :func:`_compute_layout_warnings` to decide whether
+# the directory is "non-git with residue" (blocking) vs "non-git but empty
+# enough to safely bootstrap into" (no warning, falls through to legacy
+# Pattern A direct).
+_PATTERN_A_RESIDUE_FILENAMES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "CLAUDE.local.md",
+    "send_plan.json",
+    ".claude",
+)
+
+
 @dataclass(frozen=True)
 class DelegatePlan:
     task_id: str
@@ -89,10 +113,24 @@ class DelegatePlan:
     closes_issue: Optional[int]
     refs_issues: list[int]
     artifacts_to_create: list[Path] = field(default_factory=list)
-    # Pattern B only: absolute path of the repo from which `git worktree add`
-    # is run. None for Pattern A / C, or when no usable base repo could be
-    # determined (apply will then raise WorktreeApplyError).
+    # Absolute path of the repo from which ``git worktree add`` is run.
+    # Set for Pattern B (live_repo_worktree, claude_org_repo_worktree,
+    # generic) AND for Pattern A when the resolver routed worker_dir into
+    # the Issue #489 unified ``<base>/.worktrees/<task>/`` layout. None
+    # for Pattern A legacy direct (workers/<slug>/), Pattern C, or when
+    # no usable base repo could be determined (apply then raises
+    # WorktreeApplyError on Pattern B, or skips worktree creation on
+    # Pattern A legacy / Pattern C).
     base_repo: Optional[Path] = None
+    # Issue #489 surface: non-blocking notes (e.g. legacy ``_repo_clone``
+    # layout still in use; canonical clone is preferred). Apply still
+    # proceeds — they are informational only.
+    warnings: list[str] = field(default_factory=list)
+    # Issue #489 surface: layout integrity refused apply. ``preview`` JSON
+    # exposes these so Secretary can fix the deployment before retrying;
+    # ``apply`` raises :class:`BlockingPreviewWarningError` rather than
+    # touching the DB / filesystem.
+    blocking_warnings: list[str] = field(default_factory=list)
 
     def to_summary_dict(self) -> dict[str, Any]:
         return {
@@ -110,6 +148,8 @@ class DelegatePlan:
             "settings_args": dict(self.settings_args),
             "artifacts_to_create": [str(p) for p in self.artifacts_to_create],
             "base_repo": str(self.base_repo) if self.base_repo else None,
+            "warnings": list(self.warnings),
+            "blocking_warnings": list(self.blocking_warnings),
         }
 
 
@@ -160,6 +200,118 @@ def _summarize_description(description: str, limit: int = 120) -> str:
 
 def _brief_filename(self_edit: bool) -> str:
     return "CLAUDE.local.md" if self_edit else "CLAUDE.md"
+
+
+def _has_pattern_a_residue(workers_slug_dir: Path) -> bool:
+    """Return True iff ``workers_slug_dir`` is non-empty in a way that
+    looks like a previous Pattern A dispatch's left-overs (CLAUDE.md /
+    send_plan.json / .claude/ etc.).
+
+    A directory that does not exist or only contains hidden git internals
+    is treated as "safe to fall through to legacy Pattern A direct
+    bootstrapping" (the historical first-time behavior). The residue
+    check intentionally lists tell-tale dispatch artifacts rather than
+    "any file" so a manually-placed README.md on a brand-new workers
+    deployment doesn't trip the blocker.
+    """
+    if not workers_slug_dir.exists() or not workers_slug_dir.is_dir():
+        return False
+    try:
+        entries = list(workers_slug_dir.iterdir())
+    except OSError:
+        return False
+    for entry in entries:
+        if entry.name in _PATTERN_A_RESIDUE_FILENAMES:
+            return True
+    return False
+
+
+def _compute_layout_warnings(
+    *,
+    project_slug: str,
+    workers_dir: Path,
+    pattern: str,
+    base_repo: Optional[Path],
+) -> tuple[list[str], list[str]]:
+    """Compute ``(warnings, blocking_warnings)`` for the preview surface
+    (Issue #489 (d)).
+
+    Currently emits:
+
+    - ``blocking_warnings``: ``workers/<slug>/`` exists as a non-git
+      directory with Pattern-A-residue files (CLAUDE.md / send_plan.json
+      / .claude/) AND ``base_repo`` is None (no usable base discoverable
+      from any source — canonical clone, ``_repo_clone`` legacy, or a
+      registered local project path). The directory is the ambiguous
+      Pattern A / Pattern B collision target — apply against it would
+      either re-write residual files or try to ``git worktree add``
+      from a non-git directory. Surface as blocking so Secretary can
+      clean the residue or bootstrap a base before retrying.
+
+      Codex Round 3 Major: the predicate is ``base_repo is None`` (the
+      authoritative "no usable base" answer the rest of the plan was
+      built against) — NOT "did ``find_workers_dir_clone`` return
+      something". A registered local-path project (``project.path =
+      /repos/clock-app``) supplies ``base_repo`` via the payload's
+      project-path branch even when ``find_workers_dir_clone`` returns
+      None, so leftover residue in ``workers/<slug>/`` is NOT a real
+      collision — apply uses the registered local clone as base.
+
+    - ``warnings``: ``base_repo`` resolved through the legacy
+      ``workers/<slug>/_repo_clone/`` subdirectory rather than the
+      canonical ``workers/<slug>/``. Apply still proceeds — the legacy
+      layout works — but the canonical layout is preferred so a
+      follow-up migration step can normalize it.
+
+    Pattern C ephemeral / gitignored cases never touch ``workers/<slug>/``
+    directly, so they bypass both checks.
+    """
+    warnings: list[str] = []
+    blocking_warnings: list[str] = []
+    if pattern == "C":
+        return warnings, blocking_warnings
+    workers_slug_dir = (Path(workers_dir) / project_slug).resolve()
+    if base_repo is None and _has_pattern_a_residue(workers_slug_dir):
+        blocking_warnings.append(
+            f"workers_dir/{project_slug}/ exists with Pattern-A residue "
+            f"(CLAUDE.md / send_plan.json / .claude/) but no usable base "
+            f"clone could be determined (canonical workers_dir/{project_slug}/, "
+            f"legacy workers_dir/{project_slug}/_repo_clone/, and the "
+            "registered local-path base all came up empty). Refusing to "
+            "apply — either clean the residue and rerun (legacy Pattern A "
+            f"bootstrap), or clone the project at workers_dir/{project_slug}/ "
+            "first so dispatch can use the Issue #489 canonical layout "
+            "(workers_dir/<slug>/.worktrees/<task>/)."
+        )
+    if base_repo is not None:
+        try:
+            resolved = base_repo.resolve()
+        except OSError:
+            resolved = base_repo
+        # Legacy fallback lives at ``<canonical>/_repo_clone``. We detect
+        # the legacy subdir by exact-name comparison against the canonical
+        # parent so a deliberately misnamed ``_repo_clone`` sibling of an
+        # unrelated directory cannot trigger the warning.
+        if (
+            resolved.name == _REPO_CLONE_LEGACY_NAME
+            and resolved.parent.resolve() == workers_slug_dir
+        ):
+            warnings.append(
+                f"workers_dir/{project_slug}/_repo_clone/ detected as base "
+                "clone (legacy layout). The Issue #489 canonical layout "
+                f"places the clone directly at workers_dir/{project_slug}/. "
+                "Migrate by moving the clone up one level so it lives at "
+                f"workers_dir/{project_slug}/ (a strict migration script "
+                "is out of scope for Issue #489 itself — a follow-up "
+                "issue may automate the move)."
+            )
+    return warnings, blocking_warnings
+
+
+# Mirrors :data:`tools.resolve_worker_layout._REPO_CLONE_SUBDIR` so the
+# warning helper above doesn't reach into the resolver's private name to
+# do an equality check.
+_REPO_CLONE_LEGACY_NAME = "_repo_clone"
 
 
 def _format_delegate_body(
@@ -307,7 +459,32 @@ def build_delegate_plan(
     # Pattern B: figure out which repo `git worktree add` should be run from.
     # live_repo_worktree → Secretary's live claude-org repo;
     # plain Pattern B    → the registered project's path.
+    # Pattern A (Issue #489): when the resolver routed worker_dir into
+    # ``<base>/.worktrees/<task>/`` (i.e. a real clone was detected), the
+    # base is whatever ``find_workers_dir_clone`` resolved. Carry it on
+    # ``plan.base_repo`` so ``_ensure_worktree`` actually creates the
+    # worktree — without this, apply for the new Pattern A layout would
+    # just mkdir an empty ``.worktrees/<task>/`` under the base clone and
+    # the worker would land in a non-checkout directory (Codex Round 1
+    # Blocker).
     base_repo: Optional[Path] = None
+    if layout.pattern == "A":
+        # Pattern A's Issue #489 unified layout puts worker_dir at
+        # ``<base>/.worktrees/<task>/`` regardless of whether the base is a
+        # workers/<slug>/ clone, a workers/<slug>/_repo_clone/ legacy
+        # subdir, or the claude-org mirror clone. Derive base_repo from
+        # the worker_dir shape so all three sources are handled with one
+        # rule. Pattern A legacy direct (worker_dir == workers/<slug>/)
+        # has no ``.worktrees`` parent and leaves ``base_repo`` None, so
+        # ``_ensure_worktree`` stays a no-op for that path.
+        try:
+            wd_resolved = Path(layout.worker_dir).resolve()
+        except OSError:
+            wd_resolved = Path(layout.worker_dir)
+        if wd_resolved.parent.name == ".worktrees":
+            candidate = wd_resolved.parent.parent
+            if rwl.is_local_git_repo(str(candidate)):
+                base_repo = candidate
     if layout.pattern == "B":
         if layout.pattern_variant == "live_repo_worktree":
             base_repo = Path(claude_org_root).resolve()
@@ -361,6 +538,33 @@ def build_delegate_plan(
     settings_args = dict(layout.settings_args)
     if base_repo is not None:
         settings_args["base-clone"] = str(base_repo)
+    # Issue #489 Codex Round 3 Blocker: Pattern A's Issue #489 unified
+    # worktree layout (``<base>/.worktrees/<task>/``) requires the same
+    # Git-metadata sandbox carve-outs as Pattern B (the worktree's
+    # ``.git/worktrees/<task>/`` admin dir, the shared ``.git/objects``,
+    # the THIS-branch ref, ``.git/packed-refs``). ``worker_roles.<role>.sandbox_by_pattern.A``
+    # in ``tools/org_extension_schema.json`` is authored for the LEGACY
+    # Pattern A layout (worker_dir == workers/<slug>/, no shared
+    # ``.git``) and does NOT include those mounts; selecting it for a
+    # worktree-based dispatch would cause git commit / push / fetch to
+    # fail with "permission denied" inside the bwrap sandbox. We surface
+    # ``pattern=B`` to the runtime ONLY for the sandbox selection while
+    # leaving ``layout.pattern`` / ``settings_args["task-id"]`` / the
+    # DELEGATE body / DB row at the original A label (first-vs-concurrent
+    # dispatch tracking is independent of sandbox shape). ``base_repo is
+    # not None`` is the same predicate that drives ``_ensure_worktree``,
+    # so the two stay in lock-step. When the schema grows a
+    # Pattern-A-with-worktree sandbox variant this override can be
+    # removed.
+    if layout.pattern == "A" and base_repo is not None:
+        settings_args["pattern"] = "B"
+
+    warnings, blocking_warnings = _compute_layout_warnings(
+        project_slug=project_slug,
+        workers_dir=Path(workers_dir_for_norm),
+        pattern=layout.pattern,
+        base_repo=base_repo,
+    )
 
     return DelegatePlan(
         task_id=task_id,
@@ -377,6 +581,8 @@ def build_delegate_plan(
         refs_issues=list(refs_issues or []),
         artifacts_to_create=artifacts,
         base_repo=base_repo,
+        warnings=warnings,
+        blocking_warnings=blocking_warnings,
     )
 
 
@@ -428,7 +634,12 @@ def _reserve_in_db(
                 layout="flat",
                 is_git_repo=plan.layout.pattern != "C"
                 or plan.layout.pattern_variant == "gitignored_repo_root",
-                is_worktree=plan.layout.pattern == "B",
+                # Issue #489: Pattern A with a detected base clone (new
+                # ``<base>/.worktrees/<task>/`` layout) is registered as
+                # a worktree too — ``base_repo is not None`` covers both
+                # patterns. Pattern A legacy direct (workers/<slug>/) and
+                # Pattern C are NOT worktrees.
+                is_worktree=plan.base_repo is not None,
             )
             issue_refs_iter = None
             if plan.closes_issue is not None:
@@ -598,14 +809,21 @@ def _ensure_worktree(plan: DelegatePlan) -> None:
     reused worktree the Secretary removes it so apply recreates it (which then
     fetches). See the reuse branch below.
     """
-    if plan.layout.pattern != "B":
-        return
+    # Issue #489: Pattern A with a detected base clone now uses the same
+    # ``<base>/.worktrees/<task>/`` layout as Pattern B, so the worktree
+    # creation must fire for either pattern when ``base_repo`` is set.
+    # Conversely, Pattern A WITHOUT a base clone (legacy direct path,
+    # worker_dir == workers/<slug>/) and Pattern C ephemeral / gitignored
+    # both leave ``base_repo`` unset; for those, apply only writes the
+    # brief — no worktree to create.
     if plan.base_repo is None:
-        raise WorktreeApplyError(
-            f"Pattern B but no usable base repo could be determined for "
-            f"project {plan.project_slug!r} (variant="
-            f"{plan.layout.pattern_variant!r}); cannot run `git worktree add`."
-        )
+        if plan.layout.pattern == "B":
+            raise WorktreeApplyError(
+                f"Pattern B but no usable base repo could be determined for "
+                f"project {plan.project_slug!r} (variant="
+                f"{plan.layout.pattern_variant!r}); cannot run `git worktree add`."
+            )
+        return
     worker_dir = Path(plan.layout.worker_dir)
     if _is_registered_worktree(plan.base_repo, worker_dir):
         # Idempotent reuse — but only when the existing worktree is on the
@@ -780,6 +998,45 @@ def _write_send_plan(plan: DelegatePlan, *, out_path: Path) -> Path:
     return out_path
 
 
+def _abandon_queued_run(state_db_path: Path, task_id: str) -> None:
+    """Compensating UPDATE that flips a same-task queued run to
+    ``abandoned`` so it stops counting as an active reservation.
+
+    Used by :func:`apply_delegate_plan` when a post-reservation step fails
+    after the DB transaction has already committed (Issue #489 Blocker 2:
+    a leaked queued row makes the next dispatch see Pattern A as
+    occupied and silently flips it onto Pattern B). Best-effort: a
+    compensation failure is logged to stderr but not re-raised, because
+    we are already on the exception path and the original failure
+    should be what the caller observes.
+    """
+    from tools.state_db import connect
+    from tools.state_db.writer import StateWriter
+
+    try:
+        conn = connect(state_db_path)
+        try:
+            writer = StateWriter(conn)
+            with writer.transaction() as tx:
+                tx.update_run_status(
+                    task_id,
+                    "abandoned",
+                    outcome_note=(
+                        "apply post-reservation failed; compensated by "
+                        "tools.gen_delegate_payload (Issue #489 Blocker 2)"
+                    ),
+                )
+        finally:
+            conn.close()
+    except Exception as exc:  # noqa: BLE001 — best-effort compensation
+        sys.stderr.write(
+            "tools.gen_delegate_payload: failed to compensate queued run "
+            f"task_id={task_id!r} ({type(exc).__name__}: {exc}). Manually "
+            f"`UPDATE runs SET status='abandoned' WHERE task_id='{task_id}'` "
+            "to unblock subsequent dispatch.\n"
+        )
+
+
 def apply_delegate_plan(
     plan: DelegatePlan,
     *,
@@ -790,6 +1047,17 @@ def apply_delegate_plan(
     send_plan_out: Optional[Path] = None,
 ) -> ApplyResult:
     """Execute the side effects: reserve in DB, write brief, settings, send_plan."""
+    # Issue #489 (d): preview-time layout integrity check. ``blocking_warnings``
+    # surfaces deployments that have a non-git ``workers/<slug>/`` with
+    # Pattern-A residue and no usable base clone — apply would either rewrite
+    # the residue or fail loudly inside ``git worktree add``. Refuse here so
+    # the failure happens BEFORE any DB / FS write, leaving no queued row to
+    # compensate.
+    if plan.blocking_warnings:
+        raise BlockingPreviewWarningError(
+            "apply refused: preview emitted blocking warnings:\n  - "
+            + "\n  - ".join(plan.blocking_warnings)
+        )
     # Issue #309: create the worktree FIRST. If this fails (dirty dir,
     # git error, etc.) we must not leak a `runs.status='queued'` row,
     # because resolve_worker_layout treats `queued` as an active run and
@@ -799,18 +1067,29 @@ def apply_delegate_plan(
     db_reservation = _reserve_in_db(
         plan, state_db_path=state_db_path, claude_org_root=claude_org_root
     )
-    brief_path = _write_brief(plan)
-    settings_path: Optional[Path] = None
-    skipped_reason: Optional[str] = None
-    if skip_settings:
-        skipped_reason = "skip_settings flag set"
-    else:
-        settings_path, skipped_reason = _run_settings_generate(
-            plan, runtime_cmd=runtime_cmd
-        )
-    if send_plan_out is None:
-        send_plan_out = brief_path.with_name("send_plan.json")
-    send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
+    # Issue #489 Blocker 2: ``_reserve_in_db`` already committed the queued
+    # row. Anything that fails *after* this commit (brief write hitting a
+    # full disk, send_plan write losing permissions, settings subprocess
+    # raising unexpectedly) leaks an active reservation. ``StateWriter``
+    # rollback can't help — its transaction is already closed. Wrap the
+    # remaining steps and run the compensating ``abandoned`` update on
+    # failure so the next dispatch sees Pattern A as free.
+    try:
+        brief_path = _write_brief(plan)
+        settings_path: Optional[Path] = None
+        skipped_reason: Optional[str] = None
+        if skip_settings:
+            skipped_reason = "skip_settings flag set"
+        else:
+            settings_path, skipped_reason = _run_settings_generate(
+                plan, runtime_cmd=runtime_cmd
+            )
+        if send_plan_out is None:
+            send_plan_out = brief_path.with_name("send_plan.json")
+        send_plan_path = _write_send_plan(plan, out_path=send_plan_out)
+    except BaseException:
+        _abandon_queued_run(state_db_path, plan.task_id)
+        raise
     return ApplyResult(
         plan=plan,
         brief_path=brief_path,
@@ -1108,13 +1387,25 @@ def _cmd_preview(args: argparse.Namespace) -> int:
             {
                 "delegate_body": plan.delegate_body,
                 "summary": plan.to_summary_dict(),
+                # Issue #489 (d): hoist warnings / blocking_warnings to the
+                # top level so shell consumers can ``jq '.blocking_warnings | length > 0'``
+                # without descending into ``summary``. ``summary`` keeps a
+                # copy too (every key of the schema is mirrored there) so
+                # already-built tooling that only reads ``summary`` is not
+                # broken.
+                "warnings": list(plan.warnings),
+                "blocking_warnings": list(plan.blocking_warnings),
             },
             sys.stdout,
             indent=2,
             ensure_ascii=False,
         )
         sys.stdout.write("\n")
-        return 0
+        # Mirror the human-path exit code so JSON / human consumers agree:
+        # blocking_warnings → rc=3 so CI wrappers detect the refusal even when
+        # they only read stdout JSON. ``stderr`` is left clean here (the JSON
+        # body already carries the warning content) to keep pipelines simple.
+        return 3 if plan.blocking_warnings else 0
 
     print("--- DELEGATE body (preview, no writes) ---")
     print(plan.delegate_body)
@@ -1126,6 +1417,17 @@ def _cmd_preview(args: argparse.Namespace) -> int:
     print()
     print("--- Layout summary ---")
     print(json.dumps(plan.to_summary_dict(), indent=2, ensure_ascii=False))
+    # Issue #489 (d): emit warnings to stderr (so a piped stdout JSON / body
+    # capture stays clean), and BLOCKING markers loudly so an attempted
+    # ``apply`` after this preview will refuse. The non-zero exit on
+    # blocking_warnings means CI / wrapper scripts see a clear signal.
+    if plan.warnings:
+        for w in plan.warnings:
+            sys.stderr.write(f"warning: {w}\n")
+    if plan.blocking_warnings:
+        for w in plan.blocking_warnings:
+            sys.stderr.write(f"BLOCKING: {w}\n")
+        return 3
     return 0
 
 

--- a/tools/resolve_worker_layout.py
+++ b/tools/resolve_worker_layout.py
@@ -365,55 +365,85 @@ def find_claude_org_clone(
     return candidate if repo_name in _CLAUDE_ORG_MIRROR_REPO_NAMES else None
 
 
+# Legacy subdirectory layout: some manually-bootstrapped projects placed
+# the clone at ``workers/<slug>/_repo_clone/`` so ``workers/<slug>/`` could
+# hold loose notes (CLAUDE.md / send_plan.json) alongside the clone.
+# Issue #489 collapses that split — the canonical layout is the clone
+# living directly at ``workers/<slug>/`` and every dispatch (Pattern A or
+# B) uses ``<base>/.worktrees/<task>/``. The legacy form is still
+# accepted as a base, but ``gen_delegate_payload`` surfaces a deprecation
+# warning so deployments can migrate.
+_REPO_CLONE_SUBDIR = "_repo_clone"
+
+
+def _origin_matches_registered(
+    clone_path: Path, project_path: Optional[str]
+) -> bool:
+    """Return True iff ``clone_path`` is acceptable as a base clone for the
+    project registered at ``project_path``.
+
+    The Issue #370 origin URL gate, factored out so every clone-discovery
+    path (canonical ``workers/<slug>``, legacy ``workers/<slug>/_repo_clone``,
+    Pattern B ``base_repo`` derivation in ``gen_delegate_payload``) shares
+    the same trust signal. ``_extract_github_repo_name`` is scheme-agnostic
+    (https + ssh + ssh-with-port), so this gate MUST NOT key on ``"://"``.
+
+    Contract:
+    - When ``project_path`` parses as a github URL, the clone's ``origin``
+      MUST be a github URL with the same repo name. Owner is intentionally
+      unpinned so forks are accepted (mirrors :func:`find_claude_org_clone`
+      and :func:`is_claude_org_project` — see CONTRIBUTING.md for the
+      fork-based workflow). A bare ``git init`` with no origin, or an
+      origin pointing at an unrelated repo, is rejected.
+    - For non-github registry URLs (gitlab / bitbucket / custom git
+      server) or placeholders like ``-``, the gate falls back to the
+      slug + local-git-repo trust signal. The motivating renga / Issue
+      #489 cases are github so the strict gate above covers the
+      practical risk.
+    """
+    if not is_local_git_repo(str(clone_path)):
+        return False
+    registered_name = _extract_github_repo_name(project_path or "")
+    if registered_name is None:
+        return True
+    origin = _git_origin_url(clone_path)
+    clone_name = _extract_github_repo_name(origin) if origin else None
+    return clone_name == registered_name
+
+
 def find_workers_dir_clone(
     project_slug: str,
     project_path: Optional[str],
     workers_dir: Path,
 ) -> Optional[Path]:
-    """Return ``workers_dir/<project_slug>`` if it is a local git repo that
-    matches the registered project, else None.
+    """Return the path to use as a Pattern A/B base clone, or ``None``.
 
-    Issue #450: registry rows registered with a URL-only path (e.g.
-    ``| renga | renga | https://github.com/.../renga.git | ... |``) typically
-    have a manually-cloned local repo at the conventional
-    ``workers_dir/<project_slug>`` location. Pattern B needs a local base
-    for ``git worktree add``; use that clone when none of the prior base
-    branches resolve.
+    Issue #450 + #489: registry rows registered with a URL-only path
+    (e.g. ``| renga | renga | https://github.com/.../renga.git | ... |``)
+    need a locally-cloned repo to back ``git worktree add``. Two layouts
+    are accepted:
 
-    Slug match (``workers_dir/<project_slug>``) alone is not enough — a
-    leftover unrelated repo at that path would silently redirect dispatch
-    (the Issue #370 precedent for "別 repo への誤派遣"). When the registered
-    path looks like a github URL, additionally require the clone's
-    ``origin`` URL to point at a github repo with the same name (owner is
-    intentionally not pinned so forks are accepted, mirroring
-    :func:`find_claude_org_clone`). For non-github registry URLs the
-    trust signal falls back to the slug + local-git-repo check; the
-    motivating renga case is github so this gate covers the practical risk.
+    - canonical: ``workers_dir/<project_slug>/`` — the layout Issue #489
+      codifies. Pattern A uses ``<base>/.worktrees/<task>/`` so it cannot
+      collide with Pattern B over the same directory.
+    - legacy fallback: ``workers_dir/<project_slug>/_repo_clone/`` — used
+      by some older bootstrapping scripts that wanted ``workers/<slug>/``
+      free for loose notes. Still accepted so existing deployments keep
+      working; ``gen_delegate_payload`` flags it with a deprecation
+      warning in the preview output. Canonical is preferred when both
+      are present.
+
+    Both candidates run through :func:`_origin_matches_registered`, so
+    slug + path alone never grants base-clone status — the gate must
+    succeed to be accepted (Issue #370 precedent for "別 repo への誤派遣").
     """
-    candidate = (Path(workers_dir) / project_slug).resolve()
-    if not is_local_git_repo(str(candidate)):
-        return None
-    # ``_extract_github_repo_name`` accepts both ``https://github.com/o/r.git``
-    # and ``git@github.com:o/r.git`` (the regex is scheme-agnostic), so we
-    # MUST NOT gate on ``"://"`` — that would let SSH-style registry URLs
-    # bypass the origin gate (Codex Round 3 Blocker).
-    registered_name = _extract_github_repo_name(project_path or "")
-    if registered_name is not None:
-        # Registered URL is a github remote (the motivating renga case):
-        # the clone's ``origin`` MUST also be a github remote with the same
-        # repo name. A bare ``git init`` with no origin, or an origin
-        # pointing at an unrelated repo, is rejected — otherwise any
-        # leftover same-named directory would be silently adopted
-        # (Codex Round 2 Blocker; Issue #370 precedent).
-        origin = _git_origin_url(candidate)
-        clone_name = _extract_github_repo_name(origin) if origin else None
-        if clone_name != registered_name:
-            return None
-    # Non-github registry URL (gitlab, bitbucket, custom git server) or a
-    # placeholder like "-": ``_extract_github_repo_name`` returns None and
-    # we fall back to the slug + local-git-repo trust signal. The motivating
-    # renga case is github so the strict gate above covers the practical risk.
-    return candidate
+    canonical = (Path(workers_dir) / project_slug).resolve()
+    if _origin_matches_registered(canonical, project_path):
+        return canonical
+    legacy = (canonical / _REPO_CLONE_SUBDIR).resolve()
+    if _origin_matches_registered(legacy, project_path):
+        return legacy
+    return None
 
 
 def is_claude_org_project(project_slug: str, claude_org_root: Path) -> bool:
@@ -487,6 +517,7 @@ def resolve(
     # Normalize registry-display aliases to the canonical project slug.
     # ``claude-org-en`` is the 通称 (display name) for the ``claude-org``
     # mirror; downstream code only operates on the canonical form.
+    original_slug = project_slug
     project_slug = _CLAUDE_ORG_SLUG_ALIASES.get(project_slug, project_slug)
 
     targets = list(targets or [])
@@ -502,6 +533,35 @@ def resolve(
     else:
         projects = []
     project = find_project(projects, project_slug)
+    # Issue #484: the alias normalization above assumes ``claude-org-en`` is
+    # only ever the 通称 for the canonical ``claude-org`` *mirror* row. But a
+    # remote project can be registered under the alias *name* itself
+    # (``| … | claude-org-en | https://github.com/…/claude-org | … |``).
+    # Normalizing to ``claude-org`` then made ``find_project`` miss that row,
+    # so the resolver dropped to Pattern C ephemeral on the very first
+    # delegation even though a clone URL was registered. When the canonical
+    # slug matches nothing but the original (un-normalized) slug does, that
+    # row is a genuinely distinct registered project — not the mirror — so
+    # adopt it and revert ``project_slug`` to the registered name (keeps
+    # worker_dir naming / active-run gating consistent with the registry and
+    # leaves the ``find_claude_org_clone`` mirror path inert for this slug).
+    #
+    # Gated on "no local mirror clone for the canonical slug": when a clone
+    # *does* exist at ``{workers_dir}/claude-org`` the established Issue #370
+    # mirror machinery owns the alias (it re-pins onto the clone below), and
+    # gen_delegate_payload re-applies the same canonical normalization for the
+    # DELEGATE body / DB reservation — reverting here would diverge the two
+    # (Codex review). So the alias-row fallback only fires for the genuine
+    # no-clone deployment that Issue #484 hit.
+    if (
+        project is None
+        and original_slug != project_slug
+        and find_claude_org_clone(project_slug, workers_dir) is None
+    ):
+        fallback = find_project(projects, original_slug)
+        if fallback is not None:
+            project = fallback
+            project_slug = original_slug
 
     # claude-org-ja is intentionally absent from the checked-in registry
     # (the row used to leak a user-specific local path). When the slug +
@@ -630,32 +690,72 @@ def resolve(
                 "annotation."
             )
         force_b = active or self_edit or bool(project.mirror_of)
+        # Issue #489: when a usable base clone is detected at
+        # ``workers/<slug>/`` (or the legacy ``workers/<slug>/_repo_clone/``
+        # subdir), every Pattern A or B task lands under
+        # ``<base>/.worktrees/<task>/``. This is what collapses the
+        # historical Pattern A vs Pattern B collision over the same
+        # ``workers/<slug>/`` directory — Pattern A no longer uses that
+        # path as its work dir, so Pattern B's worktree-add against it
+        # cannot stomp on Pattern A's commits. ``None`` here means "no
+        # local clone yet"; we fall through to the legacy direct path so
+        # first-time / `-`-placeholder / local-path-registry deployments
+        # behave as they did before.
+        #
+        # Codex Round 2 Major: ``find_workers_dir_clone`` is only
+        # consulted for URL-only / placeholder registry rows. When the
+        # registry records a real local git repo path
+        # (``project.path = /repos/clock-app``), THAT path is the
+        # canonical base — ``workers/<slug>/`` is a per-dispatch work
+        # area, NEVER a clone. The helper's permissive non-URL fallback
+        # would otherwise silently adopt any random git repo that
+        # happened to live at ``workers/<slug>/`` and diverge from
+        # ``gen_delegate_payload``'s base derivation (which still
+        # prefers ``project.path`` for local-path rows).
+        if project.path and is_local_git_repo(project.path):
+            base_for_worktree = None
+        else:
+            base_for_worktree = find_workers_dir_clone(
+                project_slug, project.path, workers_dir
+            )
         if force_b:
             pattern = "B"
             if self_edit:
                 variant = "live_repo_worktree"
                 worker_dir = claude_org_root / ".worktrees" / task_id
+            elif base_for_worktree is not None:
+                variant = None
+                worker_dir = base_for_worktree / ".worktrees" / task_id
             else:
                 variant = None
                 worker_dir = workers_dir / project_slug / ".worktrees" / task_id
         else:
             pattern, variant = "A", None
-            worker_dir = workers_dir / project_slug
+            if base_for_worktree is not None:
+                worker_dir = base_for_worktree / ".worktrees" / task_id
+            else:
+                worker_dir = workers_dir / project_slug
 
     worker_dir = worker_dir.resolve() if worker_dir.is_absolute() else worker_dir.resolve()
 
-    # --- claude-org mirror anchoring (Issue #370) -------------------------
+    # --- claude-org mirror anchoring (Issue #370 + Issue #489) ----------
     # Re-pin worker_dir on the actual clone (which lives at
     # ``{workers_dir}/claude-org``). For Pattern B, also tag the variant so
     # gen_delegate_payload can derive base_repo from worker_dir.parent.parent
     # without needing a registry row. Skipped for Pattern C / gitignored
     # cases — those already use the synthesized project.path directly.
+    #
+    # Codex Round 2 Major (Issue #489): Pattern A on the mirror also
+    # uses the unified ``<clone>/.worktrees/<task>/`` layout. The
+    # previous "Pattern A = clone root" behavior would have re-introduced
+    # the historical collision (mirror_of-less first dispatch wrote
+    # CLAUDE.md / send_plan.json directly into the canonical clone,
+    # exactly the directory a concurrent Pattern B dispatch needs as
+    # its worktree base).
     if claude_org_clone is not None and pattern in ("A", "B"):
+        worker_dir = (claude_org_clone / ".worktrees" / task_id).resolve()
         if pattern == "B":
             variant = "claude_org_repo_worktree"
-            worker_dir = (claude_org_clone / ".worktrees" / task_id).resolve()
-        else:
-            worker_dir = claude_org_clone.resolve()
 
     # --- TOML [worker] block overrides (Issue #290 defect 1) --------------
     # Honor explicit values from the caller (typically a worker_brief.toml
@@ -847,15 +947,43 @@ def resolve(
             # would refuse to treat it as a worktree. Skipped when
             # claude_org_clone has already pinned the clone-root path —
             # the post-override fallback below re-derives for that case.
+            #
+            # Issue #489 (Codex Round 1 Major follow-up): consult
+            # :func:`find_workers_dir_clone` here too so the override
+            # lands the worktree under the SAME base the auto-derive
+            # would pick (canonical ``workers/<slug>/`` OR legacy
+            # ``workers/<slug>/_repo_clone/``). Hardcoding
+            # ``workers/<slug>/.worktrees/`` made the override diverge
+            # from the auto-derived path whenever the base lived under
+            # the legacy subdirectory.
             if (
                 pattern == "B"
                 and variant is None
                 and not explicit_worker_dir
                 and claude_org_clone is None
             ):
-                worker_dir = (
-                    workers_dir / project_slug / ".worktrees" / task_id
-                ).resolve()
+                # Codex Round 2 Major: skip the workers_dir fallback
+                # when the registry records a real local clone path —
+                # use that as the base instead so resolver and payload
+                # agree on which repo backs the worktree.
+                _override_project_path = (
+                    project.path if project is not None else None
+                )
+                if (
+                    _override_project_path
+                    and is_local_git_repo(_override_project_path)
+                ):
+                    override_base = None
+                else:
+                    override_base = find_workers_dir_clone(
+                        project_slug, _override_project_path, workers_dir,
+                    )
+                if override_base is not None:
+                    worker_dir = (override_base / ".worktrees" / task_id).resolve()
+                else:
+                    worker_dir = (
+                        workers_dir / project_slug / ".worktrees" / task_id
+                    ).resolve()
             # Same idea for ``--pattern A``: when the override drops
             # B → A, pin worker_dir back at the clone root rather than
             # leaving it in a stale ``.worktrees/<task_id>/`` path that
@@ -864,11 +992,48 @@ def resolve(
             # ``--pattern A`` on slug=claude-org leaves worker_dir at the
             # auto-derived ``.worktrees/<task_id>/`` even though the
             # final pattern is A, an incoherent layout.
+            #
+            # Issue #489 (Codex Round 1 Major follow-up): mirror the
+            # Pattern A auto-derive — when a usable base clone is
+            # detected at workers/<slug>/ or workers/<slug>/_repo_clone/,
+            # the override-driven worker_dir also lands at
+            # ``<base>/.worktrees/<task>/`` (the new unified layout).
+            # Otherwise the override and auto-derive disagree on layout
+            # for the same project.
             if pattern == "A" and not explicit_worker_dir:
                 if claude_org_clone is not None:
-                    worker_dir = claude_org_clone.resolve()
+                    # Issue #489: mirror Pattern A also lands in the
+                    # unified ``<clone>/.worktrees/<task>/`` layout (see
+                    # the mirror anchoring block below) — keep the
+                    # ``--pattern A`` override consistent.
+                    worker_dir = (
+                        claude_org_clone / ".worktrees" / task_id
+                    ).resolve()
                 else:
-                    worker_dir = (workers_dir / project_slug).resolve()
+                    # Codex Round 2 Major: skip the workers_dir fallback
+                    # when the registry records a real local clone path —
+                    # use that as the base instead so resolver and payload
+                    # agree on which repo backs the worktree.
+                    _override_project_path_a = (
+                        project.path if project is not None else None
+                    )
+                    if (
+                        _override_project_path_a
+                        and is_local_git_repo(_override_project_path_a)
+                    ):
+                        override_base = None
+                    else:
+                        override_base = find_workers_dir_clone(
+                            project_slug,
+                            _override_project_path_a,
+                            workers_dir,
+                        )
+                    if override_base is not None:
+                        worker_dir = (
+                            override_base / ".worktrees" / task_id
+                        ).resolve()
+                    else:
+                        worker_dir = (workers_dir / project_slug).resolve()
             # ``--pattern C`` override: ephemeral default. Without this
             # branch the override would dispatch into the *registered*
             # project's directory (auto-derive's Pattern A worker_dir),


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#490](https://github.com/suisya-systems/claude-org-ja/pull/490)

Merge SHA: `324704f434f5cfaecbf1b35274c18e1863f17da8`

Source: ja PR [#490](https://github.com/suisya-systems/claude-org-ja/pull/490)
Merge SHA: `324704f434f5cfaecbf1b35274c18e1863f17da8`

| class | count |
|---|---|
| runtime | 4 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tests/test_gen_delegate_payload.py`
- `tests/test_resolve_worker_layout.py`
- `tools/gen_delegate_payload.py`
- `tools/resolve_worker_layout.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
