### PR TITLE
auto-mirror: ja#498 feat(claude): scope block-org-structure guard to claude-org repo, allow target-repo .claude/ writes (Edit/Write only)

### DIFF
--- a/.hooks/block-org-structure.sh
+++ b/.hooks/block-org-structure.sh
@@ -72,6 +72,16 @@ ROOT_ONLY_BLOCKED=('registry' 'dashboard' 'knowledge')
 CANONICAL_WORKER=$(normalize_drive_letter "$(normalize_slashes "$(portable_realpath "$WORKER_DIR")")")
 CANONICAL_CLAUDE_ORG=$(normalize_drive_letter "$(normalize_slashes "$(portable_realpath "$CLAUDE_ORG_PATH")")")
 
+# WORKER_DIR が claude-org 本体の内側か外側かを判定する。
+# このガードの目的は claude-org 本体の組織構造保護であり、対象リポジトリ（claude-org の
+# 外に置かれた worker dir）の .claude/ は Claude Code の正当な設定ディレクトリなので保護対象外。
+# 判定軸: CANONICAL_WORKER が CANONICAL_CLAUDE_ORG と一致するか、その配下にあるか。
+# （末尾スラッシュ付き前方一致で claude-org-ja-foo 等の兄弟前方一致誤判定を防ぐ）
+WORKER_IN_ORG=0
+if [[ "$CANONICAL_WORKER" == "$CANONICAL_CLAUDE_ORG" || "$CANONICAL_WORKER" == "$CANONICAL_CLAUDE_ORG/"* ]]; then
+  WORKER_IN_ORG=1
+fi
+
 # --- Write/Edit の場合: file_path をチェック ---
 if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
   FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -94,6 +104,23 @@ if [[ "$TOOL_NAME" == "Write" || "$TOOL_NAME" == "Edit" ]]; then
   PLANS_DIR="$CANONICAL_WORKER/.claude/plans"
   if [[ "$CANONICAL_FILE" == "$PLANS_DIR/"* || "$CANONICAL_FILE" == "$PLANS_DIR" ]]; then
     exit 0
+  fi
+
+  # 例外: WORKER_DIR が claude-org 本体の外（=対象リポジトリの worker。本 hook が
+  # attach される worker_roles.default の通常ケース）の場合、WORKER_DIR/.claude/ 配下への
+  # 書き込みを許可する。対象リポジトリの .claude/ (settings / commands / agents / skills 等) は
+  # Claude Code プロジェクト設定として正当で、組織構造ガードの保護対象（claude-org 本体）では
+  # ない。WORKER_DIR が claude-org 内の場合は従来どおり .claude/ をブロックする（例: claude-org
+  # 自身を対象とする audit worker は本 hook が attach され in-org でこの分岐に到達する。
+  # claude-org-self-edit role は本 hook 自体を attach しない運用のため対象外 —
+  # role-pattern-sandbox-contract.md §5.3）。本変更は
+  # CLAUDE_ORG_PATH/.claude/ への書込経路を一切増やさないため、knowledge-curation-contract
+  # §3.1（claude-org 自身の .claude/skills/ 境界）には影響しない。
+  if [[ "$WORKER_IN_ORG" == "0" ]]; then
+    CLAUDE_DIR="$CANONICAL_WORKER/.claude"
+    if [[ "$CANONICAL_FILE" == "$CLAUDE_DIR/"* || "$CANONICAL_FILE" == "$CLAUDE_DIR" ]]; then
+      exit 0
+    fi
   fi
 
   # 全深度ブロック: パスコンポーネントに含まれるかチェック
@@ -143,6 +170,13 @@ if [[ "$TOOL_NAME" == "Bash" ]]; then
       if [[ "$DIR" == ".claude" ]] && echo "$NORMALIZED_CMD" | grep -qE "\.claude/plans(/|[[:space:]]|\"|$)"; then
         continue
       fi
