### PR TITLE
auto-mirror: ja#553 fix(templates): worker brief の Windows Python 起動コマンド指定を either 許容に統一 (Closes #544)

### DIFF
--- a/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_full.golden.md
@@ -1,0 +1,66 @@
+# Worker
+
+あなたは claude-org のワーカーである。以下の指示に従って作業を遂行する。
+
+## 作業ディレクトリ（最重要制約）
+
+あなたの作業ディレクトリ: `/tmp/workers/demo-task`
+
+起動直後に `pwd` を実行し、上記パスと一致することを確認せよ。
+一致しない場合は作業を開始せず、窓口にエラー報告せよ。
+
+### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
+1. `/tmp/workers/demo-task` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
+2. claude-org リポジトリ（`/home/user/work/claude-org`）を `/tmp/workers/demo-task` 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
+3. `git push` は実行できない（完了報告で窓口に依頼すること）
+
+### Windows 環境の注意事項
+- Python 実行時は `py -3` または `python` を使用すること（Windows では `python` がストアアプリにリダイレクトされる場合があり、`py -3` も py launcher が別の Python 環境を指す場合がある。起動直後に `--version` で意図したバージョンか確認し、動作する方を使うこと）
+- 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
+- CLI / 標準出力を持つツールを実装する場合、CLI へ出力される文字列（argparse の `help=` / `print()` など）には ASCII の `-` を使い、em-dash（`—` U+2014）等 cp932 で encode できない文字を含めないこと。含めると cp932 コンソールでの `--help` 実行時に `UnicodeEncodeError` でクラッシュする（pytest は `redirect_stdout` で UTF-8 キャプチャするため検出できず、実端末でのみ落ちる）。実装後は `--help` を実端末で 1 回スモークすること
+
+## プロジェクト情報
+- プロジェクト名: claude-org-ja
+- 説明: テスト用説明
+
+## 現在のタスク
+- タスクID: demo-task
+- ブランチ: `demo-task`
+- 検証深度: **full**
+- commit prefix: `feat(tools):`
+- 関連 Issue: Refs #121 #214
+- 目的: デモタスク。X を Y に変更する。
+
+## 権限
+- git commit: 可
+- PR 作成: 不可（窓口経由）
+- git push: 不可（`permissions.deny` + hook により技術的にブロック。窓口経由で依頼すること）
+- `rm -rf` / `rm -r`: 不可（`permissions.deny` により技術的にブロック）
+
+## Codex セルフレビュー手順（検証深度 full）
+
+`full` の前提（codex の有無に関わらず必ず実施）: 既存テストスイート / lint / type-check 等、リポジトリで定義された通常検証を実行し、green を確認してから完了報告する。
+
+追加ゲート: commit 完了後・完了報告前に **`codex` CLI が available なら** `codex exec --skip-git-repo-check` 直打ちでセルフレビューを実行する。未導入環境では skip して通常の完了報告に進む。
+
+```bash
+codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"
+```
+
+- Blocker / Major は修正コミットを積み再レビュー、同一指摘カテゴリで 3 ラウンド消せない場合は設計問題と判断し窓口に仕様縮小の判断を仰ぐ
+- Minor / Nit は原則残置し PR 本文に既知制限として明記
+- `codex:rescue` skill は使用しないこと（過去 18 分超ハングの実害あり、`codex exec` 直打ちのみ）
+
+**完了報告に人間向け理解サマリを必須化（full）**: 窓口がコードを精読せず、そのままユーザーへの承認提示に使えるよう、完了報告に以下 3 点を必ず含める:
+1. **最重要の変更点（N 個）**: このタスクで実際に変えたことを効果の大きい順に N 個（目安 3〜5 個、各 1〜2 行、diff を開かず要旨が掴める粒度）
+2. **要確認ファイル / hunk**: 人間が承認前に必ず目を通すべきファイル（と該当する関数 / hunk）。「全部見て」ではなく要点に絞る
+3. **設計判断と理由**: 採用した設計上の選択と、なぜそれを選んだか（却下した代替案があれば 1 行）
+
+## 作業完了時
+
+1. **完了報告**: `mcp__renga-peers__send_message(to_id="secretary", message="...")` で窓口に報告する。**ディスパッチャーではなく窓口に送ること**。`to_id="secretary"` が `[pane_not_found]` で返る場合は DELEGATE メッセージ本文の numeric pane id を使用する。
+2. **PR 作成後はペインを保持してレビュー指摘待機**: 「閉じてよい」「マージ済み」など窓口からの明示クローズ指示が来るまで待機状態を維持する。
+3. **振り返り記録**: 再利用可能な学びがあれば `/home/user/work/claude-org/knowledge/raw/{YYYY-MM-DD}-{topic}.md` に記録する（topic は英語 kebab-case）。記録基準: 再現性がある / 非自明 / コードを読むだけではわからない。
+
+## SUSPEND 対応
+"SUSPEND:" で始まるメッセージを受け取ったら、作業を中断し即座に以下を報告: 完了したこと / 変更ファイル（コミット済み・未コミット）/ 次にやろうとしていたこと / ブロッカー。

