### PR TITLE
auto-mirror: ja#532 feat(claude): Epic #6 E (ja#514) — prose both-system + contract proposals + allowlist broker consume (Closes #514)

### DIFF
--- a/tests/test_transport_allowlist_consume.py
+++ b/tests/test_transport_allowlist_consume.py
@@ -1,0 +1,455 @@
+"""settings allowlist の broker consume (Epic #6 E / ja#514, §5.3) の
+golden / 不変条件テスト。
+
+D (ja#513) から defer した「user_common / per-role settings の mcp allowlist が
+renga 固定」問題の解消を検証する。設計 SoT: transport-lab
+``docs/design/ja-migration-plan.md`` §5.3 / §8 Issue E。
+
+**絶対条件 = 既定 renga で生成物が bit 等価 (byte 一致)**。検証する性質:
+
+1. **flag=renga (既定) で恒等 / bit 等価** — ``tools.transport.rewrite_allow_entries``
+   が入力をそのまま返し、``org_setup_prune`` の生成 allow が permissions.md の
+   テンプレートと 1 byte も変わらないこと (renga アンカー不変)。
+2. **flag=broker で broker tier に置換** — renga の MCP ブロック
+   (``mcp__renga-peers__*``) がロールの broker auth tier
+   (``mcp__org-broker__*``) に置換され、``Bash(...)`` 等の非 MCP エントリは
+   順序保持されること。
+3. **byte-drift 非波及** — ``org_extension_schema.json`` / permissions.md は
+   touch せず、``check_role_configs`` の renga 既定検証が不変であること。
+   broker 期待面の付け替えは in-memory のみ。
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+from claude_org_runtime import transport as rt_descriptor
+
+from tools import transport as t
+from tools import org_setup_prune as osp
+from tools import check_role_configs as crc
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PERMISSIONS_MD = (
+    REPO_ROOT / ".claude" / "skills" / "org-setup" / "references" / "permissions.md"
+)
+SCHEMA = REPO_ROOT / "tools" / "org_extension_schema.json"
+
+RENGA_PREFIX = "mcp__renga-peers__"
+BROKER_PREFIX = "mcp__org-broker__"
+
+
+@contextmanager
+def _env_transport(value):
+    """``ORG_TRANSPORT`` を一時設定 (None で明示削除) し、確実に復元する。"""
+    sentinel = object()
+    prev = os.environ.get(t.ENV_KEY, sentinel)
+    try:
+        if value is None:
+            os.environ.pop(t.ENV_KEY, None)
+        else:
+            os.environ[t.ENV_KEY] = value
+        yield
+    finally:
+        if prev is sentinel:
+            os.environ.pop(t.ENV_KEY, None)
+        else:
+            os.environ[t.ENV_KEY] = prev
+
+
+def _secretary_template_allow() -> list:
+    """実 permissions.md の窓口テンプレートの permissions.allow を取り出す。"""
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    blocks = osp.extract_role_blocks(
+        PERMISSIONS_MD.read_text(encoding="utf-8"), schema["roles"]
+    )
+    return list(blocks["secretary"]["permissions"]["allow"])
+
+
+class RewriteIdentityUnderRenga(unittest.TestCase):
+    """flag=renga (既定) では rewrite_allow_entries が恒等 = bit 等価の核。"""
+
+    def test_explicit_renga_is_identity(self):
+        allow = _secretary_template_allow()
+        out = t.rewrite_allow_entries(allow, "secretary", flag="renga")
+        self.assertEqual(out, allow)
+
+    def test_default_unset_env_is_renga_identity(self):
+        allow = _secretary_template_allow()
+        with _env_transport(None):  # ORG_TRANSPORT 無設定 = 既定 renga
+            out = t.rewrite_allow_entries(allow, "secretary")
+        self.assertEqual(out, allow)
+
+    def test_identity_for_all_org_roles(self):
+        # renga ではどのロールでも入力をそのまま返す (per-role 手書きサブセットを
+        # descriptor の renga-14 で勝手に上書きしない = byte 等価)。
+        sample = ["mcp__renga-peers__send_message", "Bash(git add:*)"]
+        for role in ("user_common", "secretary", "dispatcher", "curator", "worker"):
+            with self.subTest(role=role):
+                self.assertEqual(
+                    t.rewrite_allow_entries(sample, role, flag="renga"), sample
+                )
+
+    def test_returns_new_list_not_same_object(self):
+        # 恒等でも呼び出し側の入力を共有・破壊しないよう新リストを返す。
+        allow = _secretary_template_allow()
+        out = t.rewrite_allow_entries(allow, "secretary", flag="renga")
+        self.assertIsNot(out, allow)
+
+
+class RewriteBrokerSwap(unittest.TestCase):
+    """flag=broker で renga MCP ブロックを broker tier に置換する。"""
+
+    def test_secretary_block_swapped_to_broker_tier(self):
+        allow = _secretary_template_allow()
+        renga_count = sum(1 for e in allow if e.startswith(RENGA_PREFIX))
+        self.assertGreater(renga_count, 0, "前提: 窓口テンプレに renga MCP がある")
+        out = t.rewrite_allow_entries(allow, "secretary", flag="broker")
+        # renga エントリは 1 つも残らない
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in out))
+        # broker エントリは descriptor の secretary tier と一致
+        broker = [e for e in out if e.startswith(BROKER_PREFIX)]
+        self.assertEqual(broker, t.allow_entries("secretary", flag="broker"))
+        # 非 MCP エントリ (Bash 等) は順序を保って残る
+        non_mcp_in = [
+            e for e in allow if not e.startswith(RENGA_PREFIX)
+        ]
+        non_mcp_out = [e for e in out if not e.startswith(BROKER_PREFIX)]
+        self.assertEqual(non_mcp_out, non_mcp_in)
+
+    def test_broker_block_inserted_at_first_renga_position(self):
+        allow = ["Bash(a)", "mcp__renga-peers__x", "Bash(b)", "mcp__renga-peers__y"]
+        out = t.rewrite_allow_entries(allow, "worker", flag="broker")
+        # 最初の renga 位置 (index 1) に broker tier がまとめて入り、Bash 順序は不変
+        self.assertEqual(out[0], "Bash(a)")
+        tier = t.allow_entries("worker", flag="broker")
+        self.assertEqual(out[1 : 1 + len(tier)], tier)
+        self.assertEqual(out[1 + len(tier):], ["Bash(b)"])
+
+    def test_no_renga_block_passthrough(self):
+        # renga MCP を持たないロールのテンプレ (dispatcher/curator) は broker でも
+        # 素通し — 無いものに tier を勝手に注入しない (「ブロックの swap」に限定)。
+        allow = ["Bash(git add:*)", "Bash(git commit:*)"]
+        self.assertEqual(
+            t.rewrite_allow_entries(allow, "dispatcher", flag="broker"), allow
+        )
+
+    def test_broker_tiers_match_descriptor(self):
+        # messaging tier (4) vs ops tier、descriptor が唯一の SoT。
+        self.assertEqual(len(t.allow_entries("worker", flag="broker")), 4)
+        self.assertEqual(len(t.allow_entries("curator", flag="broker")), 4)
+        self.assertEqual(len(t.allow_entries("user_common", flag="broker")), 4)
+        self.assertEqual(len(t.allow_entries("dispatcher", flag="broker")), 12)
+        self.assertEqual(len(t.allow_entries("secretary", flag="broker")), 13)
+        # 全 broker エントリは org-broker プレフィックス
+        for role in ("worker", "dispatcher", "secretary"):
+            for e in t.allow_entries(role, flag="broker"):
+                self.assertTrue(e.startswith(BROKER_PREFIX))
+
+
+class AllowEntriesConsumesDescriptor(unittest.TestCase):
+    """ja は allowlist をハードコードせず runtime descriptor を consume する。"""
+
+    def test_renga_matches_descriptor(self):
+        for role in ("user_common", "secretary", "dispatcher", "curator", "worker"):
+            with self.subTest(role=role):
+                self.assertEqual(
+                    t.allow_entries(role, flag="renga"),
+                    list(rt_descriptor.allow_entries_for_role(role, flag="renga")),
+                )
+
+    def test_broker_matches_descriptor(self):
+        for role in ("user_common", "secretary", "dispatcher", "curator", "worker"):
+            with self.subTest(role=role):
+                self.assertEqual(
+                    t.allow_entries(role, flag="broker"),
+                    list(rt_descriptor.allow_entries_for_role(role, flag="broker")),
+                )
+
+
+class OrgSetupPruneBitEquivalence(unittest.TestCase):
+    """org_setup_prune の生成 settings が renga で byte 等価 / broker で置換。"""
+
+    def _write_secretary(self, transport_value):
+        schema = osp.load_schema(SCHEMA)
+        md = PERMISSIONS_MD.read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / ".claude").mkdir(parents=True)
+            with _env_transport(transport_value):
+                rc = osp.process_role(
+                    "secretary", schema, md,
+                    root=root, dry_run=False,
+                    claude_org_path_arg=str(root), no_backup=True,
+                )
+            self.assertEqual(rc, 0)
+            written = json.loads(
+                (root / ".claude" / "settings.local.json").read_text(encoding="utf-8")
+            )
+        return written["permissions"]["allow"]
+
+    def test_renga_default_generates_template_allow_byte_equivalent(self):
+        # ORG_TRANSPORT 無設定 (既定 renga) → 生成 allow == permissions.md テンプレ。
+        template_allow = _secretary_template_allow()
+        generated = self._write_secretary(None)
+        self.assertEqual(generated, template_allow)
+
+    def test_renga_explicit_equals_default(self):
+        self.assertEqual(
+            self._write_secretary("renga"), self._write_secretary(None)
+        )
+
+    def test_broker_generates_org_broker_allow(self):
+        generated = self._write_secretary("broker")
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in generated))
+        broker = [e for e in generated if e.startswith(BROKER_PREFIX)]
+        self.assertEqual(broker, t.allow_entries("secretary", flag="broker"))
+
+
+class CheckRoleConfigsTransportAware(unittest.TestCase):
+    """check_role_configs の broker 検証付け替え (in-memory のみ)。"""
+
+    def test_renga_returns_same_object_identity(self):
+        rs = {"required_allow": [RENGA_PREFIX + "send_message", RENGA_PREFIX + "list_panes"]}
+        with _env_transport(None):
+            out = crc._transport_aware_role_schema("secretary", rs)
+        self.assertIs(out, rs)  # 既定 renga: schema オブジェクトを一切触らない
+
+    def test_no_required_allow_returns_same_object(self):
+        rs = {"settings_paths": ["x"]}
+        with _env_transport("broker"):
+            self.assertIs(crc._transport_aware_role_schema("dispatcher", rs), rs)
+
+    def test_broker_rewrites_required_allow_without_mutating_original(self):
+        rs = {"required_allow": [RENGA_PREFIX + "send_message", RENGA_PREFIX + "list_panes"]}
+        original = list(rs["required_allow"])
+        with _env_transport("broker"):
+            out = crc._transport_aware_role_schema("secretary", rs)
+        # 元 schema は不変 (byte-drift される org_extension_schema.json を守る)
+        self.assertEqual(rs["required_allow"], original)
+        self.assertIsNot(out, rs)
+        self.assertEqual(out["required_allow"], t.allow_entries("secretary", flag="broker"))
+
+
+class CheckRoleConfigsOnDiskBrokerValidation(unittest.TestCase):
+    """broker で生成した on-disk settings が broker 検証を通過する。"""
+
+    def _settings_for(self, transport_value):
+        schema = osp.load_schema(SCHEMA)
+        md = PERMISSIONS_MD.read_text(encoding="utf-8")
+        d = tempfile.mkdtemp()
+        root = Path(d)
+        (root / ".claude").mkdir(parents=True)
+        with _env_transport(transport_value):
+            osp.process_role(
+                "secretary", schema, md, root=root, dry_run=False,
+                claude_org_path_arg=str(root), no_backup=True,
+            )
+        return schema, root
+
+    def test_broker_on_disk_passes_broker_validation(self):
+        schema, root = self._settings_for("broker")
+        # settings_paths を secretary のテンプレ生成先に向けて on-disk 検証する。
+        sec = schema["roles"]["secretary"]
+        sec = {**sec, "settings_paths": [".claude/settings.local.json"]}
+        schema = {**schema, "roles": {**schema["roles"], "secretary": sec}}
+        with _env_transport("broker"):
+            findings = crc.check_on_disk(
+                schema, root, include_untracked=True, role_override="secretary"
+            )
+        errors = [f for f in findings if getattr(f, "severity", "") == "ERROR"]
+        self.assertEqual(errors, [], msg=f"broker settings should pass broker validation: {errors}")
+
+    def test_broker_on_disk_fails_renga_validation(self):
+        # 取り違え検出: broker 設定を renga 期待で検証すると不一致が出る。
+        schema, root = self._settings_for("broker")
+        sec = {**schema["roles"]["secretary"], "settings_paths": [".claude/settings.local.json"]}
+        schema = {**schema, "roles": {**schema["roles"], "secretary": sec}}
+        with _env_transport(None):  # renga 期待
+            findings = crc.check_on_disk(
+                schema, root, include_untracked=True, role_override="secretary"
+            )
+        errors = [f for f in findings if getattr(f, "severity", "") == "ERROR"]
+        self.assertTrue(errors, "broker settings should NOT pass renga validation")
+
+
+class UserCommonAllowlistProjection(unittest.TestCase):
+    """user_common (~/.claude/settings.json) の broker 射影 (Option A, §5.3)。
+
+    curator / worker / dispatcher が継承する messaging MCP floor を broker 化する
+    経路。**renga は strict no-op (file を 1 byte も書かない)**。
+    """
+
+    _RENGA_SETTINGS = {
+        "permissions": {
+            "allow": [
+                "Bash(renga --version)",
+                "mcp__renga-peers__set_summary",
+                "mcp__renga-peers__send_message",
+                "mcp__renga-peers__check_messages",
+                "mcp__renga-peers__list_peers",
+                "mcp__renga-peers__spawn_pane",
+            ]
+        },
+        "env": {"CLAUDE_CODE_NO_FLICKER": "1"},
+    }
+
+    def _write_tmp(self, data) -> Path:
+        d = tempfile.mkdtemp()
+        p = Path(d) / "settings.json"
+        p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        return p
+
+    def test_renga_is_strict_no_op_file_untouched(self):
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        before = p.read_bytes()
+        with _env_transport(None):  # 既定 renga
+            rc = osp.process_user_common_allowlist(
+                settings_path=p, dry_run=False, no_backup=True
+            )
+        self.assertEqual(rc, 0)
+        # byte 完全一致 (read-modify-write すら起こさない)。
+        self.assertEqual(p.read_bytes(), before)
+
+    def test_renga_explicit_is_no_op(self):
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        before = p.read_bytes()
+        with _env_transport("renga"):
+            osp.process_user_common_allowlist(
+                settings_path=p, dry_run=False, no_backup=True
+            )
+        self.assertEqual(p.read_bytes(), before)
+
+    def test_broker_dry_run_does_not_write(self):
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        before = p.read_bytes()
+        with _env_transport("broker"):
+            osp.process_user_common_allowlist(
+                settings_path=p, dry_run=True, no_backup=True
+            )
+        self.assertEqual(p.read_bytes(), before)
+
+    def test_broker_projects_messaging_floor(self):
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        with _env_transport("broker"):
+            rc = osp.process_user_common_allowlist(
+                settings_path=p, dry_run=False, no_backup=True
+            )
+        self.assertEqual(rc, 0)
+        allow = json.loads(p.read_text(encoding="utf-8"))["permissions"]["allow"]
+        # renga MCP は消え、broker messaging tier が入る
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in allow))
+        broker = [e for e in allow if e.startswith(BROKER_PREFIX)]
+        self.assertEqual(sorted(broker), sorted(t.allow_entries("user_common", flag="broker")))
+        self.assertEqual(len(broker), 4)  # messaging tier
+        # 非 MCP エントリ・env は保持
+        self.assertIn("Bash(renga --version)", allow)
+        self.assertEqual(
+            json.loads(p.read_text(encoding="utf-8")).get("env"),
+            {"CLAUDE_CODE_NO_FLICKER": "1"},
+        )
+
+    def test_broker_idempotent(self):
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        with _env_transport("broker"):
+            osp.process_user_common_allowlist(settings_path=p, dry_run=False, no_backup=True)
+            after_first = p.read_bytes()
+            osp.process_user_common_allowlist(settings_path=p, dry_run=False, no_backup=True)
+            after_second = p.read_bytes()
+        self.assertEqual(after_first, after_second)
+
+    def test_merge_pure_drops_renga_and_ensures_tier(self):
+        tier = t.allow_entries("user_common", flag="broker")
+        out = osp.merge_user_common_allowlist(self._RENGA_SETTINGS, tier)
+        allow = out["permissions"]["allow"]
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in allow))
+        for e in tier:
+            self.assertIn(e, allow)
+        # 元 dict は破壊されない
+        self.assertTrue(
+            any(e.startswith(RENGA_PREFIX) for e in self._RENGA_SETTINGS["permissions"]["allow"])
+        )
+
+    def test_merge_drops_stale_broker_ops_entries(self):
+        # codex round-2 Major: 既存の上位 tier broker (ops) が残留して継承漏れ
+        # しないこと。射影後は messaging tier ぴったりになる。
+        tier = t.allow_entries("user_common", flag="broker")
+        stale = {
+            "permissions": {
+                "allow": [
+                    "Bash(git add:*)",
+                    "mcp__org-broker__send_message",   # messaging (残る)
+                    "mcp__org-broker__spawn_pane",     # ops tier の stale (除去対象)
+                    "mcp__org-broker__close_pane",     # ops tier の stale (除去対象)
+                    "mcp__renga-peers__list_panes",    # 反対 transport の stale
+                ]
+            }
+        }
+        out = osp.merge_user_common_allowlist(stale, tier)
+        broker = [e for e in out["permissions"]["allow"] if e.startswith(BROKER_PREFIX)]
+        # ぴったり messaging tier に射影される (ops の残骸なし)
+        self.assertEqual(sorted(broker), sorted(tier))
+        self.assertNotIn("mcp__org-broker__spawn_pane", broker)
+        self.assertNotIn("mcp__org-broker__close_pane", broker)
+        # renga 残骸も消える / 非 transport は残る
+        self.assertFalse(any(e.startswith(RENGA_PREFIX) for e in out["permissions"]["allow"]))
+        self.assertIn("Bash(git add:*)", out["permissions"]["allow"])
+
+    def test_merge_creates_allow_when_absent(self):
+        tier = t.allow_entries("user_common", flag="broker")
+        out = osp.merge_user_common_allowlist({"env": {}}, tier)
+        self.assertEqual(out["permissions"]["allow"], list(tier))
+        self.assertEqual(out["env"], {})  # 他 key は invent しない/保持
+
+    def test_merge_malformed_shape_raises(self):
+        tier = t.allow_entries("user_common", flag="broker")
+        with self.assertRaises(ValueError):
+            osp.merge_user_common_allowlist(
+                {"permissions": {"allow": "not-a-list"}}, tier
+            )
+        with self.assertRaises(ValueError):
+            osp.merge_user_common_allowlist({"permissions": [1, 2]}, tier)
+
+    def test_unknown_transport_aborts_rc2_without_write(self):
+        # codex round-2 Minor: 未知 ORG_TRANSPORT は traceback でなく rc=2 abort。
+        p = self._write_tmp(self._RENGA_SETTINGS)
+        before = p.read_bytes()
+        with _env_transport("bogus"):
+            rc = osp.process_user_common_allowlist(
+                settings_path=p, dry_run=False, no_backup=True
+            )
+        self.assertEqual(rc, 2)
+        self.assertEqual(p.read_bytes(), before)  # 書込なし
+
+    def test_broker_idempotent_after_stale_cleanup(self):
+        # stale ops が混ざった初期状態でも 1 回目で射影、2 回目で no-op。
+        stale = {
+            "permissions": {
+                "allow": [
+                    "mcp__org-broker__spawn_pane",
+                    "mcp__renga-peers__list_panes",
+                    "Bash(git add:*)",
+                ]
+            }
+        }
+        p = self._write_tmp(stale)
+        with _env_transport("broker"):
+            osp.process_user_common_allowlist(settings_path=p, dry_run=False, no_backup=True)
+            first = p.read_bytes()
+            osp.process_user_common_allowlist(settings_path=p, dry_run=False, no_backup=True)
+            second = p.read_bytes()
+        self.assertEqual(first, second)
+        allow = json.loads(first.decode("utf-8"))["permissions"]["allow"]
+        self.assertNotIn("mcp__org-broker__spawn_pane", allow)
+        self.assertEqual(
+            sorted(e for e in allow if e.startswith(BROKER_PREFIX)),
+            sorted(t.allow_entries("user_common", flag="broker")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_role_configs.py
+++ b/tools/check_role_configs.py
@@ -290,6 +290,40 @@ def _is_git_tracked(path: Path, root: Path) -> bool:
 WORKER_LOCAL_SETTINGS = ".claude/settings.local.json"
 
 
+def _transport_aware_role_schema(role_name: str, role_schema: dict) -> dict:
+    """Return ``role_schema`` with ``required_allow`` projected onto the active
+    transport's allowlist (§5.3, D から defer した broker consume).
+
+    **既定 ``renga`` では同一オブジェクトをそのまま返す (恒等)** ので、CI の通常
+    経路 (``ORG_TRANSPORT`` 無設定) は挙動・検証結果が完全に不変。
+    ``ORG_TRANSPORT=broker`` のときだけ、schema の renga 期待
+    (``mcp__renga-peers__*``) を当該ロールの broker tier (``mcp__org-broker__*``)
+    へ rewrite した **浅いコピー** を返す。これは on-disk の broker 設定
+    (``ORG_TRANSPORT=broker`` で生成したもの) を検証するための期待面の付け替えで、
+    byte 比較される ``org_extension_schema.json`` 自体は touch しない (in-memory
+    のみ)。permissions.md は renga のままなので ``check_docs`` 側は付け替えない。
+    """
+    required = role_schema.get("required_allow")
+    if not isinstance(required, list):
+        return role_schema
+    # transport モジュールは同じ tools/ ディレクトリ。スクリプト実行時は script
+    # dir が sys.path[0]、モジュール import 時は呼び元が path を通している前提だが、
+    # 念のため lazy import 時に保険を入れる。
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _here = str(_Path(__file__).resolve().parent)
+    if _here not in _sys.path:
+        _sys.path.insert(0, _here)
+    import transport as _transport
+
+    rewritten = _transport.rewrite_allow_entries(required, role_name)
+    if rewritten == required:
+        # renga (恒等) もしくは renga ブロックを持たないロール: 無変更。
+        return role_schema
+    return {**role_schema, "required_allow": rewritten}
+
+
 def check_on_disk(
     schema: dict,
     root: Path,
@@ -333,7 +367,7 @@ def check_on_disk(
                     str(path),
                     role_override,
                     config,
-                    role_schema,
+                    _transport_aware_role_schema(role_override, role_schema),
                     schema.get("global", {}),
                     extra_allowed=_load_override_allow(path),
                 )
@@ -393,7 +427,7 @@ def check_on_disk(
                     str(path),
                     role_name,
                     config,
-                    role_schema,
+                    _transport_aware_role_schema(role_name, role_schema),
                     schema.get("global", {}),
                     extra_allowed=_load_override_allow(path),
                 )

--- a/tools/org_setup_prune.py
+++ b/tools/org_setup_prune.py
@@ -52,6 +52,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import check_role_configs as _check  # noqa: E402  -- reuse validate_config
+import transport as _transport  # noqa: E402  -- flag-aware MCP allowlist (§5.3)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SCHEMA = REPO_ROOT / "tools" / "org_extension_schema.json"
@@ -616,6 +617,173 @@ def process_user_common_sandbox(
     return 0
 
 
+def _transport_fq_prefixes() -> tuple[str, ...]:
+    """全 transport (renga / broker) の FQ MCP プレフィックス集合。
+
+    user_common 射影で「反対 transport の残骸」や「上位 tier の stale エントリ」を
+    一掃するため、active tier 以外の transport MCP を一律 drop する判定に使う。
+    """
+    return tuple(_transport.surface(f).fq_prefix for f in _transport.TRANSPORTS)
+
+
+def merge_user_common_allowlist(
+    current: dict,
+    tier_entries: list[str] | tuple[str, ...],
+) -> dict:
+    """``permissions.allow`` を transport の user_common tier へ **射影** した
+    **新しい settings dict** を返す (§5.3, user_common の broker 射影)。
+
+    「射影」= **全 transport の MCP エントリ (renga / org-broker いずれの FQ
+    プレフィックス始まりも) を一旦除去**し、``tier_entries`` (active transport の
+    messaging tier) を idempotent に確保する。これにより、過去の手動設定や実験で
+    残った反対 transport / 上位 tier (例 ``mcp__org-broker__spawn_pane``) が
+    user_common に残留して継承で漏れることを防ぐ (codex round-2 Major)。
+
+    - transport MCP **以外** のエントリ (``Bash(...)`` / 他 MCP サーバー /
+      ``Bash(renga --version)`` 等) と env 等の他 key は順序・内容を保持する。
+    - 未追加の ``tier_entries`` のみ末尾に append (重複 skip = idempotent)。
+    - ``permissions.allow`` が無ければ ``tier_entries`` で新設する (他の
+      top-level key は invent しない。``--user-common-sandbox`` と同方針)。
+    - input は破壊しない (浅いコピー)。malformed shape は ``ValueError``。
+    """
+    if not isinstance(current, dict):
+        raise ValueError(
+            f"top level must be a JSON object, got {type(current).__name__}"
+        )
+    perms = current.get("permissions")
+    if perms is None:
+        perms_out: dict = {}
+    elif isinstance(perms, dict):
+        perms_out = dict(perms)
+    else:
+        raise ValueError(
+            f"'permissions' must be an object, got {type(perms).__name__}"
+        )
+    allow = perms_out.get("allow")
+    if allow is None:
+        allow = []
+    elif not isinstance(allow, list) or not all(isinstance(x, str) for x in allow):
+        raise ValueError("'permissions.allow' must be a list of strings")
+    transport_prefixes = _transport_fq_prefixes()
+    # 全 transport の MCP エントリ (renga / broker いずれも) を drop。transport
+    # MCP 以外 (Bash / 他 MCP サーバー) は順序保持。これで「active tier ぴったり」へ
+    # 射影され、stale な上位 tier / 反対 transport が継承漏れしない。
+    new_allow = [
+        e for e in allow if not any(e.startswith(p) for p in transport_prefixes)
+    ]
+    # active transport の tier を idempotent に確保 (未追加のみ末尾 append)。
+    for entry in tier_entries:
+        if entry not in new_allow:
+            new_allow.append(entry)
+    perms_out["allow"] = new_allow
+    out = dict(current)
+    out["permissions"] = perms_out
+    return out
+
+
+def process_user_common_allowlist(
+    *,
+    settings_path: Path,
+    dry_run: bool,
+    no_backup: bool,
+    env=None,
+) -> int:
+    """``ORG_TRANSPORT=broker`` のときだけ ``~/.claude/settings.json`` の
+    ``permissions.allow`` を transport の user_common messaging tier
+    (``mcp__org-broker__*`` 4 種) へ射影する (§5.3, D から defer した broker
+    consume の user_common 分)。
+
+    **renga (既定) は完全 no-op = 1 byte も書かない**。user_common の renga
+    allowlist は org-setup スキル + ``permissions.md`` 経由で適用される既定運用が
+    SoT であり、本モードはそれを **broker のときだけ** 射影し直す加算経路。
+    curator / worker / dispatcher は MCP floor を user_common から継承するため、
+    これで broker 時の messaging-4 floor が供給される。
+
+    ``--user-common-sandbox`` と同じ安全パターン: backup (.bak) / dry-run /
+    idempotent / malformed-shape は書込前に ``ValueError`` で abort。
+    """
+    try:
+        flag = _transport.resolve(env=env)
+    except ValueError as exc:
+        # 未知 / 空の ORG_TRANSPORT。書込前に rc=2 で abort
+        # (--user-common-sandbox と同じ運用。traceback を出さない)。
+        print(
+            f"[org_setup_prune] user_common allowlist: invalid ORG_TRANSPORT "
+            f"({exc}); aborting before any read/write.",
+            file=sys.stderr,
+        )
+        return 2
+    if flag == _transport.DEFAULT_TRANSPORT:
+        # 既定 renga: 不変保証のため file には一切触れない (read もしない)。
+        print(
+            "[org_setup_prune] user_common allowlist: transport=renga (既定); "
+            "no-op — ~/.claude/settings.json は不変 (renga allowlist は org-setup "
+            "スキル + permissions.md が SoT)。ORG_TRANSPORT=broker で broker 射影。"
+        )
+        return 0
+
+    tier = _transport.allow_entries("user_common", flag=flag, env=env)
+
+    if settings_path.is_file():
+        try:
+            current = json.loads(settings_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(
+                f"[org_setup_prune] user_common allowlist: current settings.json is "
+                f"invalid JSON ({exc}); aborting before any write.",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        current = {}
+
+    try:
+        target = merge_user_common_allowlist(current, tier)
+    except ValueError as exc:
+        print(
+            f"[org_setup_prune] user_common allowlist: {settings_path} has malformed "
+            f"permissions shape: {exc}; aborting.",
+            file=sys.stderr,
+        )
+        return 2
+
+    cur_allow = ((current.get("permissions") or {}) if isinstance(current, dict) else {}).get("allow") or []
+    tgt_allow = target["permissions"]["allow"]
+    added = [e for e in tgt_allow if e not in cur_allow]
+    removed = [e for e in cur_allow if e not in tgt_allow]
+
+    if dry_run:
+        print(f"=== user_common allowlist (transport={flag}): {settings_path} ===")
+        for e in removed:
+            print(f"  - {e}")
+        for e in added:
+            print(f"  + {e}")
+        if not added and not removed:
+            print("  (no changes)")
+        return 0
+
+    if target == current:
+        print(
+            f"[org_setup_prune] user_common allowlist: {settings_path} already "
+            f"projects the {flag} messaging tier; no changes."
+        )
+        return 0
+
+    bak = write_settings(settings_path, target, make_backup=not no_backup)
+    summary_bits = []
+    if added:
+        summary_bits.append(f"added {added}")
+    if removed:
+        summary_bits.append(f"removed {removed}")
+    summary = ("; " + ", ".join(summary_bits)) if summary_bits else ""
+    print(
+        f"[org_setup_prune] user_common allowlist: wrote {settings_path}"
+        + (f" (backup: {bak.name})" if bak else "")
+        + summary
+    )
+    return 0
+
+
 def _safe_deny_list(settings: dict, key: str) -> list[str]:
     """Return a copy of ``sandbox.filesystem.{key}`` from ``settings``,
     defaulting to an empty list when any spine node is missing. ``key`` is
