### PR TITLE
auto-mirror: ja#494 fix(claude): expand dispatcher ERROR detection (full-visible scan + 529/transient codes + spinner-age) (Closes #492)

### DIFF
--- a/tests/test_inspect_anomaly_scan.py
+++ b/tests/test_inspect_anomaly_scan.py
@@ -1,0 +1,238 @@
+"""Regression tests for tools/inspect_anomaly_scan.py (Issue #492).
+
+These lock the three ERROR-detection gaps fixed in
+``.dispatcher/references/worker-monitoring.md`` §4(d):
+
+* gap (1) — the scan must cover every visible row, not just bottom 10;
+* gap (2) — ``529`` (and ``502`` / ``503`` / ``504``) must be detected;
+* gap (3) — a spinner that has been counting for >= 5 minutes is an
+  ERROR-equivalent.
+
+The headline test reproduces the 2026-05-28 observation from
+``worker-skill-worktree-remove-force-491``: an ``API Error: 529`` banner
+parked at row 15 of a 43-row pane, a ``✻ ... for 9m ...`` spinner, and a
+bottom-10 window that contains only blanks + prompt + status bar.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools import inspect_anomaly_scan as ias  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "inspect_anomaly_scan.py"
+
+
+def _observed_pane() -> list[dict]:
+    """The 2026-05-28 pane: 529 banner at row 15, 9m spinner, empty bottom 10.
+
+    Mirrors the grid quoted in Issue #492. Rows are 1-indexed to match how
+    the Issue describes them; the detector is row-agnostic so the exact
+    numbering only matters for the bottom-N slice below.
+    """
+    lines = [{"row": r, "text": ""} for r in range(1, 44)]
+
+    def put(row: int, text: str) -> None:
+        lines[row - 1] = {"row": row, "text": text}
+
+    put(12, "Ran 1 shell command")
+    put(13, "  ⎿  ok")
+    put(14, "←renga-peers: ack from secretary")
+    put(15, "API Error: 529 Overloaded. Retrying…")
+    put(17, "✻ Sautéed for 9m 12s")
+    put(39, "──────────────────────")
+    put(40, "❯")
+    put(41, "  ⏵⏵ accept edits on")
+    put(42, "claude-opus-4-8")
+    return lines
+
+
+class ObservedRegressionTests(unittest.TestCase):
+    """The headline Issue #492 case must fire ERROR; bottom-10 alone must not."""
+
+    def test_full_scan_detects_529_and_stuck_spinner(self) -> None:
+        detections = ias.scan_lines(_observed_pane())
+        reasons = {d.reason for d in detections}
+
+        # gap (2): the 529 banner is caught (by the bare 529 code and/or by
+        # the "API Error" substring — at least one substring detection on
+        # the banner row).
+        banner = [d for d in detections if d.row == 15]
+        self.assertTrue(banner, "529 banner at row 15 must be detected")
+        self.assertTrue(
+            any(r.startswith("substring:") for r in reasons),
+            f"expected a substring detection, got {reasons}",
+        )
+
+        # gap (3): the 9m spinner is an ERROR-equivalent.
+        self.assertIn("spinner_age:9m", reasons)
+
+        # every detection maps onto the ERROR notification path.
+        self.assertTrue(all(d.kind == "error" for d in detections))
+
+    def test_bottom_10_window_misses_the_banner(self) -> None:
+        """Demonstrates gap (1): the old bottom-10 scan is blind here."""
+        pane = _observed_pane()
+        bottom_10 = pane[-10:]  # rows 34-43: blanks + prompt + status bar
+        self.assertEqual(ias.scan_lines(bottom_10), [])
+
+
+class SubstringTests(unittest.TestCase):
+    def test_api_error_case_insensitive(self) -> None:
+        self.assertTrue(ias.scan_lines(["some api error happened"]))
+        self.assertTrue(ias.scan_lines(["SOME API ERROR HAPPENED"]))
+
+    def test_rate_limit_detected(self) -> None:
+        self.assertTrue(ias.scan_lines(["rate limit reached, backing off"]))
+
+    def test_clean_line_no_detection(self) -> None:
+        self.assertEqual(ias.scan_lines(["Ran 1 shell command", "  ⎿  ok"]), [])
+
+    def test_single_reason_per_line(self) -> None:
+        # "API Error" (strong substring) wins; the gated 529 code does not add
+        # a second detection on the same line.
+        dets = ias.scan_lines(["API Error: 529 Overloaded"])
+        self.assertEqual(len(dets), 1)
+        self.assertEqual(dets[0].reason, "substring:API Error")
+
+
+class StatusCodeTests(unittest.TestCase):
+    """gap (2): status codes detected, but only as gated tokens.
+
+    These guard the regression without leaning on the ``API Error``
+    substring — removing a code from ``ERROR_STATUS_CODES`` makes the
+    relevant subTest fail.
+    """
+
+    def test_each_code_detected_without_api_error_wording(self) -> None:
+        # Lines carry an error-context keyword but NOT "API Error", so the
+        # bare-code path is what fires.
+        contexts = {
+            "429": "HTTP 429 too many requests, retrying",
+            "500": "Upstream 500 server error",
+            "502": "got 502 from gateway",
+            "503": "service unavailable (503)",
+            "504": "504 gateway timeout, retry",
+            "529": "Overloaded (529), retrying…",
+        }
+        for code, line in contexts.items():
+            with self.subTest(code=code):
+                dets = ias.scan_lines([line])
+                self.assertEqual(
+                    [d.reason for d in dets],
+                    [f"status_code:{code}"],
+                    f"{code} should be detected via the gated code path",
+                )
+
+    def test_bare_code_without_error_context_not_detected(self) -> None:
+        # No error keyword on the line → benign, must not fire.
+        for benign in ("500 passed, 0 failed", "see issue #529", "build 502 ok"):
+            with self.subTest(line=benign):
+                self.assertEqual(ias.scan_lines([benign]), [])
+
+    def test_substring_of_larger_number_not_detected(self) -> None:
+        # "5000" must not match \b500\b even with error context present.
+        self.assertEqual(
+            ias.scan_lines(["error connecting to localhost:5000"]), []
+        )
+
+    def test_issue_ref_with_error_context_not_detected(self) -> None:
+        # A "#529" GitHub ref must not fire even when the same line mentions
+        # "error" (e.g. an issue conversation in the pane). The (?<!#) guard
+        # drops it; \b alone would let it through.
+        for line in (
+            "Issue #529: error detection",
+            "error in issue #529 reproduction",
+        ):
+            with self.subTest(line=line):
+                self.assertEqual(ias.scan_lines([line]), [])
+
+
+class AnchoredRegexTests(unittest.TestCase):
+    def test_error_prefix_detected(self) -> None:
+        dets = ias.scan_lines(["Error: boom"])
+        self.assertEqual(len(dets), 1)
+        self.assertTrue(dets[0].reason.startswith("regex:"))
+
+    def test_error_uppercase_prefix_detected(self) -> None:
+        self.assertTrue(ias.scan_lines(["ERROR: boom"]))
+
+    def test_error_not_at_line_start_not_matched_by_regex(self) -> None:
+        # "  Error: " is not line-anchored, so the regex path does not fire.
+        dets = ias.scan_lines(["  Error: indented"])
+        self.assertFalse(any(d.reason.startswith("regex:") for d in dets))
+
+
+class SpinnerAgeTests(unittest.TestCase):
+    def test_spinner_below_threshold_not_detected(self) -> None:
+        self.assertEqual(ias.scan_lines(["✻ Cogitating for 2m 30s"]), [])
+
+    def test_spinner_at_threshold_detected(self) -> None:
+        dets = ias.scan_lines(["✻ Cogitating for 5m 0s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:5m"])
+
+    def test_spinner_above_threshold_detected(self) -> None:
+        dets = ias.scan_lines(["✺ Pondering for 12m 8s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:12m"])
+
+    def test_non_ascii_verb_matches(self) -> None:
+        dets = ias.scan_lines(["✻ Sautéed for 6m 23s"])
+        self.assertEqual([d.reason for d in dets], ["spinner_age:6m"])
+
+    def test_custom_threshold(self) -> None:
+        dets = ias.scan_lines(
+            ["✻ Working for 3m 0s"], spinner_threshold_min=2
+        )
+        self.assertEqual([d.reason for d in dets], ["spinner_age:3m"])
+
+    def test_not_a_spinner_line(self) -> None:
+        self.assertEqual(ias.scan_lines(["working for 9m on the task"]), [])
+
+
+class NormalizationTests(unittest.TestCase):
+    def test_accepts_bare_strings(self) -> None:
+        dets = ias.scan_lines(["API Error: 529"])
+        self.assertEqual(dets[0].row, 0)
+
+    def test_handles_none_text(self) -> None:
+        self.assertEqual(ias.scan_lines([{"row": 1, "text": None}]), [])
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, payload: dict, *extra: str):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *extra],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+        )
+
+    def test_cli_structured_content_exit_3_on_anomaly(self) -> None:
+        payload = {"structuredContent": {"lines": _observed_pane()}}
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 3)
+        out = json.loads(proc.stdout)
+        reasons = {d["reason"] for d in out["detections"]}
+        self.assertIn("spinner_age:9m", reasons)
+
+    def test_cli_clean_pane_exit_0(self) -> None:
+        payload = {"lines": [{"row": 1, "text": "Ran 1 shell command"}]}
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(json.loads(proc.stdout)["detections"], [])
+
+    def test_cli_custom_threshold(self) -> None:
+        payload = {"lines": ["✻ Working for 3m 0s"]}
+        proc = self._run(payload, "--spinner-threshold-min", "2")
+        self.assertEqual(proc.returncode, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/inspect_anomaly_scan.py
+++ b/tools/inspect_anomaly_scan.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Deterministic ERROR / spinner-age anomaly detector for dispatcher §4(d).
+
+This is the codified core of ``.dispatcher/references/worker-monitoring.md``
+Step 4 (d) "ERROR 検出". The detection used to live as prose that the
+dispatcher Claude applied by eyeballing the ``inspect_pane`` grid, which
+let three classes of failure slip through (Issue #492):
+
+* **Gap (1) — bottom-N window**: §4(d) scanned only the bottom 10 rows, so
+  an error banner that scrolled up (e.g. row 15 of a 43-row pane, with a
+  blank middle band below it) was invisible. This module scans **every
+  visible row** returned by ``inspect_pane``.
+* **Gap (2) — missing 529**: Anthropic's overload code ``529`` (and the
+  transient ``502`` / ``503`` / ``504``) were not in the substring list.
+* **Gap (3) — stuck spinner**: a ``{glyph} {verb} for {Xm Ys}`` spinner
+  that grows past a threshold (default 5 minutes) signals an effectively
+  hung API retry loop, independent of any substring match. This module
+  treats an aged spinner as an ERROR-equivalent detection.
+
+Keeping the logic as a pure function (:func:`scan_lines`) gives the
+contract a regression test (``tests/test_inspect_anomaly_scan.py``
+reproduces the 2026-05-28 case: 529 banner at row 15 + 9m spinner +
+empty bottom 10) and lets the dispatcher pipe ``inspect_pane`` output
+through a single deterministic detector via the CLI below.
+
+Scope: this module covers the ERROR-class detections (substring + anchored
+regex + spinner age). APPROVAL_BLOCKED detection stays in the prose §4(b)
+because it is target-line + cursor-position sensitive and not part of
+Issue #492.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from typing import Iterable, Optional, Sequence, Union
+
+# Default spinner-age threshold in minutes. A Claude Code spinner that has
+# been counting for this many minutes or more is treated as a stuck run.
+# Issue #492: observed 6m23s / 9m spins that never recovered on their own.
+SPINNER_AGE_THRESHOLD_MIN = 5
+
+# Case-insensitive *strong* substrings — these fire unconditionally because
+# they are unambiguous error wording. ``API Error`` covers the lowercase
+# ``api error`` variant via the case-insensitive compare, but both are kept
+# to mirror the documented §4(d) list verbatim.
+ERROR_SUBSTRINGS: tuple[str, ...] = (
+    "API Error",
+    "api error",
+    "rate limit",
+)
+
+# HTTP / Anthropic status codes. Matched only as standalone tokens (word
+# boundaries) AND only when the same line carries an error-ish keyword.
+# Broadening the scan from bottom-10 to *all* visible rows (Issue #492 gap 1)
+# amplifies the false-positive risk of bare-digit substrings, so a benign
+# line like ``localhost:5000``, ``500 passed``, or an issue ref ``#529`` must
+# not trip ``ERROR_DETECTED``. The codes remain the deliberate, futureproof
+# supplement for when Claude Code renames its error wording (Issue #492 gap 2):
+# ``529`` = Anthropic overload, ``502``/``503``/``504`` = transient gateway.
+ERROR_STATUS_CODES: tuple[str, ...] = ("429", "500", "502", "503", "504", "529")
+# ``(?<!#)`` drops GitHub-style issue refs (``#529``) which ``\b`` alone keeps
+# (``#`` is a non-word char, so a word boundary sits before the digit). A
+# longer-digit token like ``5000`` is already excluded by the trailing ``\b``.
+_STATUS_CODE_RE = re.compile(r"(?<!#)\b(429|500|502|503|504|529)\b")
+_ERROR_CONTEXT_RE = re.compile(
+    r"error|overload|unavailable|rate limit|too many requests|"
+    r"retry|retrying|gateway|server error|throttl",
+    re.IGNORECASE,
+)
+
+# Line-prefix anchored regexes (case-sensitive, matching the §4(d) prose).
+ERROR_ANCHORED_PATTERNS: tuple[str, ...] = (
+    r"^Error: ",
+    r"^ERROR: ",
+)
+_ERROR_ANCHORED_RES = tuple(re.compile(p) for p in ERROR_ANCHORED_PATTERNS)
+
+# Stuck-spinner regex. Claude Code renders ``{spinner_glyph} {verb} for
+# {Xm Ys}`` while a tool call or API retry runs; under healthy operation the
+# counter clears within seconds. The glyph class covers the rotating braille
+# / star glyphs Claude Code cycles through (kept generous on purpose — a new
+# glyph should not silently disable the detector). ``\w+`` matches the verb
+# including non-ASCII letters (e.g. "Sautéed") since Python's ``\w`` is
+# Unicode-aware for ``str`` patterns.
+SPINNER_AGE_PATTERN = (
+    r"^\s*[✻✺✶✷✸✹✦✧✱✲✳·∙▪●○◍◌◐◑◒◓*]+\s+\w+\s+for\s+(\d+)m\s+(\d+)s"
+)
+_SPINNER_AGE_RE = re.compile(SPINNER_AGE_PATTERN)
+
+
+@dataclass(frozen=True)
+class Detection:
+    """One ERROR-class anomaly found on a pane line.
+
+    ``kind`` is always ``"error"`` so callers map every detection onto the
+    existing ``ERROR_DETECTED`` notification path (spinner age is an
+    ERROR-equivalent per Issue #492 gap 3). ``reason`` distinguishes the
+    trigger for journal / debugging (``substring:API Error`` /
+    ``status_code:529`` / ``regex:^Error: `` / ``spinner_age:9m``).
+    """
+
+    kind: str
+    reason: str
+    row: Optional[int]
+    matched: str
+
+
+def _normalize(
+    lines: Iterable[Union[str, dict]],
+) -> list[tuple[Optional[int], str]]:
+    """Coerce the ``inspect_pane`` ``lines`` payload to ``(row, text)`` pairs.
+
+    Accepts either the structured ``[{"row": int, "text": str}, ...]`` shape
+    or a bare list of strings (row index inferred positionally).
+    """
+    out: list[tuple[Optional[int], str]] = []
+    for idx, item in enumerate(lines):
+        if isinstance(item, dict):
+            row = item.get("row")
+            text = item.get("text", "")
+        else:
+            row = idx
+            text = item
+        out.append((row, "" if text is None else str(text)))
+    return out
+
+
+def scan_lines(
+    lines: Iterable[Union[str, dict]],
+    *,
+    spinner_threshold_min: int = SPINNER_AGE_THRESHOLD_MIN,
+) -> list[Detection]:
+    """Scan **all** visible pane lines for ERROR-class anomalies.
+
+    Returns a list of :class:`Detection`, one per matching line/trigger.
+    An empty list means the pane looks clean. The scan deliberately covers
+    every row (Issue #492 gap 1) rather than only the bottom N.
+    """
+    detections: list[Detection] = []
+    for row, text in _normalize(lines):
+        if not text:
+            continue
+
+        lowered = text.lower()
+        content_hit = False
+        for needle in ERROR_SUBSTRINGS:
+            if needle.lower() in lowered:
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"substring:{needle}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+                # One content hit per line is enough to flag it.
+                content_hit = True
+                break
+
+        # Status code, gated on error context (only if no strong substring
+        # already flagged the line, to avoid a duplicate detection).
+        if not content_hit:
+            code_m = _STATUS_CODE_RE.search(text)
+            if code_m and _ERROR_CONTEXT_RE.search(text):
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"status_code:{code_m.group(1)}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+
+        for rx in _ERROR_ANCHORED_RES:
+            if rx.search(text):
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"regex:{rx.pattern}",
+                        row=row,
+                        matched=text,
+                    )
+                )
+                break
+
+        m = _SPINNER_AGE_RE.match(text)
+        if m:
+            minutes = int(m.group(1))
+            if minutes >= spinner_threshold_min:
+                detections.append(
+                    Detection(
+                        kind="error",
+                        reason=f"spinner_age:{minutes}m",
+                        row=row,
+                        matched=text,
+                    )
+                )
+
+    return detections
+
+
+def _load_lines(payload: dict) -> Sequence[Union[str, dict]]:
+    """Pull the ``lines`` array out of an ``inspect_pane`` result blob.
+
+    Accepts the raw ``structuredContent`` object (``{"lines": [...]}``) or a
+    bare list already at the top level.
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        if isinstance(payload.get("lines"), list):
+            return payload["lines"]
+        sc = payload.get("structuredContent")
+        if isinstance(sc, dict) and isinstance(sc.get("lines"), list):
+            return sc["lines"]
+    raise ValueError(
+        "input JSON must be a list of lines or contain a 'lines' / "
+        "'structuredContent.lines' array"
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan inspect_pane grid lines for ERROR / spinner-age anomalies "
+            "(dispatcher worker-monitoring §4(d), Issue #492)."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        type=argparse.FileType("r", encoding="utf-8"),
+        default=sys.stdin,
+        help="JSON file with inspect_pane result (default: stdin).",
+    )
+    parser.add_argument(
+        "--spinner-threshold-min",
+        type=int,
+        default=SPINNER_AGE_THRESHOLD_MIN,
+        help=(
+            "Spinner-age threshold in minutes; a spinner counting for >= this "
+            f"many minutes is an ERROR-equivalent (default: {SPINNER_AGE_THRESHOLD_MIN})."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    payload = json.load(args.input)
+    detections = scan_lines(
+        _load_lines(payload), spinner_threshold_min=args.spinner_threshold_min
+    )
+    json.dump(
+        {"detections": [asdict(d) for d in detections]},
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+    # Exit 3 when an anomaly is found so a shell caller can branch without
+    # parsing JSON; exit 0 means the pane is clean.
+    return 3 if detections else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#494](https://github.com/suisya-systems/claude-org-ja/pull/494)

Merge SHA: `5eee8bd182dde15ac6d5dd50fad1b6ff4cca01f7`

Source: ja PR [#494](https://github.com/suisya-systems/claude-org-ja/pull/494)
Merge SHA: `5eee8bd182dde15ac6d5dd50fad1b6ff4cca01f7`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 1 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_inspect_anomaly_scan.py`
- `tools/inspect_anomaly_scan.py`

</details>
<details><summary>divergence-allowed (1)</summary>

- `.dispatcher/references/worker-monitoring.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