+      # 注: out-of-org（対象リポジトリ）worker 向けの .claude/ 緩和は Write/Edit 経路のみ。
+      # Bash 半は従来どおり .claude/ 操作を全ブロックする。Bash 半は grep ベースの
+      # best-effort で、相対 (../claude-org-ja/.claude/) や変数展開 (${CLAUDE_ORG_PATH}/.claude/)
+      # 経由の claude-org 本体 .claude/ 参照を確実にスコープできず、緩和すると §3.1 の
+      # Layer-4 境界に穴が開くため（CANONICAL_WORKER で positively scope できる Write/Edit
+      # 経路と異なる）。skill ファイル作成は Write ツールが親 dir を自動生成するため、
+      # Bash 緩和なしでも対象リポジトリの .claude/skills/ 作成は成立する。
       deny_with_reason "Bash コマンドで claude-org の組織構造ディレクトリ ($DIR/) を作成しようとしています。"
     fi
   done

--- a/tests/test-block-org-structure.sh
+++ b/tests/test-block-org-structure.sh
@@ -25,6 +25,14 @@ portable_realpath() {
 WORKER_DIR="$(portable_realpath "$REPO_ROOT")"
 CLAUDE_ORG_PATH="$(portable_realpath "$REPO_ROOT/../..")"
 
+# Out-of-org WORKER_DIR: a sibling of claude-org (NOT under CLAUDE_ORG_PATH).
+# Models a worker_roles.default worker operating on a target repository. For such
+# workers the org-structure guard lifts the WORKER_DIR/.claude/ block (the target
+# repo's .claude/ is legitimate Claude Code project config), while the other
+# org-structure dirs stay blocked. WORKER_DIR inside CLAUDE_ORG_PATH (the in-org
+# cases above) keeps the original blocking behavior.
+OOO_WORKER_DIR="$(portable_realpath "$CLAUDE_ORG_PATH/../target-repo-test")"
+
 PASS=0; FAIL=0; TEST_NUM=0
 TMPFILES=()
 cleanup() { rm -f "${TMPFILES[@]}"; }
@@ -58,6 +66,14 @@ run_hook() {
   local json="$1" stderr_file="$2"
   local exit_code=0
   echo "$json" | env WORKER_DIR="$WORKER_DIR" CLAUDE_ORG_PATH="$CLAUDE_ORG_PATH" bash "$HOOK" 2>"$stderr_file" || exit_code=$?
+  echo "$exit_code"
+}
+
+# Same as run_hook but with an out-of-org WORKER_DIR (target-repo worker).
+run_hook_ooo() {
+  local json="$1" stderr_file="$2"
+  local exit_code=0
+  echo "$json" | env WORKER_DIR="$OOO_WORKER_DIR" CLAUDE_ORG_PATH="$CLAUDE_ORG_PATH" bash "$HOOK" 2>"$stderr_file" || exit_code=$?
   echo "$exit_code"
 }
 
@@ -252,6 +268,90 @@ stderr=$(mktemp); TMPFILES+=("$stderr")
 json='{"tool_name":"Read","tool_input":{"file_path":"'"$WORKER_DIR"'/.claude/settings.json"}}'
 ec=$(run_hook "$json" "$stderr")
 assert_exit 0 "$ec" "Other tool (Read): passes through"
+
+# ========== Out-of-org WORKER_DIR Tests (target-repo worker) ==========
+# WORKER_DIR is a sibling of claude-org (outside CLAUDE_ORG_PATH). The guard's
+# purpose is protecting claude-org itself, so the target repo's .claude/ is allowed
+# on the Edit/Write half (realpath-scoped to WORKER_DIR/.claude), while the other
+# org-structure dirs remain blocked. The Bash half is NOT relaxed (it blocks
+# .claude/ for all roles) — see the out-of-org Bash cases below.
+
+# 28. out-of-org WORKER_DIR/.claude/skills/<name>/SKILL.md (allow)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/.claude/skills/my-skill/SKILL.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 0 "$ec" "Write(out-of-org): target repo .claude/skills/ is allowed"
+
+# 29. out-of-org WORKER_DIR/.claude/settings.json (allow — whole .claude/)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/.claude/settings.json"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 0 "$ec" "Write(out-of-org): target repo .claude/settings.json is allowed"
+
+# 30. out-of-org WORKER_DIR/.claude/commands/foo.md (allow — whole .claude/)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/.claude/commands/foo.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 0 "$ec" "Write(out-of-org): target repo .claude/commands/ is allowed"
+
+# 31. out-of-org WORKER_DIR/.dispatcher/foo (block — only .claude/ is lifted)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/.dispatcher/task.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Write(out-of-org): .dispatcher/ is still blocked"
+
+# 32. out-of-org WORKER_DIR/.state/foo (block — only .claude/ is lifted)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/.state/state.json"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Write(out-of-org): .state/ is still blocked"
+
+# 33. out-of-org WORKER_DIR/registry/foo (block — only .claude/ is lifted)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Write","tool_input":{"file_path":"'"$OOO_WORKER_DIR"'/registry/workers.json"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Write(out-of-org): registry/ is still blocked"
+
+# --- out-of-org Bash: the .claude/ relaxation is Edit/Write-only; the Bash half
+#     keeps blocking .claude/ for all roles. A shell-string grep cannot safely scope
+#     relative/variable references away from claude-org's own .claude/, so relaxing
+#     it would open a Layer-4 hole into knowledge-curation-contract §3.1. ---
+
+# 34. out-of-org Bash mkdir .claude/skills (block — Bash half is NOT relaxed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"mkdir -p .claude/skills/my-skill"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): mkdir .claude/skills is blocked (Bash half not relaxed)"
+
+# 35. out-of-org Bash mkdir .state (block)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"mkdir -p .state/foo"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): mkdir .state is blocked"
+
+# 36. out-of-org Bash absolute CLAUDE_ORG_PATH/.claude/ (block — §3.1 boundary)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"cp foo '"$CLAUDE_ORG_PATH"'/.claude/skills/x/SKILL.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): write into CLAUDE_ORG_PATH/.claude/ is blocked"
+
+# 37. out-of-org Bash worker's OWN absolute .claude/ (block — Bash half not relaxed; use Write)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"mkdir -p '"$OOO_WORKER_DIR"'/.claude/skills/x"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): worker's own absolute .claude/ via Bash is blocked"
+
+# 38. out-of-org Bash relative reference to claude-org's .claude/ (block — closed Layer-4 leak)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"cp foo ../claude-org-ja/.claude/skills/x/SKILL.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): relative ../claude-org-ja/.claude/ is blocked"
+
+# 39. out-of-org Bash variable reference to claude-org's .claude/ (block — closed Layer-4 leak)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"cp foo ${CLAUDE_ORG_PATH}/.claude/skills/x/SKILL.md"}}'
+ec=$(run_hook_ooo "$json" "$stderr")
+assert_exit 2 "$ec" "Bash(out-of-org): variable \${CLAUDE_ORG_PATH}/.claude/ is blocked"
 
 # --- Summary ---
 echo "# $PASS passed, $FAIL failed out of $TEST_NUM tests"


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#498](https://github.com/suisya-systems/claude-org-ja/pull/498)

Merge SHA: `7b517d6d6e561ea5f7e8e257b30862a47a47cad4`

Source: ja PR [#498](https://github.com/suisya-systems/claude-org-ja/pull/498)
Merge SHA: `7b517d6d6e561ea5f7e8e257b30862a47a47cad4`

| class | count |
|---|---|
| runtime | 2 |
| translation | 2 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `.hooks/block-org-structure.sh`
- `tests/test-block-org-structure.sh`

</details>
<details><summary>translation (2)</summary>

- `docs/contracts/role-pattern-sandbox-contract.md`
- `docs/contracts/worker-git-guardrails-design.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