@@ -842,6 +1010,20 @@ def process_role(
         print(str(exc), file=sys.stderr)
         return 2
 
+    # transport flag-aware MCP allowlist (§5.3, D から defer した broker consume)。
+    # ``ORG_TRANSPORT=broker`` のときだけ allow の renga MCP ブロック
+    # (``mcp__renga-peers__*``) を当該ロールの broker tier 集合
+    # (``mcp__org-broker__*``) へ置換する。**既定 ``renga`` では恒等 (target は
+    # 一切変えない = 生成物が byte 等価)**。renga アンカーの
+    # ``org_extension_schema.json`` / ``permissions.md`` には触れず、生成段でのみ
+    # broker 面を加算する (byte-drift を壊さない設計)。
+    perms = target.get("permissions")
+    if isinstance(perms, dict) and isinstance(perms.get("allow"), list):
+        rewritten_allow = _transport.rewrite_allow_entries(perms["allow"], role)
+        if rewritten_allow != perms["allow"]:
+            # broker のときのみ到達 (renga は恒等で False)。
+            perms["allow"] = rewritten_allow
+
     safety_blockers = _validate_target_safety(role, role_schema, schema.get("global", {}), target)
     if safety_blockers:
         print(
@@ -897,6 +1079,17 @@ def main(argv: list[str] | None = None) -> int:
              "See Issue #429 (Task B/C, denyRead) and Issue #433 (denyWrite migration).",
     )
     parser.add_argument(
+        "--user-common-allowlist",
+        action="store_true",
+        help="Project the user_common (~/.claude/settings.json) MCP permissions.allow "
+             "onto the active transport (ORG_TRANSPORT). With ORG_TRANSPORT=broker this "
+             "drops mcp__renga-peers__* and ensures the broker messaging tier "
+             "(mcp__org-broker__*) is present; the default renga transport is a strict "
+             "no-op (the file is never touched). Idempotent; writes a .bak unless "
+             "--no-backup. Resolves the broker MCP floor that curator/worker/dispatcher "
+             "inherit from user_common (Epic #6 E / ja#514 §5.3).",
+    )
+    parser.add_argument(
         "--user-common-settings-path",
         type=Path,
         default=None,
@@ -915,8 +1108,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not args.role and not args.all and not args.user_common_sandbox:
-        parser.error("specify --role <name>, --all, or --user-common-sandbox")
+    if (
+        not args.role
+        and not args.all
+        and not args.user_common_sandbox
+        and not args.user_common_allowlist
+    ):
+        parser.error(
+            "specify --role <name>, --all, --user-common-sandbox, or "
+            "--user-common-allowlist"
+        )
 
     rc = 0
 
@@ -948,6 +1149,15 @@ def main(argv: list[str] | None = None) -> int:
         r = process_user_common_sandbox(
             settings_path=settings_path,
             home=home,
+            dry_run=args.dry_run,
+            no_backup=args.no_backup,
+        )
+        rc = rc or r
+
+    if args.user_common_allowlist:
+        settings_path = args.user_common_settings_path or DEFAULT_USER_COMMON_SETTINGS_PATH
+        r = process_user_common_allowlist(
+            settings_path=settings_path,
             dry_run=args.dry_run,
             no_backup=args.no_backup,
         )

--- a/tools/transport.py
+++ b/tools/transport.py
@@ -1,0 +1,211 @@
+"""ja 側の transport surface アクセサ — runtime descriptor を読む単一シーム。
+
+Epic #6 次段 D (ja#513): ja 統合シーム。設計 SoT は transport-lab の
+``docs/design/ja-migration-plan.md`` §5.1(flag) / §5.2(i 生成系シーム)。
+
+なぜこのモジュールが要るか (§5.2 (i) 単一 SoT):
+ja の renga ツール参照は複数の生成器 (``tools/gen_delegate_payload.py`` /
+``tools/gen_worker_brief.py`` + テンプレート) が別々に同じ transport
+プレフィックス (``mcp__renga-peers__`` / ``mcp__org-broker__``) と spawn 注入
+flag を必要とする。各所にハードコードすると runtime と ja で二重管理になり
+drift する。そこで **flag → {server 名, 注入 flag, ロール別 tool 集合} を返す
+runtime の transport surface descriptor
+(:mod:`claude_org_runtime.transport`) を唯一の SoT とし、ja 側生成器は本
+モジュール 1 つを経由してそれを読む**。runtime には一切変更を加えず、ja は
+pin (``>=0.1.17``) で consume するだけ。
+
+非破壊の絶対条件 (§5.1 / §5.3):
+- transport flag の所在は環境変数 ``ORG_TRANSPORT`` (``renga`` | ``broker``)。
+- **既定 (無設定) = ``renga``** で現行と bit 等価 (既存生成物が 1 byte も
+  変わらない)。``broker`` は ``ORG_TRANSPORT=broker`` を明示した時のみ。
+- 解決順は runtime と整合: explicit 引数 > ``ORG_TRANSPORT`` env > 既定 renga。
+- renga 経路は削除せず併存 (opt-in / 切戻し可)。
+"""
+from __future__ import annotations
+
+from typing import Mapping, Optional
+
+# runtime 0.1.17 で公開された transport surface descriptor。ja はこれを
+# 一次 SoT として consume する (ハードコードしない, §5.2)。
+from claude_org_runtime.transport import (  # noqa: F401  (re-export)
+    DEFAULT_TRANSPORT,
+    ENV_KEY,
+    TRANSPORTS,
+    TransportSurface,
+    get_surface,
+    resolve_transport,
+)
+
+# 報告呼び出しに使う bare tool 名。``send_message`` は両 transport 共通の
+# 動詞で、transport 固有なのは server / プレフィックス (これらは descriptor が
+# 所有)。とはいえ tool 集合の SoT も descriptor (``tools_for_role``) なので、
+# この名前が descriptor の公開集合から外れていないかを参照時に検証し、将来の
+# rename / 削除を黙って取り逃さない (drift 防止, §5.2)。
+_SEND_MESSAGE_TOOL = "send_message"
+
+__all__ = [
+    "DEFAULT_TRANSPORT",
+    "ENV_KEY",
+    "TRANSPORTS",
+    "TransportSurface",
+    "resolve",
+    "surface",
+    "fq_prefix",
+    "server_name",
+    "send_message_call",
+    "spawn_inject",
+    "allow_entries",
+    "rewrite_allow_entries",
+]
+
+
+def resolve(
+    explicit: Optional[str] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """有効な transport flag (``renga`` | ``broker``) を返す。
+
+    解決順は runtime の ``transport_allowlist`` と整合: explicit 引数 >
+    ``ORG_TRANSPORT`` env > 既定 ``renga`` (§5.1)。``env=None`` は
+    ``os.environ`` を読む。空文字列・未知値は ``ValueError``。
+    """
+    return resolve_transport(explicit, env=env)
+
+
+def surface(
+    flag: Optional[str] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> TransportSurface:
+    """transport flag の :class:`TransportSurface` を返す (flag=None は解決)。"""
+    return get_surface(flag, env=env)
+
+
+def server_name(
+    flag: Optional[str] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """MCP サーバー名 (``renga-peers`` / ``org-broker``) を返す。
+
+    生成物の中で「窓口がコピーする send_message 呼び出しの輸送名」など、FQ
+    プレフィックスではなくサーバー名そのものを差し込む箇所に使う。
+    """
+    return surface(flag, env=env).server
+
+
+def fq_prefix(
+    flag: Optional[str] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """FQ MCP tool プレフィックス (``mcp__renga-peers__`` / ``mcp__org-broker__``)。"""
+    return surface(flag, env=env).fq_prefix
+
+
+def send_message_call(
+    flag: Optional[str] = None,
+    *,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """ワーカー / 窓口の報告に使う FQ ``send_message`` ツール名を返す。
+
+    renga 既定では ``mcp__renga-peers__send_message`` (現行と bit 等価)、
+    ``broker`` では ``mcp__org-broker__send_message``。プレフィックスは
+    role 非依存 (server ベース) なので role を取らない。
+
+    ``send_message`` が descriptor の公開 tool 集合に存在することを検証し、
+    runtime 側で rename / 削除があれば即座に ``ValueError`` で顕在化させる
+    (ハードコード名が descriptor から drift するのを防ぐ, §5.2)。
+    """
+    surf = surface(flag, env=env)
+    if _SEND_MESSAGE_TOOL not in surf.tools_for_role("worker"):
+        raise ValueError(
+            f"transport {surf.flag!r} descriptor no longer exposes "
+            f"{_SEND_MESSAGE_TOOL!r} for the worker tier; ja generators "
+            "must be re-derived from the runtime transport descriptor "
+            "(claude_org_runtime.transport)."
+        )
+    return f"{surf.fq_prefix}{_SEND_MESSAGE_TOOL}"
+
+
+def spawn_inject(
+    flag: Optional[str] = None,
+    *,
+    broker_mcp_config: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> str:
+    """子ペイン spawn 時にランチャが注入する flag 文字列を返す。
+
+    renga は固定 ``--dangerously-load-development-channels
+    server:renga-peers``、broker は ``--mcp-config <broker>``
+    (``broker_mcp_config`` で具体化、未指定なら ``<broker>`` プレースホルダ)。
+    """
+    return surface(flag, env=env).spawn_inject(broker_mcp_config=broker_mcp_config)
+
+
+def allow_entries(
+    role: str,
+    *,
+    flag: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> list:
+    """role の ``mcp__<server>__<tool>`` allowlist エントリ (transport 解決込み)。
+
+    §5.3 (allowlist の flag-aware 化) の単一 SoT。runtime の
+    :func:`claude_org_runtime.settings.generator.transport_allowlist`
+    (= descriptor 駆動) を consume する。``flag`` 解決順は他のアクセサと整合:
+    explicit > ``ORG_TRANSPORT`` env > 既定 ``renga``。
+
+    既定 ``renga`` では全ロールが required-14 surface
+    (``mcp__renga-peers__*``)、``broker`` ではロールの auth tier に応じた
+    ``mcp__org-broker__*`` 集合 (worker/curator=4・dispatcher/secretary=ops)
+    を返す。未知ロールは broker で messaging tier (4) に落ちる
+    (descriptor の default-deny 既定)。
+    """
+    # runtime の生成器 API を一次 SoT として lazy import (ja は consume のみ、
+    # ハードコードしない, §5.2 (i) / §5.3)。
+    from claude_org_runtime.settings.generator import transport_allowlist
+
+    return list(transport_allowlist(role, transport=flag, env=env))
+
+
+def rewrite_allow_entries(
+    entries,
+    role: str,
+    *,
+    flag: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> list:
+    """allow / required_allow 等の文字列リスト中の renga MCP ブロックを、
+    解決した transport の role-tier 集合へ置換して返す。
+
+    **非破壊の核 (§5.3)**: 既定 ``renga`` (``DEFAULT_TRANSPORT``) では
+    **入力をそのまま返す (恒等)** ので、既存の生成物・schema 期待は 1 byte も
+    変わらない (bit 等価)。``broker`` 等の非既定 flag のときだけ、renga の FQ
+    プレフィックス (``mcp__renga-peers__``) で始まるエントリ群を除去し、**最初に
+    現れた位置へ** transport の tier エントリを挿入する。``Bash(...)`` 等の
+    非 MCP エントリは順序を保って残す。
+
+    renga ブロックが 1 つも無いリスト (例: mcp を持たないロールの per-role
+    テンプレート) は非既定 flag でも素通し (tier エントリを勝手に注入しない =
+    「renga ブロックの swap」に限定し、無いものは足さない)。
+    """
+    resolved = resolve(flag, env=env)
+    if resolved == DEFAULT_TRANSPORT:
+        # 既定 renga: 恒等。byte 等価を構造的に保証する。
+        return list(entries)
+    renga_prefix = surface(DEFAULT_TRANSPORT, env=env).fq_prefix
+    tier = allow_entries(role, flag=resolved, env=env)
+    out: list = []
+    inserted = False
+    for entry in entries:
+        if isinstance(entry, str) and entry.startswith(renga_prefix):
+            if not inserted:
+                out.extend(tier)
+                inserted = True
+            # renga エントリ本体は drop (tier で置換済み)。
+            continue
+        out.append(entry)
+    return out


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#532](https://github.com/suisya-systems/claude-org-ja/pull/532)

Merge SHA: `0cff042204053c5be2b0ea316f24a843bbd27470`

Source: ja PR [#532](https://github.com/suisya-systems/claude-org-ja/pull/532)
Merge SHA: `0cff042204053c5be2b0ea316f24a843bbd27470`

| class | count |
|---|---|
| runtime | 4 |
| translation | 3 |
| divergence-allowed | 4 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tests/test_transport_allowlist_consume.py`
- `tools/check_role_configs.py`
- `tools/org_setup_prune.py`
- `tools/transport.py`

</details>
<details><summary>translation (3)</summary>

- `CLAUDE.md`
- `docs/contracts/backend-interface-contract.md`
- `docs/non-goals.md`

</details>
<details><summary>divergence-allowed (4)</summary>

- `.dispatcher/CLAUDE.md`
- `.dispatcher/references/pane-close.md`
- `.dispatcher/references/spawn-flow.md`
- `.dispatcher/references/worker-monitoring.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
