### PR TITLE
docs(en): reflect ja#495 escalation_to_user ask-time gate (Closes #288)

### DIFF
--- a/.claude/skills/org-escalation/SKILL.md
+++ b/.claude/skills/org-escalation/SKILL.md
@@ -53,10 +53,12 @@ When the Lead receives a peer message containing "approval request", "judgment e
      ```
      If a pending entry for the same task_id already exists this is idempotent (no-op). The register is the primary lookup source for the Dispatcher's SECRETARY_RELAY_GAP_SUSPECTED detector ([`../../../.dispatcher/references/worker-monitoring.md` Step 5.1](../../../.dispatcher/references/worker-monitoring.md#step-5-1)).
 
-3. **Relay to the human**: organize the content and the options and present them. Right after presenting, update the register to `escalated`:
+3. **Relay to the human**: organize the content and the options and present them. **At the moment you present the options (the ask moment)**, immediately before updating the register to `escalated` via `resolve --kind to_user`, emit an awaiting_user signal to the attention watcher (Issue #28, ask-time gate):
    ```bash
+   bash tools/journal_append.sh notify_sent kind=awaiting_user task_id={task_id} gate=escalation_to_user note="<short summary of the options presented>"
    python tools/pending_decisions.py resolve --task-id {task_id} --kind to_user
    ```
+   The classifier picks it up as `secretary_awaiting_user` (default severity `urgent`) and beeps the instant a decision is requested. In interactive use the user replies within tens of seconds to a few minutes, so pending_decision aging (15 min) effectively never fires, which makes this ask-time emit the primary route for the urgent notification. The Step 4.5 emit (`escalation_reply_forward`) remains a separate forward-time emit (Step 3 = ask time / 4.5 = forward time). This emit only appends a single journal line and does not touch the register or pending_decisions state.
 
 4. **The moment a reply arrives from the user** — **before** forwarding it to the worker — record `user_replied_at` in the register (Issue #301):
    ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,17 +51,18 @@ When a completion / progress / Codex round / escalation-for-decision message arr
 
 At gates where the Secretary stops because "the next move is waiting on a user reply", emit a one-line signal so the attention watcher can alert the user. The Secretary side stops inside this claude-org-ja repo, so when the user is not at the screen the awaiting_user state can sit unattended for a long time. By having the runtime classifier map this emit to `secretary_awaiting_user` (default severity `urgent`), the user is notified by a beep or equivalent.
 
-### Target gates (3 sites)
+### Target gates (4 sites)
 - **`worker_completed`**: after receiving a completion report from a Worker → issuing an ack + appending the review transition to the DB `events` table → just before stopping to wait on the user's approval. [`/org-delegate`](./.claude/skills/org-delegate/SKILL.md) Step 5 sub 2a.
 - **`ci_green_merge_gate`**: during post-PR CI monitoring, on receipt of `CI_COMPLETED` (CI green) → just before asking the user for merge approval. [`/org-pull-request`](./.claude/skills/org-pull-request/SKILL.md) 2b-i.
+- **`escalation_to_user`**: at the moment a Worker's decision request is escalated to a human and the options are presented (the ask moment), just before the wait for the user's reply. [`/org-escalation`](./.claude/skills/org-escalation/SKILL.md) Step 3. In interactive use the user replies within tens of seconds to a few minutes, so pending_decision aging (15 min) effectively never fires, which makes this ask-time emit the primary route for the urgent notification.
 - **`escalation_reply_forward`**: after escalating a decision request to a human, receiving the user's reply, and just before forwarding it to the Worker. The `mark-user-replied` → `resolve --kind to_worker` boundary of [`/org-escalation`](./.claude/skills/org-escalation/SKILL.md).
 
 ### Canonical emit form
 ```
 bash tools/journal_append.sh notify_sent kind=awaiting_user task_id=TASK gate=GATE note=SHORT
 ```
-- `task_id`: the task_id corresponding to the target Worker / PR / decision (for `escalation_reply_forward`, the task_id tied to the decision).
-- `gate`: one of `worker_completed` / `ci_green_merge_gate` / `escalation_reply_forward`.
+- `task_id`: the task_id corresponding to the target Worker / PR / decision (for `escalation_to_user` / `escalation_reply_forward`, the task_id tied to the decision).
+- `gate`: one of `worker_completed` / `ci_green_merge_gate` / `escalation_to_user` / `escalation_reply_forward`.
 - `note`: short context of one line or less (PR number / Issue number / summary, etc.).
 
 ### Notifier behavior


### PR DESCRIPTION
Translation-parity + forward-port reflection of ja#495 (the `escalation_to_user` ask-time awaiting_user gate) into the en mirror. The runtime-class half (attention.example.json) already landed via #287; this is the docs/skills half tracked by #288.

## Changes (2 files)
- `CLAUDE.md` (translation parity): target-gate list 3 → 4, adds the `escalation_to_user` bullet, updates the canonical-emit task_id/gate enumeration.
- `.claude/skills/org-escalation/SKILL.md` (en-canonical, forward-port): Step 3 emits `gate=escalation_to_user` `awaiting_user` immediately when presenting options (the ask moment), just before `resolve --kind to_user`; documented as a separate timing from the Step 4.5 forward-time emit (journal-only side effect).

Docs-only, no new links. codex self-review: no Blocker/Major.

Closes #288.