### PR TITLE
docs(en): translate ja#485 worker-claude-template self-edit boilerplate (Closes #278)

### DIFF
--- a/.claude/skills/org-delegate/references/worker-claude-template.md
+++ b/.claude/skills/org-delegate/references/worker-claude-template.md
@@ -23,7 +23,7 @@ If it does not match, do not begin work — report the error to the Secretary.
 
 ### Prohibited (technically blocked by permissions.deny + PreToolUse Hooks)
 1. Do not reproduce the claude-org structure (`.claude/`, `.dispatcher/`, `.curator/`, `.state/`, `registry/`, `dashboard/`, `knowledge/`, etc.) inside `{worker_dir}`.
-2. Do not separately clone the claude-org repository (`{claude_org_path}`) — edit it directly.
+2. Do not clone the claude-org repository (`{claude_org_path}`) into `{worker_dir}` (claude-org itself is reference-only; the edit target is only the project in this worker directory).
 3. You cannot run `git push` (ask the Secretary in the completion report).
 
 ### Correct workflow


### PR DESCRIPTION
Final translation-parity reflection of the ja#485 reword into `.claude/skills/org-delegate/references/worker-claude-template.md`. The other ja#485 translation-class file (`tools/templates/worker_brief_normal.md`) already landed via #285 (Refs #278); this completes the ja#485 translation set.

## Change (1 file)
Prohibition item 2 reworded from `Do not separately clone ... — edit it directly.` to: do not clone the claude-org repository into `{worker_dir}` (claude-org itself is reference-only; the edit target is only the project in this worker directory).

Docs-only, no new links, no Python test impact. codex self-review: no findings.

Closes #278.