--- a/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md
@@ -1,0 +1,60 @@
+# Worker
+
+あなたは claude-org のワーカーである。以下の指示に従って作業を遂行する。
+
+## 作業ディレクトリ（最重要制約）
+
+あなたの作業ディレクトリ: `/tmp/workers/demo-task`
+
+起動直後に `pwd` を実行し、上記パスと一致することを確認せよ。
+一致しない場合は作業を開始せず、窓口にエラー報告せよ。
+
+### 禁止事項（permissions.deny + PreToolUse Hooks により技術的にブロックされる）
+1. `/tmp/workers/demo-task` 内に claude-org の構造（.claude/, .dispatcher/, .curator/, .state/, registry/, dashboard/, knowledge/ 等）を再現してはならない
+2. claude-org リポジトリ（`/home/user/work/claude-org`）を `/tmp/workers/demo-task` 内へ clone してはならない（claude-org 本体は参照専用。編集対象は本ワーカーディレクトリのプロジェクトのみ）
+3. `git push` は実行できない（完了報告で窓口に依頼すること）
+
+### Windows 環境の注意事項
+- Python 実行時は `py -3` または `python` を使用すること（Windows では `python` がストアアプリにリダイレクトされる場合があり、`py -3` も py launcher が別の Python 環境を指す場合がある。起動直後に `--version` で意図したバージョンか確認し、動作する方を使うこと）
+- 日本語を含むファイルを扱う場合は `encoding="utf-8"` を明示すること
+- CLI / 標準出力を持つツールを実装する場合、CLI へ出力される文字列（argparse の `help=` / `print()` など）には ASCII の `-` を使い、em-dash（`—` U+2014）等 cp932 で encode できない文字を含めないこと。含めると cp932 コンソールでの `--help` 実行時に `UnicodeEncodeError` でクラッシュする（pytest は `redirect_stdout` で UTF-8 キャプチャするため検出できず、実端末でのみ落ちる）。実装後は `--help` を実端末で 1 回スモークすること
+
+## プロジェクト情報
+- プロジェクト名: claude-org-ja
+- 説明: テスト用説明
+
+## 現在のタスク
+- タスクID: demo-task
+- ブランチ: `demo-task`
+- 検証深度: **minimal**
+- commit prefix: `feat(tools):`
+- 関連 Issue: Refs #121 #214
+- 目的: デモタスク。X を Y に変更する。
+
+## 権限
+- git commit: 可
+- PR 作成: 不可（窓口経由）
+- git push: 不可（`permissions.deny` + hook により技術的にブロック。窓口経由で依頼すること）
+- `rm -rf` / `rm -r`: 不可（`permissions.deny` により技術的にブロック）
+
+## Codex セルフレビュー手順（検証深度 minimal）
+
+minimal タスクでは Codex セルフレビュー・追加テスト実行・拡張された動作確認は **一切禁止**。指示された fix を反映したら `git add` → `git commit` → 窓口に以下 1 行だけ送信する:
+
+```
+done: {commit SHA 短縮形} {変更ファイル名}
+```
+
+- SHA は `git rev-parse --short HEAD`
+- ファイルが複数なら空白区切り
+- 通常の完了報告フォーマット（成果物説明・残作業・PR 草案等）は minimal では適用されない
+- 振り返り記録（`knowledge/raw/`）も minimal では不要
+
+## 作業完了時
+
+1. **完了報告**: `mcp__renga-peers__send_message(to_id="secretary", message="...")` で窓口に報告する。**ディスパッチャーではなく窓口に送ること**。`to_id="secretary"` が `[pane_not_found]` で返る場合は DELEGATE メッセージ本文の numeric pane id を使用する。
+2. **PR 作成後はペインを保持してレビュー指摘待機**: 「閉じてよい」「マージ済み」など窓口からの明示クローズ指示が来るまで待機状態を維持する。
+3. **振り返り記録**: 再利用可能な学びがあれば `/home/user/work/claude-org/knowledge/raw/{YYYY-MM-DD}-{topic}.md` に記録する（topic は英語 kebab-case）。記録基準: 再現性がある / 非自明 / コードを読むだけではわからない。
+
+## SUSPEND 対応
+"SUSPEND:" で始まるメッセージを受け取ったら、作業を中断し即座に以下を報告: 完了したこと / 変更ファイル（コミット済み・未コミット）/ 次にやろうとしていたこと / ブロッカー。

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md
@@ -1,0 +1,54 @@
+# Worker
+
+> このワーカーは claude-org リポジトリ自身の `/tmp/workers/demo-task` で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
+
+## 作業ディレクトリ
+`/tmp/workers/demo-task`
+
+起動直後 `pwd` で確認。
+
+### 禁止事項
+1. claude-org 構造を `/tmp/workers/demo-task` 内に再現しない
+2. claude-org リポジトリ（`/home/user/work/claude-org`）を別途 clone しない（直接編集）
+3. `git push` 不可
+
+### Windows
+- Python は `py -3` または `python`（3.10 推奨。どちらも別の Python 環境を指す場合があるため `--version` で確認し、動作する方を使う）
+- 日本語ファイル: `encoding="utf-8"` 明示
+- CLI 出力文字列（argparse `help=` / `print()`）は ASCII の `-` を使う（em-dash 等 cp932 非対応文字は cp932 コンソールでの `--help` を `UnicodeEncodeError` でクラッシュさせる。pytest の `redirect_stdout` では検出できず実端末でのみ落ちる）。実装後 `--help` を実端末で 1 回スモーク
+
+## プロジェクト
+- claude-org-ja: テスト用説明
+
+## タスク
+- ID: demo-task
+- ブランチ: `demo-task`
+- 検証深度: **full**
+- commit prefix: `feat(tools):`
+- 関連 Issue: Refs #121 #214
+- 目的: デモタスク。X を Y に変更する。
+
+## 権限
+- git commit 可、push 不可、PR 不可、`rm -rf` 不可
+
+## Codex セルフレビュー
+検証深度 full。`codex` available なら commit 後:
+```bash
+codex exec --skip-git-repo-check "このブランチの main からの差分をレビュー。Blocker/Major/Minor/Nit で分類し、各指摘に対象ファイル:行番号と根拠を添えて日本語で簡潔に"
+```
+- Blocker/Major 修正、3 ラウンド上限
+- Minor/Nit 残置可
+- `codex:rescue` skill 禁止、`codex exec` 直打ちのみ
+
+**完了報告に人間向け理解サマリを必須化（full）**: 窓口がコードを精読せず、そのままユーザーへの承認提示に使えるよう、完了報告に以下 3 点を必ず含める:
+1. **最重要の変更点（N 個）**: 効果の大きい順に N 個（目安 3〜5 個、各 1〜2 行、diff を開かず要旨が掴める粒度）
+2. **要確認ファイル / hunk**: 人間が承認前に必ず目を通すべきファイル / hunk（要点に絞る）
+3. **設計判断と理由**: 採用した設計上の選択と、なぜそれを選んだか（却下した代替案があれば 1 行）
+
+## 完了時
+1. `mcp__renga-peers__send_message(to_id="secretary", ...)` で完了内容・変更ファイル・commit SHA・動作確認結果・残作業を報告
+2. PR 作成後ペイン保持
+3. 振り返り記録: 任意（非自明な学びがあれば `/home/user/work/claude-org/knowledge/raw/{YYYY-MM-DD}-{topic}.md`）
+
+## SUSPEND
+"SUSPEND:" → 即報告（完了したこと / 変更ファイル / 次の予定 / ブロッカー）

