### PR TITLE
docs(en): mirror ja#485 worker_brief_normal.md self-edit boilerplate fix

### DIFF
--- a/tools/templates/worker_brief_normal.md
+++ b/tools/templates/worker_brief_normal.md
@@ -11,7 +11,7 @@
 
 ### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
 1. `${worker_dir}` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
-2. claude-org リポジトリ（`${claude_org_path}`）を別途 clone してはならない（直接編集すること）
+2. claude-org リポジトリ（`${claude_org_path}`）を `${worker_dir}` 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
 3. `git push` は実行できない（完了報告で窓口に依頼すること）
 
 ### Windows 環境の注意事項


### PR DESCRIPTION
## Summary

Mirrors the ja#485 fix to en `tools/templates/worker_brief_normal.md` (single-line reword). This unblocks the CI on the two auto-mirror PRs (#277 ja#485, #282 ja#490) which fail the same assertion (`assertNotIn('直接編集すること', brief)` in `test_gen_delegate_payload.py` / `test_gen_worker_brief.py`) because the en template still carried the old boilerplate.

## Change
```
-2. claude-org リポジトリ（${claude_org_path}）を別途 clone してはならない（直接編集すること）
+2. claude-org リポジトリ（${claude_org_path}）を ${worker_dir} 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
```
Verbatim mirror of the ja#485 change (blob `b53d5ca..a05d260`, matches ja side).

## Verification
- Rendered `gen_worker_brief.render(self_edit=False)` and confirmed the 3 previously-failing assertions now pass (`直接編集すること`=absent, `別途 clone`=absent, `参照専用`=present).
- Full `unittest discover -s tests`: identical pass/fail profile to clean main (no regression from this change; pre-existing Windows-local-only failures are green on Linux CI).
- codex self-review: no findings.

Once merged, #277 and #282 update-branch onto this and go green.