### PR TITLE
auto-mirror: ja#523 feat(claude): work-discovery triage compute layer (read-only scan) — #520 Phase 1

### DIFF
--- a/tests/test_work_discovery_scan.py
+++ b/tests/test_work_discovery_scan.py
@@ -1,0 +1,601 @@
+"""Unit tests for tools/work_discovery_scan.py — Phase 1 (Issue #520).
+
+These lock the deterministic computation-layer contract from
+``docs/design/work-discovery-triage.md`` §3/§4/§5 and the §11 calibration:
+
+* dependency extraction is high-precision (§11-3): blocking keywords with
+  *immediate* ``#N`` refs only; ``Parent:`` / ``Design:`` / ``Refs`` /
+  ``Closes`` / ``Discovered while working on`` / bare ``#N`` / prose-only
+  ``Depends on:`` must NOT be read as blockers (avoid false exclusion);
+* blocked Issues are excluded *with a visible reason*, never silently;
+* the estimated axes carry ``*_estimated`` flags + ``signals[]`` (§4.4);
+* ``truncated_count`` is always reported (§5.1, no silent truncation);
+* ``scan()`` is a pure function — same input → same output — and never
+  touches ``gh`` / git / state.db (INV-1/INV-3);
+* exit codes are 0 / 10 / 2 (never 1), driven by status (§5.1).
+
+The whole suite drives the pure core with synthetic Issue dicts; no
+network, no subprocess. A final test execs the script through
+``--from-file`` to confirm the stdout-JSON + exit-code wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools import work_discovery_scan as wds  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "tools" / "work_discovery_scan.py"
+
+
+def _issue(number, *, title="t", body="", labels=None, updated="2026-06-01T00:00:00Z"):
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": [{"name": n} for n in (labels or [])],
+        "updatedAt": updated,
+    }
+
+
+# ----------------------------------------------------------------------
+# Dependency extraction (§4.1 / §11-3 calibration)
+# ----------------------------------------------------------------------
+
+
+class TestBlockingRefExtraction(unittest.TestCase):
+    def test_blocked_by_immediate_ref(self):
+        self.assertEqual(
+            wds.extract_blocking_refs("Blocked by #482", is_epic=False), [482]
+        )
+
+    def test_depends_on_multiple_refs(self):
+        self.assertEqual(
+            wds.extract_blocking_refs(
+                "Depends on #100, #101 and #102", is_epic=False
+            ),
+            [100, 101, 102],
+        )
+
+    def test_requires_ref(self):
+        self.assertEqual(
+            wds.extract_blocking_refs("Requires #7", is_epic=False), [7]
+        )
+
+    def test_pr_prefixed_ref(self):
+        self.assertEqual(
+            wds.extract_blocking_refs("Blocked by PR #55", is_epic=False), [55]
+        )
+
+    def test_prose_depends_on_yields_no_ref(self):
+        # Real #177/#178: "Depends on:" describes unfiled sibling commits and
+        # only mentions #80 deep in the prose ("filed under #80"). The #80 is
+        # the parent umbrella, not an immediate dependency — must NOT extract.
+        body = (
+            "- Parent: #80\n"
+            "- Design: PR #175\n"
+            "- Depends on: Commit 1 (tokenizer) and Commit 2 follow-up "
+            "Issues — see follow-up Issues to be filed under #80.\n"
+        )
+        self.assertEqual(wds.extract_blocking_refs(body, is_epic=False), [])
+
+    def test_non_blocking_notations_ignored(self):
+        # §11-3: none of these are blockers.
+        body = (
+            "Parent: #80\n"
+            "Design: PR #175\n"
+            "Refs #500\n"
+            "Closes #501\n"
+            "Discovered while working on #480\n"
+            "See #999 for context.\n"
+        )
+        self.assertEqual(wds.extract_blocking_refs(body, is_epic=False), [])
+
+    def test_task_list_ref_counts_for_non_epic(self):
+        body = "## Subtasks\n- [ ] #11\n- [x] #12\n"
+        self.assertEqual(
+            wds.extract_blocking_refs(body, is_epic=False), [11]
+        )
+
+    def test_task_list_ignored_for_epic(self):
+        # An epic's child checklist is tracking, not a blocker on the epic.
+        body = "## Children\n- [ ] #11\n- [ ] #12\n"
+        self.assertEqual(wds.extract_blocking_refs(body, is_epic=True), [])
+
+    def test_empty_body(self):
+        self.assertEqual(wds.extract_blocking_refs(None, is_epic=False), [])
+        self.assertEqual(wds.extract_blocking_refs("", is_epic=False), [])
+
+
+class TestClassifyDependency(unittest.TestCase):
+    def test_resolved_when_refs_all_closed(self):
+        issue = _issue(10, body="Blocked by #5")
+        status, open_refs = wds.classify_dependency(issue, open_refs=set())
+        self.assertEqual(status, "resolved")
+        self.assertEqual(open_refs, [])
+
+    def test_blocked_when_ref_open(self):
+        issue = _issue(10, body="Blocked by #5")
+        status, open_refs = wds.classify_dependency(issue, open_refs={5})
+        self.assertEqual(status, "blocked")
+        self.assertEqual(open_refs, [5])
+
+    def test_block_label_forces_blocked(self):
+        issue = _issue(10, body="no refs", labels=["blocked"])
+        status, open_refs = wds.classify_dependency(issue, open_refs=set())
+        self.assertEqual(status, "blocked")
+        self.assertEqual(open_refs, [])
+
+    def test_on_hold_label_forces_blocked(self):
+        issue = _issue(10, labels=["on-hold"])
+        status, _ = wds.classify_dependency(issue, open_refs=set())
+        self.assertEqual(status, "blocked")
+
+    def test_unknown_ref_treated_resolved(self):
+        # A ref to a number not in open_refs (closed issue / merged PR /
+        # nonexistent) is resolved — no over-exclusion (§11-3).
+        issue = _issue(10, body="Depends on #9999")
+        status, _ = wds.classify_dependency(issue, open_refs={1, 2, 3})
+        self.assertEqual(status, "resolved")
+
+
+# ----------------------------------------------------------------------
+# Priority (§4.1, §11-2 degradation)
+# ----------------------------------------------------------------------
+
+
+class TestPriority(unittest.TestCase):
+    def test_priority_high_label(self):
+        level, _ = wds.compute_priority(_issue(1, labels=["priority:high"]))
+        self.assertEqual(level, "high")
+
+    def test_p0_label_high(self):
+        level, _ = wds.compute_priority(_issue(1, labels=["p0"]))
+        self.assertEqual(level, "high")
+
+    def test_backlog_label_low(self):
+        level, sig = wds.compute_priority(_issue(1, labels=["backlog"]))
+        self.assertEqual(level, "low")
+        self.assertTrue(any("backlog" in s for s in sig))
+
+    def test_default_medium_without_labels(self):
+        # §11-2: this repo has no priority labels / milestones → medium.
+        level, sig = wds.compute_priority(_issue(1, labels=["enhancement"]))
+        self.assertEqual(level, "medium")
+        self.assertTrue(any("default medium" in s for s in sig))
+
+
+# ----------------------------------------------------------------------
+# Effort (§4.1 / §4.4)
+# ----------------------------------------------------------------------
+
+
+class TestEffort(unittest.TestCase):
+    def test_size_label_not_estimated(self):
+        size, estimated, sig = wds.estimate_effort(_issue(1, labels=["size:L"]))
+        self.assertEqual(size, "L")
+        self.assertFalse(estimated)
+        self.assertTrue(any("label:size:l" in s for s in sig))
+
+    def test_bare_size_label(self):
+        size, estimated, _ = wds.estimate_effort(_issue(1, labels=["M"]))
+        self.assertEqual(size, "M")
+        self.assertFalse(estimated)
+
+    def test_heuristic_small(self):
+        size, estimated, sig = wds.estimate_effort(_issue(1, body="short"))
+        self.assertEqual(size, "S")
+        self.assertTrue(estimated)
+        self.assertTrue(any("estimated effort" in s for s in sig))
+
+    def test_heuristic_large_by_length(self):
+        size, estimated, _ = wds.estimate_effort(_issue(1, body="x" * 2500))
+        self.assertEqual(size, "L")
+        self.assertTrue(estimated)
+
+    def test_heuristic_large_by_criteria(self):
+        body = "intro\n" + "\n".join("- [ ] item" for _ in range(9))
+        size, estimated, _ = wds.estimate_effort(_issue(1, body=body))
+        self.assertEqual(size, "L")
+        self.assertTrue(estimated)
+
+
+# ----------------------------------------------------------------------
+# Estimated axes (§4.2 / §4.4)
+# ----------------------------------------------------------------------
+
+
+class TestEstimatedAxes(unittest.TestCase):
+    def test_parallelizable_leaf(self):
+        ok, sig = wds.estimate_parallelizable([])
+        self.assertTrue(ok)
+        self.assertTrue(any("leaf" in s for s in sig))
+
+    def test_not_parallelizable_with_open_refs(self):
+        ok, sig = wds.estimate_parallelizable([5, 6])
+        self.assertFalse(ok)
+        self.assertTrue(any("#5" in s for s in sig))
+
+    def test_unblocked_by_recent_merge_via_blocking_ref(self):
+        ok, sig = wds.estimate_unblocked_by_recent_merge(
+            _issue(10), blocking_refs=[200], recent_merge_pr_numbers={200},
+            recent_merge_closed_issues=set(), recent_merge_referenced_issues=set(),
+        )
+        self.assertTrue(ok)
+        self.assertTrue(any("#200" in s for s in sig))
+
+    def test_unblocked_by_recent_merge_via_pr_link(self):
+        ok, _ = wds.estimate_unblocked_by_recent_merge(
+            _issue(10), blocking_refs=[], recent_merge_pr_numbers=set(),
+            recent_merge_closed_issues=set(), recent_merge_referenced_issues={10},
+        )
+        self.assertTrue(ok)
+
+    def test_no_recent_merge_linkage(self):
+        ok, sig = wds.estimate_unblocked_by_recent_merge(
+            _issue(10), blocking_refs=[1], recent_merge_pr_numbers=set(),
+            recent_merge_closed_issues=set(), recent_merge_referenced_issues=set(),
+        )
+        self.assertFalse(ok)
+        self.assertTrue(any("no recent-merge" in s for s in sig))
+
+
+class TestSummary(unittest.TestCase):
+    def test_skips_headings_and_quotes(self):
+        body = "# Title\n\n> quote\n\nThe real first line.\n"
+        self.assertEqual(
+            wds.extract_summary(body, "fallback"), "The real first line."
+        )
+
+    def test_falls_back_to_title(self):
+        self.assertEqual(wds.extract_summary("# only heading\n", "T"), "T")
+
+    def test_truncates_long_line(self):
+        out = wds.extract_summary("w " * 200, "t")
+        self.assertLessEqual(len(out), 121)
+        self.assertTrue(out.endswith("…"))
+
+
+# ----------------------------------------------------------------------
+# Ranking + full scan (§4.3 / §5.1)
+# ----------------------------------------------------------------------
+
+
+class TestRankingAndScan(unittest.TestCase):
+    def test_priority_beats_effort(self):
+        issues = [
+            _issue(1, labels=["backlog"], body="short"),  # low / S
+            _issue(2, labels=["priority:high"], body="x" * 3000),  # high / L
+        ]
+        result = wds.scan(issues, set(), [], wds.ScanConfig())
+        self.assertEqual(result["candidates"][0]["issue"], 2)
+
+    def test_recent_merge_ranks_above_plain(self):
+        issues = [
+            _issue(1, body="plain"),
+            _issue(2, body="Refs nothing"),
+        ]
+        merges = [{"number": 900, "title": "x", "body": "Closes #2"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        self.assertEqual(result["candidates"][0]["issue"], 2)
+        self.assertTrue(
+            result["candidates"][0]["unblocked_by_recent_merge"]
+        )
+
+    def test_truncation_reported(self):
+        issues = [_issue(i, body="b") for i in range(1, 8)]  # 7 resolved
+        result = wds.scan(issues, set(), [], wds.ScanConfig(top_n=3))
+        self.assertEqual(result["candidate_count"], 3)
+        self.assertEqual(result["truncated_count"], 4)
+
+    def test_blocked_excluded_with_reason_not_silent(self):
+        issues = [
+            _issue(10, body="Blocked by #5"),  # blocked (#5 open)
+            _issue(5, body="open dep"),
+        ]
+        result = wds.scan(issues, set(), [], wds.ScanConfig())
+        excluded = {e["issue"]: e for e in result["excluded_blocked"]}
+        self.assertIn(10, excluded)
+        self.assertEqual(excluded[10]["blocking_refs"], [5])
+        self.assertTrue(excluded[10]["note"])  # reason present, not silent
+
+    def test_no_candidates_status(self):
+        issues = [_issue(10, body="Blocked by #5", labels=["blocked"])]
+        result = wds.scan(issues, set(), [], wds.ScanConfig())
+        self.assertEqual(result["status"], "no_candidates")
+        self.assertEqual(result["candidate_count"], 0)
+
+    def test_recommendation_is_rank_1(self):
+        issues = [
+            _issue(1, body="plain"),
+            _issue(2, labels=["priority:high"], body="b"),
+        ]
+        result = wds.scan(issues, set(), [], wds.ScanConfig())
+        self.assertEqual(result["recommendation"]["issue"], 2)
+        self.assertTrue(result["recommendation"]["reason"])
+
+    def test_estimated_flags_always_present(self):
+        result = wds.scan([_issue(1, body="b")], set(), [], wds.ScanConfig())
+        cand = result["candidates"][0]
+        for key in (
+            "effort_estimated",
+            "parallelizable_estimated",
+            "unblocked_by_recent_merge_estimated",
+        ):
+            self.assertIn(key, cand)
+        self.assertTrue(cand["parallelizable_estimated"])
+        self.assertTrue(cand["signals"])  # auditable signals present
+
+    def test_generated_for_propagates(self):
+        result = wds.scan(
+            [_issue(1, body="b")], set(), [], wds.ScanConfig(trigger="post_merge")
+        )
+        self.assertEqual(result["generated_for"], "post_merge")
+
+    def test_internal_fields_stripped(self):
+        result = wds.scan([_issue(1, body="b")], set(), [], wds.ScanConfig())
+        self.assertNotIn("_updated_at", result["candidates"][0])
+
+    def test_determinism_same_input_same_output(self):
+        issues = [
+            _issue(3, labels=["priority:high"], body="a"),
+            _issue(1, body="b"),
+            _issue(2, labels=["backlog"], body="c"),
+        ]
+        r1 = wds.scan(issues, set(), [], wds.ScanConfig())
+        r2 = wds.scan(
+            [dict(i, labels=list(i["labels"])) for i in issues],
+            set(), [], wds.ScanConfig(),
+        )
+        self.assertEqual(
+            json.dumps(r1, sort_keys=True, ensure_ascii=False),
+            json.dumps(r2, sort_keys=True, ensure_ascii=False),
+        )
+
+    def _cand(self, number, *, priority="medium", parallelizable=True):
+        # A hand-built candidate dict for ranking-mechanism tests. (In a real
+        # scan every candidate is parallelizable by construction — see
+        # estimate_parallelizable's docstring — so we synthesize one that is
+        # not, purely to exercise the free_panes weighting.)
+        return {
+            "issue": number,
+            "priority": priority,
+            "effort": "M",
+            "parallelizable": parallelizable,
+            "unblocked_by_recent_merge": False,
+            "_updated_at": "2026-06-01T00:00:00Z",
+        }
+
+    def test_free_panes_positive_boosts_parallelizable(self):
+        cands = [
+            self._cand(1, parallelizable=False),
+            self._cand(2, parallelizable=True),
+        ]
+        top, _ = wds.rank_candidates(cands, top_n=3, free_panes=2)
+        self.assertEqual(top[0]["issue"], 2)  # parallel boosted ahead
+
+    def test_free_panes_zero_neutralizes_parallel_boost(self):
+        # With no free pane to fill, parallelism carries no weight; the tie
+        # falls through to recency, which is equal → stable original order.
+        cands = [
+            self._cand(1, parallelizable=False),
+            self._cand(2, parallelizable=True),
+        ]
+        top, _ = wds.rank_candidates(cands, top_n=3, free_panes=0)
+        self.assertEqual(top[0]["issue"], 1)
+
+
+# ----------------------------------------------------------------------
+# CLI wiring: stdout JSON + exit codes (§5.1)
+# ----------------------------------------------------------------------
+
+
+class TestCliWiring(unittest.TestCase):
+    def _run(self, bundle):
+        fd, name = tempfile.mkstemp(suffix=".json", prefix="wds_bundle_")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(bundle, f)
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--from-file", name],
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            os.unlink(name)
+        return proc
+
+    def test_exit_10_when_candidates(self):
+        bundle = {
+            "issues": [_issue(1, body="b")],
+            "open_pr_numbers": [],
+            "recent_merges": [],
+        }
+        proc = self._run(bundle)
+        self.assertEqual(proc.returncode, wds.EXIT_CANDIDATES_FOUND)
+        data = json.loads(proc.stdout)
+        self.assertEqual(data["status"], "candidates_found")
+
+    def test_exit_0_when_no_candidates(self):
+        bundle = {
+            "issues": [_issue(1, body="x", labels=["blocked"])],
+            "open_pr_numbers": [],
+            "recent_merges": [],
+        }
+        proc = self._run(bundle)
+        self.assertEqual(proc.returncode, wds.EXIT_NO_CANDIDATES)
+        self.assertEqual(json.loads(proc.stdout)["status"], "no_candidates")
+
+    def test_exit_2_on_error(self):
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        self.assertEqual(json.loads(proc.stdout)["status"], "error")
+
+    def test_exit_codes_never_collide_with_1(self):
+        # Guard the §5.1 rationale: a Python crash exits 1, which must not be
+        # reachable as a meaningful status code.
+        self.assertNotIn(1, {wds.EXIT_NO_CANDIDATES, wds.EXIT_CANDIDATES_FOUND, wds.EXIT_ERROR})
+
+    def test_error_json_keeps_fixed_schema(self):
+        # Codex review (Major): the error branch must carry the same audit
+        # fields as a normal result, not a bespoke shape.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--from-file", "/no/such/file.json"],
+            capture_output=True,
+            text=True,
+        )
+        data = json.loads(proc.stdout)
+        for key in (
+            "status",
+            "generated_for",
+            "candidate_count",
+            "truncated_count",
+            "input_truncated",
+            "candidates",
+            "recommendation",
+            "excluded_blocked",
+            "error",
+        ):
+            self.assertIn(key, data)
+        self.assertEqual(data["candidate_count"], 0)
+        self.assertEqual(data["truncated_count"], 0)
+
+    def test_argparse_error_emits_json_exit_2(self):
+        # Codex review round 2 (Minor): a CLI parse error must still print a
+        # single JSON object to stdout and exit 2, not bare usage on stderr.
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--top-n", "not-an-int"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, wds.EXIT_ERROR)
+        data = json.loads(proc.stdout)  # stdout is valid JSON
+        self.assertEqual(data["status"], "error")
+        self.assertIn("argument error", data["error"])
+
+    def test_input_truncated_present_in_normal_output(self):
+        bundle = {
+            "issues": [_issue(1, body="b")],
+            "open_pr_numbers": [],
+            "recent_merges": [],
+        }
+        proc = self._run(bundle)
+        data = json.loads(proc.stdout)
+        self.assertIn("input_truncated", data)
+        self.assertEqual(
+            data["input_truncated"], {"open_issues": False, "open_prs": False}
+        )
+
+
+class TestCommentsAndMilestone(unittest.TestCase):
+    """Codex review (Major/Minor): blockers in comments + milestone tier."""
+
+    def test_blocker_in_comment_detected(self):
+        # §4.1: a blocker added later in a *comment* must still be detected.
+        issue = {
+            "number": 10,
+            "title": "t",
+            "body": "no blocker in body",
+            "labels": [],
+            "comments": [{"body": "Update: Blocked by #5 now."}],
+            "updatedAt": "2026-06-01T00:00:00Z",
+        }
+        status, open_refs = wds.classify_dependency(issue, open_refs={5})
+        self.assertEqual(status, "blocked")
+        self.assertEqual(open_refs, [5])
+
+    def test_comment_blocker_excluded_in_scan(self):
+        issues = [
+            {
+                "number": 10,
+                "title": "t",
+                "body": "b",
+                "labels": [],
+                "comments": [{"body": "Depends on #5"}],
+                "updatedAt": "2026-06-01T00:00:00Z",
+            },
+            _issue(5, body="open dep"),
+        ]
+        result = wds.scan(issues, set(), [], wds.ScanConfig())
+        excluded = {e["issue"] for e in result["excluded_blocked"]}
+        self.assertIn(10, excluded)
+
+    def test_unblocked_via_ref_closed_by_recent_merge(self):
+        # Codex review (Major): Depends on #100 + a recent PR that Closes
+        # #100 → this issue is now unblocked-by-recent-merge.
+        ok, sig = wds.estimate_unblocked_by_recent_merge(
+            _issue(10),
+            blocking_refs=[100],
+            recent_merge_pr_numbers=set(),
+            recent_merge_closed_issues={100},
+            recent_merge_referenced_issues={100},
+        )
+        self.assertTrue(ok)
+        self.assertTrue(any("#100" in s for s in sig))
+
+    def test_unblocked_via_closed_ref_in_full_scan(self):
+        issues = [_issue(10, body="Depends on #100")]
+        merges = [{"number": 900, "title": "x", "body": "Closes #100"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        self.assertTrue(
+            result["candidates"][0]["unblocked_by_recent_merge"]
+        )
+
+    def test_bare_refs_does_not_close_blocking_ref(self):
+        # Codex review round 2 (Major): a recent PR that only `Refs #100`
+        # (not Closes/Fixes/Resolves) must NOT mark #100 as resolved, so an
+        # issue depending on #100 is not unblocked via the blocking-ref side.
+        ok, _ = wds.estimate_unblocked_by_recent_merge(
+            _issue(10),
+            blocking_refs=[100],
+            recent_merge_pr_numbers=set(),
+            recent_merge_closed_issues=set(),  # #100 only referenced, not closed
+            recent_merge_referenced_issues={100},
+        )
+        self.assertFalse(ok)
+
+    def test_bare_refs_negative_in_full_scan(self):
+        issues = [_issue(10, body="Depends on #100")]
+        merges = [{"number": 900, "title": "x", "body": "Refs #100"}]
+        result = wds.scan(issues, set(), merges, wds.ScanConfig())
+        self.assertFalse(
+            result["candidates"][0]["unblocked_by_recent_merge"]
+        )
+
+    def test_milestone_emitted_as_signal(self):
+        issue = _issue(1, body="b")
+        issue["milestone"] = {"title": "v1.0"}
+        level, sig = wds.compute_priority(issue)
+        self.assertEqual(level, "medium")
+        self.assertTrue(any("milestone:v1.0" in s for s in sig))
+
+    def test_milestone_breaks_tie_above_no_milestone(self):
+        a = _issue(1, body="b")
+        b = _issue(2, body="b")
+        b["milestone"] = {"title": "v1.0"}
+        result = wds.scan([a, b], set(), [], wds.ScanConfig())
+        # Equal priority/effort/etc.; #2 (milestoned) ranks first.
+        self.assertEqual(result["candidates"][0]["issue"], 2)
+
+    def test_milestone_internal_field_stripped(self):
+        issue = _issue(1, body="b")
+        issue["milestone"] = {"title": "v1.0"}
+        result = wds.scan([issue], set(), [], wds.ScanConfig())
+        self.assertNotIn("_has_milestone", result["candidates"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/work_discovery_scan.py
+++ b/tools/work_discovery_scan.py
@@ -1,0 +1,920 @@
+#!/usr/bin/env python3
+"""Work-discovery triage — Phase 1 computation layer (Issue #520).
+
+This is the **deterministic, side-effect-free computation layer** described
+in ``docs/design/work-discovery-triage.md`` §3 (二層構造) / §4 (triage 基準)
+/ §5 (出力フォーマット). It reads open Issues (via the GitHub CLI ``gh``,
+read-only), ranks the ones whose dependencies are resolved, and prints a
+single candidate JSON object to stdout. It does **nothing else**.
+
+Invariants enforced here (design §7):
+
+* **INV-1 / INV-3 — read-only, side effects zero.** Only ``gh`` *read*
+  subcommands are invoked (``gh issue list``, ``gh pr list``; the repo is
+  taken from ``--repo`` or gh's current-repo default). No write API, no
+  ``git``, no ``spawn`` / ``commit`` /
+  ``PR``, and — unlike delivery-layer tools — **no journal / state.db
+  write either** (journal bookkeeping is the delivery layer's job, design
+  §7.1 「副作用ゼロの担保」). The scan never decides to start work; it only
+  proposes (INV-1 propose-only).
+* The tool is a **pure function of its inputs** at heart: ``scan()`` and
+  every helper below take already-fetched data and return the result dict
+  with no I/O, so the same input always yields the same output (design §4
+  再現性契約) and so it works equally as a "startup one-shot scan"
+  (design §11-4) without any delivery wiring.
+
+Machine-readable contract (design §5.1), modelled on
+``tools/check_curate_threshold.py``:
+
+* stdout — a single JSON object (see ``scan()`` for the schema).
+* exit code — the delivery layer branches on this, **not** on JSON parsing:
+
+  - ``0``  — ``no_candidates``: zero candidates after triage.
+  - ``10`` — ``candidates_found``: at least one ranked candidate.
+  - ``2``  — ``error``: unexpected failure (``gh`` missing / API error /
+    bad JSON). ``status=error`` is printed with an ``error`` field.
+
+  ``10`` (not ``1``) so an uncaught Python traceback — which exits ``1`` —
+  can never be misread as "candidates found"; and ``0`` cleanly means
+  "no candidates" without colliding with the crash code (design §5.1).
+
+Calibration of the three §11 open points against this repo's real Issues
+(``gh label list`` / ``gh issue list`` / ``gh pr list`` on 2026-06-10):
+
+* **Priority labels (§11-2)**: this repo has **no** ``priority:*`` / ``p0..p2``
+  labels and **no milestones**. Priority therefore degrades exactly as
+  §4.1 prescribes: a ``backlog`` / ``wontfix`` label → ``low``; otherwise
+  ``medium`` (the generic ``priority:*`` / ``p0..p2`` matchers are kept so
+  the contract still works on repos that do have them). Recency
+  (``updatedAt``) is used only as a ranking tiebreaker + signal, never to
+  promote/demote the priority *level* (keeps the level deterministic from
+  metadata).
+* **Dependency notation (§11-3)**: real blockers use ``Blocked by #N`` /
+  ``Depends on #N`` / ``Requires #N``. Crucially, ``Parent: #N``,
+  ``Design: PR #N``, ``Refs #N``, ``Closes #N``, ``Discovered while
+  working on #N`` and bare ``#N`` are **NOT** blockers — matching any of
+  them would wrongly exclude live candidates (the §11-3 over-matching
+  risk). The extractor keys off the three blocking keywords and pulls
+  ``#N`` only from the trailing clause, so ``Depends on: Commit 1
+  follow-up Issue`` (real #177/#178, no ``#N``) yields *no* refs.
+* **N default (§11-1)**: fixed ``N=3`` (``--top-n``), configurable.
+  ``--free-panes`` is accepted and, when > 0, boosts ``parallelizable``
+  candidates in the ranking, but does not change N in Phase 1.
+
+Estimated axes (design §4.4) — ``effort`` / ``parallelizable`` /
+``unblocked_by_recent_merge`` — always carry a ``*_estimated`` flag and
+contribute entries to the per-candidate ``signals[]`` so a human can audit
+*why* the machine guessed what it did. ``truncated_count`` and
+``excluded_blocked`` are always emitted (no silent truncation, design §5.1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+except (AttributeError, OSError):
+    pass
+
+EXIT_NO_CANDIDATES = 0
+EXIT_CANDIDATES_FOUND = 10
+EXIT_ERROR = 2
+
+DEFAULT_TOP_N = 3
+# How many most-recent merged PRs feed the `unblocked_by_recent_merge`
+# heuristic (design §4.2 "直近 K 件"). Configurable via --recent-merges.
+DEFAULT_RECENT_MERGES = 10
+# Row cap for the open-Issue / open-PR fetches. If a fetch returns exactly
+# this many rows the result may be truncated, which is surfaced via the
+# output's `input_truncated` flags (never silent — design §5.1).
+DEFAULT_OPEN_LIMIT = 500
+
+# --- dependency notation (design §4.1, calibrated §11-3) ---------------
+# Match a blocking *keyword* (anywhere on a line — body or comment, inline
+# or list-led, e.g. "Update: Blocked by #5") and capture the rest of the
+# line. Precision is enforced by _LEADING_REFS_RE below, not by anchoring:
+# a keyword not immediately followed by a `#N` (e.g. "requires careful
+# thought", "Depends on: Commit 1 ...") contributes no ref.
+_BLOCK_KEYWORD_RE = re.compile(
+    r"(?im)(?:blocked\s+by|depends\s+on|requires)\b(.*)$"
+)
+# From a blocking clause, consume only the *leading* run of refs
+# (`#N`, optionally `PR #N`, comma/and-separated). #N refs are taken from
+# this leading run **only** — so `Depends on: Commit 1 ... filed under #80`
+# (real #177/#178) yields *no* ref (the clause starts with prose, not a
+# `#N`), and `Parent: #N` / `Design: PR #N` / `Refs #N` / `Closes #N` /
+# `Discovered while working on #N` / bare `#N` are never misread as
+# blockers. This is the §11-3 over-matching guard: prefer *not* excluding.
+_LEADING_REFS_RE = re.compile(
+    r"^[\s:]*((?:(?:pr\s+)?#\d+[\s,]*(?:and\s+|&\s*)?)+)", re.I
+)
+# A bare-number ref like `#531`; the leading `(?<![\w/])` stops it firing
+# inside `org/repo#531`-style cross-repo refs (single-repo scope, §10).
+_ISSUE_REF_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+# Unchecked task-list item that references an Issue: `- [ ] #N`. Counted
+# as a pending dependency for NON-epic issues only — an epic's child
+# checklist is tracking, not a blocker on the epic itself (calibrated
+# against epic #376; see classify_dependency).
+_OPEN_TASK_REF_RE = re.compile(r"(?im)^[ \t]*[-*]\s*\[ \]\s*.*?#(\d+)\b")
+
+# PR → linked-Issue notation for the recent-merge heuristic (design §4.2).
+# §4.2 keeps two *distinct* conditions, so we keep two patterns:
+#   * a *closing* keyword (Closes/Fixes/Resolves #N) means the merged PR
+#     actually resolved #N — used to decide a blocking ref "was closed by a
+#     recent merge";
+#   * a *mere reference* (Refs #N) does not close #N — only used to decide
+#     "this Issue is referenced by (a natural follow-up of) a recent merge".
+# Conflating them would let a bare `Refs #100` mark #100 as resolved.
+_PR_CLOSE_RE = re.compile(
+    r"(?i)\b(?:closes|close|closed|fixes|fix|fixed|resolves|resolve|resolved)\s+#(\d+)\b"
+)
+_PR_REF_RE = re.compile(r"(?i)\b(?:refs|ref|re)\s+#(\d+)\b")
+
+# Labels that force `blocked` regardless of refs (design §4.1).
+_BLOCK_LABELS = {"blocked", "on-hold", "on hold"}
+# Labels that force priority `low` when no explicit priority label exists.
+_LOW_PRIORITY_LABELS = {"backlog", "wontfix"}
+
+_PRIORITY_LABEL_RE = re.compile(
+    r"(?i)^(?:priority[:/\s-]*)?(high|medium|med|low|p0|p1|p2)$"
+)
+_SIZE_LABEL_RE = re.compile(r"(?i)^(?:size|effort)[:/\s-]*(s|m|l|xs|xl)$")
+# A standalone size label like `S` / `M` / `L`.
+_BARE_SIZE_RE = re.compile(r"(?i)^(xs|s|m|l|xl)$")
+
+_PRIORITY_RANK = {"high": 2, "medium": 1, "low": 0}
+_EFFORT_RANK = {"S": 0, "M": 1, "L": 2}
+
+
+@dataclass
+class ScanConfig:
+    """Knobs for a scan run (design §11-1 / §8 generated_for)."""
+
+    top_n: int = DEFAULT_TOP_N
+    free_panes: int | None = None
+    trigger: str = "manual"
+
+
+# ----------------------------------------------------------------------
+# Pure helpers — no I/O. Each takes already-fetched data and is a pure
+# function of its arguments (design §4 再現性契約).
+# ----------------------------------------------------------------------
+
+
+def _label_names(issue: dict) -> list[str]:
+    """Normalize an issue's labels to a list of lowercase name strings.
+
+    Accepts both ``gh``'s ``[{"name": ...}]`` shape and a plain list of
+    strings (the latter is convenient for tests / `--from-file`)."""
+    out: list[str] = []
+    for label in issue.get("labels") or []:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if isinstance(name, str):
+            out.append(name.strip().lower())
+    return out
+
+
+def _comment_bodies(issue: dict) -> list[str]:
+    """Return comment body strings for an Issue (``gh`` ``comments`` field).
+
+    Accepts ``gh``'s ``[{"body": ...}]`` shape and a plain list of strings
+    (test / ``--from-file`` convenience). Missing → empty list."""
+    out: list[str] = []
+    for c in issue.get("comments") or []:
+        if isinstance(c, dict):
+            body = c.get("body")
+        else:
+            body = c
+        if isinstance(body, str):
+            out.append(body)
+    return out
+
+
+def dependency_text(issue: dict) -> str:
+    """Concatenate body + all comment bodies for dependency scanning.
+
+    Design §4.1 says blockers may live in the Issue **body or comments**
+    (a blocker added later in a comment must still be detected), so the
+    dependency extractor reads both."""
+    parts = [issue.get("body") or ""]
+    parts.extend(_comment_bodies(issue))
+    return "\n".join(parts)
+
+
+def extract_blocking_refs(text: str | None, *, is_epic: bool) -> list[int]:
+    """Return Issue/PR numbers this Issue is blocked by / depends on.
+
+    ``text`` is the Issue body concatenated with its comments (see
+    ``dependency_text``). Only the three blocking keywords (`Blocked by` /
+    `Depends on` / `Requires`) contribute, and only via the `#N` refs in
+    their trailing clause (design §4.1, §11-3 calibration). For non-epic
+    issues an unchecked task-list item `- [ ] #N` also counts as a pending
+    dependency; for epics it does not (child checklists are tracking).
+
+    Deduplicated, sorted ascending for a stable, reproducible output.
+    """
+    if not text:
+        return []
+    refs: set[int] = set()
+    for clause in _BLOCK_KEYWORD_RE.findall(text):
+        lead = _LEADING_REFS_RE.match(clause)
+        if not lead:
+            continue
+        for num in _ISSUE_REF_RE.findall(lead.group(1)):
+            refs.add(int(num))
+    if not is_epic:
+        for num in _OPEN_TASK_REF_RE.findall(text):
+            refs.add(int(num))
+    return sorted(refs)
+
+
+def has_block_label(issue: dict) -> bool:
+    """True if a `blocked` / `on-hold` label forces unresolved (design §4.1)."""
+    return any(name in _BLOCK_LABELS for name in _label_names(issue))
+
+
+def classify_dependency(
+    issue: dict, open_refs: set[int]
+) -> tuple[str, list[int]]:
+    """Decide `resolved` vs `blocked` for one Issue (design §4.1).
+
+    ``open_refs`` is the set of Issue/PR numbers that are still **open**
+    (open issues ∪ open PRs). A blocking ref counts as unresolved iff it is
+    in ``open_refs``; a ref that is not (closed issue, merged/closed PR, or
+    a number that does not exist) is treated as resolved — deliberately, to
+    avoid the §11-3 over-exclusion failure mode.
+
+    Returns ``(status, open_blocking_refs)`` where ``status`` is
+    ``"blocked"`` or ``"resolved"`` and ``open_blocking_refs`` is the
+    sorted list of refs that are still open (empty when resolved).
+    """
+    is_epic = "epic" in _label_names(issue)
+    blocking = extract_blocking_refs(dependency_text(issue), is_epic=is_epic)
+    open_blocking = sorted(n for n in blocking if n in open_refs)
+    if has_block_label(issue) or open_blocking:
+        return "blocked", open_blocking
+    return "resolved", []
+
+
+def milestone_title(issue: dict) -> str | None:
+    """Return the Issue's milestone title, or ``None`` (``gh`` ``milestone``).
+
+    Accepts ``gh``'s ``{"title": ...}`` object, a plain title string, or
+    ``None``."""
+    ms = issue.get("milestone")
+    if isinstance(ms, dict):
+        title = ms.get("title")
+        return title if isinstance(title, str) and title else None
+    if isinstance(ms, str) and ms:
+        return ms
+    return None
+
+
+def compute_priority(issue: dict) -> tuple[str, list[str]]:
+    """Compute `high`/`medium`/`low` priority + signals (design §4.1).
+
+    Tier order per §4.1 — **label > milestone > recency**:
+
+    1. an explicit priority label (`priority:*` / `p0..p2`) → its level;
+    2. a `backlog` / `wontfix` label → `low`;
+    3. otherwise `medium` (the default). A milestone, when present, does
+       not change the *level* (mapping a milestone to high/low needs a
+       due-date policy, deferred to §9 future work) but is emitted as a
+       signal and used as a ranking tiebreaker (see ``_sort_key`` — a
+       milestoned Issue ranks above a non-milestoned one of equal
+       priority), which is exactly the "milestone > recency" tier.
+
+    This repo has neither priority labels nor milestones (§11-2), so in
+    practice the result is `low` for `backlog`/`wontfix` and `medium`
+    otherwise. Recency never changes the level (it is a tiebreaker only),
+    keeping the level deterministic from metadata (§4 再現性契約).
+    """
+    signals: list[str] = []
+    for name in _label_names(issue):
+        m = _PRIORITY_LABEL_RE.match(name)
+        if not m:
+            continue
+        token = m.group(1).lower()
+        level = {
+            "high": "high",
+            "p0": "high",
+            "medium": "medium",
+            "med": "medium",
+            "p1": "medium",
+            "low": "low",
+            "p2": "low",
+        }.get(token)
+        if level:
+            signals.append(f"label:{name}")
+            return level, signals
+    for name in _label_names(issue):
+        if name in _LOW_PRIORITY_LABELS:
+            signals.append(f"label:{name}")
+            return "low", signals
+    ms = milestone_title(issue)
+    if ms:
+        signals.append(f"milestone:{ms} (level not promoted — see §9)")
+        return "medium", signals
+    signals.append("no priority label/milestone → default medium")
+    return "medium", signals
+
+
+def _count_acceptance_criteria(body: str) -> int:
+    """Number of checklist items `- [ ]` / `- [x]` (acceptance criteria)."""
+    return len(re.findall(r"(?im)^[ \t]*[-*]\s*\[[ xX]\]", body))
+
+
+def estimate_effort(issue: dict) -> tuple[str, bool, list[str]]:
+    """Return ``(size, estimated, signals)`` — S/M/L (design §4.1).
+
+    A ``size:S/M/L`` / ``effort:*`` label (or a bare ``S``/``M``/``L``
+    label) is authoritative → ``estimated=False``. Otherwise a heuristic
+    over body length + acceptance-criteria count estimates the size and
+    ``estimated=True`` (design §4.4: estimated values must say so).
+    """
+    for name in _label_names(issue):
+        m = _SIZE_LABEL_RE.match(name) or _BARE_SIZE_RE.match(name)
+        if not m:
+            continue
+        raw = m.group(1).upper()
+        size = {"XS": "S", "S": "S", "M": "M", "L": "L", "XL": "L"}.get(raw)
+        if size:
+            return size, False, [f"label:{name}"]
+
+    body = issue.get("body") or ""
+    length = len(body)
+    criteria = _count_acceptance_criteria(body)
+    # Heuristic buckets (documented so the estimate is auditable):
+    #   L: long body OR many acceptance criteria (broad scope)
+    #   S: short body AND few criteria
+    #   M: everything in between
+    if length >= 2000 or criteria >= 8:
+        size = "L"
+    elif length < 600 and criteria <= 2:
+        size = "S"
+    else:
+        size = "M"
+    signals = [
+        f"estimated effort from body_len={length}, acceptance_criteria={criteria}"
+    ]
+    return size, True, signals
+
+
+def estimate_parallelizable(
+    open_blocking_refs: list[int],
+) -> tuple[bool, list[str]]:
+    """Estimate whether the Issue is a dependency-graph leaf (design §4.2).
+
+    Parallelizable iff it has no blocking ref to a still-open Issue — i.e.
+    it can be picked up independently to fill a free pane. Always an
+    estimate (implicit conflicts not expressed as refs are invisible), so
+    ``estimated=True`` is implied by the caller's ``*_estimated`` flag.
+
+    Note: for an actual *candidate* this is True by construction — a
+    candidate is precisely an Issue with no open blocking refs (anything
+    with open blocking refs is excluded as ``blocked``). The axis is kept
+    explicit because it is meaningful output for the human ("yes,
+    independent") and because the ``free_panes`` ranking weight (design
+    §4.2 「空き pane があるときランクを上げる」) reads it; it simply does not
+    discriminate *between* candidates in the common case.
+    """
+    if open_blocking_refs:
+        return False, [
+            "has open dependency refs: "
+            + ", ".join(f"#{n}" for n in open_blocking_refs)
+        ]
+    return True, ["leaf in dependency graph (no open dependency refs)"]
+
+
+def estimate_unblocked_by_recent_merge(
+    issue: dict,
+    blocking_refs: list[int],
+    recent_merge_pr_numbers: set[int],
+    recent_merge_closed_issues: set[int],
+    recent_merge_referenced_issues: set[int],
+) -> tuple[bool, list[str]]:
+    """Estimate whether a recent merge unblocked / spawned this Issue.
+
+    Per design §4.2 — two distinct conditions, deliberately separated:
+      * **blocking-ref side**: a blocking ref of this Issue is a
+        recently-merged PR, or an Issue/PR that a recent merge actually
+        *closed* (``recent_merge_closed_issues``, from Closes/Fixes/Resolves
+        — NOT a bare ``Refs``). I.e. the thing it depended on just got done.
+      * **this-Issue side**: a recently-merged PR *references* this Issue
+        (``recent_merge_referenced_issues``, any ref incl. ``Refs``) — a
+        natural follow-up.
+    Always an estimate (conceptual follow-ups not in any ref are invisible).
+    """
+    signals: list[str] = []
+    hit = False
+    for n in blocking_refs:
+        if n in recent_merge_pr_numbers:
+            signals.append(f"blocking ref #{n} was a recently-merged PR")
+            hit = True
+        elif n in recent_merge_closed_issues:
+            signals.append(
+                f"blocking ref #{n} was closed by a recently-merged PR"
+            )
+            hit = True
+    number = issue.get("number")
+    if isinstance(number, int) and number in recent_merge_referenced_issues:
+        signals.append("referenced by a recently-merged PR")
+        hit = True
+    if not hit:
+        signals.append("no recent-merge linkage detected")
+    return hit, signals
+
+
+def extract_summary(body: str | None, title: str) -> str:
+    """One-line machine summary from the body (design §5.1 `summary`).
+
+    First meaningful line: skips blank lines, markdown headings, block
+    quotes, HTML comments, list/table markers and horizontal rules. Falls
+    back to the title. Truncated to 120 chars on a word boundary.
+    """
+    candidate = ""
+    for raw in (body or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith(("#", ">", "<!--", "---", "***", "|", "```")):
+            continue
+        # strip a leading list marker / bold wrapper
+        line = re.sub(r"^[-*+]\s+", "", line)
+        line = line.strip("*_` ")
+        if line:
+            candidate = line
+            break
+    if not candidate:
+        candidate = title.strip()
+    if len(candidate) > 120:
+        cut = candidate[:120].rsplit(" ", 1)[0]
+        candidate = (cut or candidate[:120]).rstrip() + "…"
+    return candidate
+
+
+def build_candidate(
+    issue: dict,
+    *,
+    open_refs: set[int],
+    recent_merge_pr_numbers: set[int],
+    recent_merge_closed_issues: set[int],
+    recent_merge_referenced_issues: set[int],
+) -> dict | None:
+    """Build one candidate dict, or ``None`` if the Issue is blocked.
+
+    Blocked Issues are not candidates; the caller records them in
+    ``excluded_blocked`` instead (design §5.1).
+    """
+    status, open_blocking = classify_dependency(issue, open_refs)
+    if status == "blocked":
+        return None
+
+    is_epic = "epic" in _label_names(issue)
+    all_blocking = extract_blocking_refs(dependency_text(issue), is_epic=is_epic)
+
+    priority, prio_signals = compute_priority(issue)
+    effort, effort_estimated, effort_signals = estimate_effort(issue)
+    parallelizable, par_signals = estimate_parallelizable(open_blocking)
+    unblocked, merge_signals = estimate_unblocked_by_recent_merge(
+        issue,
+        all_blocking,
+        recent_merge_pr_numbers,
+        recent_merge_closed_issues,
+        recent_merge_referenced_issues,
+    )
+
+    signals = prio_signals + effort_signals + par_signals + merge_signals
+
+    return {
+        "issue": issue.get("number"),
+        "title": issue.get("title", ""),
+        "summary": extract_summary(issue.get("body"), issue.get("title", "")),
+        "dependency": "resolved",
+        "blocking_refs": all_blocking,
+        "priority": priority,
+        "effort": effort,
+        "effort_estimated": effort_estimated,
+        "parallelizable": parallelizable,
+        "parallelizable_estimated": True,
+        "unblocked_by_recent_merge": unblocked,
+        "unblocked_by_recent_merge_estimated": True,
+        # rank filled in by rank_candidates; _updated_at / _has_milestone
+        # are internal tiebreak fields stripped before serialization.
+        "rank": None,
+        "signals": signals,
+        "_updated_at": issue.get("updatedAt") or "",
+        "_has_milestone": milestone_title(issue) is not None,
+    }
+
+
+def _sort_key(cand: dict, free_panes: int | None) -> tuple:
+    """Lexicographic ranking key (design §4.3), higher = better.
+
+    (priority, unblocked_by_recent_merge, parallelizable-when-free-panes,
+    effort smallness, milestone-presence, recency). The milestone term sits
+    just above recency, realising §4.1's "label > milestone > recency" tier.
+    Returned negated where needed so a plain ascending sort puts the best
+    candidate first.
+    """
+    prio = _PRIORITY_RANK.get(cand["priority"], 1)
+    unblocked = 1 if cand["unblocked_by_recent_merge"] else 0
+    # parallelizable only earns rank weight when there is a free pane to
+    # fill (design §4.2); otherwise it is neutral.
+    par = (
+        1
+        if (cand["parallelizable"] and (free_panes is None or free_panes > 0))
+        else 0
+    )
+    effort_small = -_EFFORT_RANK.get(cand["effort"], 1)  # S best
+    has_ms = 1 if cand.get("_has_milestone") else 0
+    recency = cand.get("_updated_at") or ""  # ISO8601 sorts lexically
+    return (-prio, -unblocked, -par, -effort_small, -has_ms, _neg_str(recency))
+
+
+def _neg_str(s: str) -> tuple:
+    """Sort helper: make a later ISO timestamp sort *earlier* (better).
+
+    Python can't negate a string, so invert each codepoint into a tuple of
+    negative ordinals; longer strings (more recent, equal prefix) then sort
+    earlier as desired.
+    """
+    return tuple(-ord(c) for c in s)
+
+
+def rank_candidates(
+    candidates: list[dict], top_n: int, free_panes: int | None
+) -> tuple[list[dict], int]:
+    """Sort candidates, assign 1-based ``rank``, return ``(top, truncated)``.
+
+    ``truncated`` is the number of resolved candidates dropped past
+    ``top_n`` — always reported so truncation is never silent (design §5.1).
+    """
+    ordered = sorted(candidates, key=lambda c: _sort_key(c, free_panes))
+    for i, cand in enumerate(ordered, start=1):
+        cand["rank"] = i
+    top = ordered[:top_n] if top_n >= 0 else ordered
+    truncated = max(0, len(ordered) - len(top))
+    return top, truncated
+
+
+def make_recommendation(top: list[dict]) -> dict | None:
+    """Build the single recommendation (rank 1) with a reason (design §4.3)."""
+    if not top:
+        return None
+    best = top[0]
+    bits = [f"優先度 {best['priority']}"]
+    if best["unblocked_by_recent_merge"]:
+        bits.append("直近マージの follow-up")
+    if best["parallelizable"]:
+        bits.append("並列可（空き pane を埋められる）")
+    bits.append(f"工数 {best['effort']}{'(推定)' if best['effort_estimated'] else ''}")
+    bits.append("依存解決済み")
+    return {
+        "issue": best["issue"],
+        "reason": "・".join(bits),
+    }
+
+
+def scan(
+    issues: list[dict],
+    open_pr_numbers: set[int],
+    recent_merges: list[dict],
+    config: ScanConfig,
+    input_truncated: dict | None = None,
+) -> dict:
+    """Pure triage core: produce the candidate JSON dict (design §5.1).
+
+    ``issues`` — open Issues (each: ``number``, ``title``, ``body``,
+    ``labels``, ``updatedAt``, ``milestone``, ``comments``).
+    ``open_pr_numbers`` — currently-open PR numbers (combined with
+    open-issue numbers to resolve blocking refs). ``recent_merges`` —
+    recent merged PRs (each: ``number``, ``title``, ``body``) for the
+    unblocked-by-recent-merge heuristic. ``input_truncated`` — optional
+    ``{"open_issues": bool, "open_prs": bool}`` set by the caller when a
+    fetch hit its row cap, surfaced in the output so input-side truncation
+    is never silent (design §5.1). No I/O here.
+    """
+    open_issue_numbers = {
+        i["number"] for i in issues if isinstance(i.get("number"), int)
+    }
+    open_refs = open_issue_numbers | open_pr_numbers
+
+    # §4.2: keep "closed by a recent merge" and "merely referenced" apart.
+    recent_merge_pr_numbers: set[int] = set()
+    recent_merge_closed_issues: set[int] = set()
+    recent_merge_referenced_issues: set[int] = set()
+    for pr in recent_merges:
+        num = pr.get("number")
+        if isinstance(num, int):
+            recent_merge_pr_numbers.add(num)
+        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        closed = {int(n) for n in _PR_CLOSE_RE.findall(text)}
+        referenced = closed | {int(n) for n in _PR_REF_RE.findall(text)}
+        recent_merge_closed_issues |= closed
+        recent_merge_referenced_issues |= referenced
+
+    candidates: list[dict] = []
+    excluded_blocked: list[dict] = []
+    for issue in issues:
+        status, open_blocking = classify_dependency(issue, open_refs)
+        if status == "blocked":
+            note = (
+                "blocked/on-hold label"
+                if has_block_label(issue) and not open_blocking
+                else (
+                    ", ".join(f"#{n}" for n in open_blocking) + " が open のため除外"
+                )
+            )
+            excluded_blocked.append(
+                {
+                    "issue": issue.get("number"),
+                    "blocking_refs": open_blocking,
+                    "note": note,
+                }
+            )
+            continue
+        cand = build_candidate(
+            issue,
+            open_refs=open_refs,
+            recent_merge_pr_numbers=recent_merge_pr_numbers,
+            recent_merge_closed_issues=recent_merge_closed_issues,
+            recent_merge_referenced_issues=recent_merge_referenced_issues,
+        )
+        if cand is not None:
+            candidates.append(cand)
+
+    top, truncated = rank_candidates(candidates, config.top_n, config.free_panes)
+    recommendation = make_recommendation(top)
+
+    # strip internal-only fields before serialization
+    for cand in top:
+        cand.pop("_updated_at", None)
+        cand.pop("_has_milestone", None)
+
+    excluded_blocked.sort(key=lambda e: (e["issue"] is None, e["issue"]))
+
+    truncation = {"open_issues": False, "open_prs": False}
+    if input_truncated:
+        truncation.update(
+            {k: bool(v) for k, v in input_truncated.items() if k in truncation}
+        )
+
+    return {
+        "status": "candidates_found" if top else "no_candidates",
+        "generated_for": config.trigger,
+        "candidate_count": len(top),
+        "truncated_count": truncated,
+        # Input-side coverage caveat: True when the open-Issue/open-PR fetch
+        # hit its row cap, so some open Issues (candidates) or open blockers
+        # may be unseen — a blocker not fetched would be mis-resolved
+        # (design §5.1: never truncate silently).
+        "input_truncated": truncation,
+        "candidates": top,
+        "recommendation": recommendation,
+        "excluded_blocked": excluded_blocked,
+    }
+
+
+# ----------------------------------------------------------------------
+# I/O layer — read-only `gh` invocations + CLI. Kept thin and separate
+# from the pure core above.
+# ----------------------------------------------------------------------
+
+
+class GhError(RuntimeError):
+    """A `gh` read call failed (missing binary, auth, API error, bad JSON)."""
+
+
+def _run_gh_json(args: list[str]) -> list | dict:
+    """Run a read-only ``gh`` command and parse its JSON stdout.
+
+    Only ``gh`` subcommands that *read* are ever passed here (callers pass
+    ``repo view`` / ``issue list`` / ``pr list``). Raises ``GhError`` on
+    any failure so ``main`` can emit ``status=error`` / exit 2.
+    """
+    if shutil.which("gh") is None:
+        raise GhError("GitHub CLI (gh) not found in PATH")
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=True
+        )
+    except subprocess.CalledProcessError as exc:
+        raise GhError(
+            f"`gh {' '.join(args)}` failed: {exc.stderr.strip() or exc}"
+        ) from exc
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise GhError(
+            f"`gh {' '.join(args)}` returned non-JSON output: {exc}"
+        ) from exc
+
+
+def _repo_args(repo: str | None) -> list[str]:
+    return ["--repo", repo] if repo else []
+
+
+def fetch_open_issues(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> list[dict]:
+    data = _run_gh_json(
+        [
+            "issue",
+            "list",
+            *_repo_args(repo),
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,labels,updatedAt,createdAt,milestone,comments",
+        ]
+    )
+    return data if isinstance(data, list) else []
+
+
+def fetch_open_pr_numbers(repo: str | None, limit: int = DEFAULT_OPEN_LIMIT) -> set[int]:
+    data = _run_gh_json(
+        [
+            "pr",
+            "list",
+            *_repo_args(repo),
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number",
+        ]
+    )
+    if not isinstance(data, list):
+        return set()
+    return {p["number"] for p in data if isinstance(p.get("number"), int)}
+
+
+def fetch_recent_merges(repo: str | None, limit: int) -> list[dict]:
+    data = _run_gh_json(
+        [
+            "pr",
+            "list",
+            *_repo_args(repo),
+            "--state",
+            "merged",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,body,mergedAt",
+        ]
+    )
+    return data if isinstance(data, list) else []
+
+
+def _load_bundle(path: str) -> tuple[list[dict], set[int], list[dict]]:
+    """Load a pre-fetched ``{issues, open_pr_numbers, recent_merges}`` JSON.
+
+    Lets the tool run fully offline (manual validation / determinism
+    checks) without touching ``gh``. Strictly read-only.
+    """
+    with open(path, encoding="utf-8") as f:
+        bundle = json.load(f)
+    issues = bundle.get("issues") or []
+    open_pr_numbers = {
+        int(n) for n in (bundle.get("open_pr_numbers") or [])
+    }
+    recent_merges = bundle.get("recent_merges") or []
+    return issues, open_pr_numbers, recent_merges
+
+
+def _error_payload(trigger: str, message: str) -> dict:
+    """The fixed-schema error envelope (design §5.1), used by every error
+    path so the delivery layer parses one shape regardless of cause."""
+    return {
+        "status": "error",
+        "generated_for": trigger,
+        "candidate_count": 0,
+        "truncated_count": 0,
+        "input_truncated": {"open_issues": False, "open_prs": False},
+        "candidates": [],
+        "recommendation": None,
+        "excluded_blocked": [],
+        "error": message,
+    }
+
+
+class _JsonErrorParser(argparse.ArgumentParser):
+    """ArgumentParser that emits the error envelope as a single stdout JSON
+    on a usage error (instead of bare usage text), keeping the §5.1
+    "stdout is a single JSON object / exit 2 on error" contract even for
+    CLI parse errors. ``--help`` still exits 0 via the default path."""
+
+    def error(self, message: str):  # noqa: D102 — argparse override
+        print(
+            json.dumps(
+                _error_payload("manual", f"argument error: {message}"),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        self.exit(EXIT_ERROR)
+
+
+def main(argv=None) -> int:
+    parser = _JsonErrorParser(
+        description=(
+            "Work-discovery triage scan (read-only). Prints a single "
+            "candidate JSON to stdout; exit 0=no_candidates, "
+            "10=candidates_found, 2=error."
+        )
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="OWNER/REPO (default: current repo via gh auto-detection).",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=DEFAULT_TOP_N,
+        help=f"Max candidates to return (default {DEFAULT_TOP_N}).",
+    )
+    parser.add_argument(
+        "--free-panes",
+        type=int,
+        default=None,
+        help="Free worker pane count; when > 0, boosts parallelizable "
+        "candidates in ranking (does not change --top-n in Phase 1).",
+    )
+    parser.add_argument(
+        "--trigger",
+        default="manual",
+        help="Context label written to generated_for "
+        "(e.g. post_merge / worker_close / startup / manual).",
+    )
+    parser.add_argument(
+        "--recent-merges",
+        type=int,
+        default=DEFAULT_RECENT_MERGES,
+        help=f"How many recent merged PRs feed the unblocked-by-recent-"
+        f"merge heuristic (default {DEFAULT_RECENT_MERGES}).",
+    )
+    parser.add_argument(
+        "--from-file",
+        default=None,
+        help="Read a pre-fetched {issues, open_pr_numbers, recent_merges} "
+        "JSON bundle instead of calling gh (offline / validation).",
+    )
+    args = parser.parse_args(argv)
+
+    config = ScanConfig(
+        top_n=args.top_n, free_panes=args.free_panes, trigger=args.trigger
+    )
+
+    try:
+        input_truncated = {"open_issues": False, "open_prs": False}
+        if args.from_file:
+            issues, open_pr_numbers, recent_merges = _load_bundle(args.from_file)
+        else:
+            issues = fetch_open_issues(args.repo)
+            open_pr_numbers = fetch_open_pr_numbers(args.repo)
+            recent_merges = fetch_recent_merges(args.repo, args.recent_merges)
+            # A full page (== cap) means the fetch may have dropped rows; the
+            # flags surface that input-side truncation in the output.
+            input_truncated = {
+                "open_issues": len(issues) >= DEFAULT_OPEN_LIMIT,
+                "open_prs": len(open_pr_numbers) >= DEFAULT_OPEN_LIMIT,
+            }
+        result = scan(
+            issues, open_pr_numbers, recent_merges, config, input_truncated
+        )
+    except Exception as exc:  # noqa: BLE001 — report any failure as error/exit 2
+        # Keep the fixed schema (design §5.1) so the delivery layer parses
+        # the error branch the same way; the audit fields are present (empty)
+        # rather than absent, and `error` carries the cause.
+        print(
+            json.dumps(
+                _error_payload(config.trigger, str(exc)),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return EXIT_ERROR
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return (
+        EXIT_CANDIDATES_FOUND
+        if result["status"] == "candidates_found"
+        else EXIT_NO_CANDIDATES
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#523](https://github.com/suisya-systems/claude-org-ja/pull/523)

Merge SHA: `393cc22f2faf2e15cc60084ac39ce25004813258`

Source: ja PR [#523](https://github.com/suisya-systems/claude-org-ja/pull/523)
Merge SHA: `393cc22f2faf2e15cc60084ac39ce25004813258`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_work_discovery_scan.py`
- `tools/work_discovery_scan.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