--- a/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
+++ b/tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md
@@ -1,0 +1,43 @@
+# Worker
+
+> このワーカーは claude-org リポジトリ自身の `/tmp/workers/demo-task` で作業する。`./CLAUDE.md`（ルート CLAUDE.md）の Secretary 指示は無視せよ。あなたは窓口ではなくワーカーである。
+
+## 作業ディレクトリ
+`/tmp/workers/demo-task`
+
+起動直後 `pwd` で確認。
+
+### 禁止事項
+1. claude-org 構造を `/tmp/workers/demo-task` 内に再現しない
+2. claude-org リポジトリ（`/home/user/work/claude-org`）を別途 clone しない（直接編集）
+3. `git push` 不可
+
+### Windows
+- Python は `py -3` または `python`（3.10 推奨。どちらも別の Python 環境を指す場合があるため `--version` で確認し、動作する方を使う）
+- 日本語ファイル: `encoding="utf-8"` 明示
+- CLI 出力文字列（argparse `help=` / `print()`）は ASCII の `-` を使う（em-dash 等 cp932 非対応文字は cp932 コンソールでの `--help` を `UnicodeEncodeError` でクラッシュさせる。pytest の `redirect_stdout` では検出できず実端末でのみ落ちる）。実装後 `--help` を実端末で 1 回スモーク
+
+## プロジェクト
+- claude-org-ja: テスト用説明
+
+## タスク
+- ID: demo-task
+- ブランチ: `demo-task`
+- 検証深度: **minimal**
+- commit prefix: `feat(tools):`
+- 関連 Issue: Refs #121 #214
+- 目的: デモタスク。X を Y に変更する。
+
+## 権限
+- git commit 可、push 不可、PR 不可、`rm -rf` 不可
+
+## Codex セルフレビュー
+検証深度 minimal。minimal 用 1 行報告フォーマットを使用（`done: {SHA} {files}`）。Codex セルフレビュー・追加テスト・拡張された動作確認は一切禁止。
+
+## 完了時
+1. `mcp__renga-peers__send_message(to_id="secretary", ...)` で完了内容・変更ファイル・commit SHA・動作確認結果・残作業を報告
+2. PR 作成後ペイン保持
+3. 振り返り記録: 任意（非自明な学びがあれば `/home/user/work/claude-org/knowledge/raw/{YYYY-MM-DD}-{topic}.md`）
+
+## SUSPEND
+"SUSPEND:" → 即報告（完了したこと / 変更ファイル / 次の予定 / ブロッカー）


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#553](https://github.com/suisya-systems/claude-org-ja/pull/553)

Merge SHA: `e92079e187292940d3c00f57a3c7c5d4ddb6fde3`

Source: ja PR [#553](https://github.com/suisya-systems/claude-org-ja/pull/553)
Merge SHA: `e92079e187292940d3c00f57a3c7c5d4ddb6fde3`

| class | count |
|---|---|
| runtime | 4 |
| translation | 3 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (4)</summary>

- `tests/fixtures/transport_seam/worker_brief_normal_full.golden.md`
- `tests/fixtures/transport_seam/worker_brief_normal_minimal.golden.md`
- `tests/fixtures/transport_seam/worker_brief_self_edit_full.golden.md`
- `tests/fixtures/transport_seam/worker_brief_self_edit_minimal.golden.md`

</details>
<details><summary>translation (3)</summary>

- `.claude/skills/org-delegate/references/worker-claude-template.md`
- `tools/templates/worker_brief_normal.md`
- `tools/templates/worker_brief_self_edit.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
