### PR TITLE
auto-mirror: ja#560 feat(claude): Agent 前景(同期)起動を一律ブロックする PreToolUse フックを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,15 @@
             "command": "bash \"${CLAUDE_PROJECT_DIR}/.hooks/block-dangerous-git.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.hooks/block-foreground-subagent.sh\""
+          }
+        ]
       }
     ]
   },

--- a/.hooks/block-foreground-subagent.sh
+++ b/.hooks/block-foreground-subagent.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# PreToolUse Hook: subagent ツール (Agent) の前景(同期)起動をブロックする
+# 方式: exit 2 + stderr メッセージ でブロック
+#
+# 背景・範囲 B(一律: 窓口 + ワーカー全て):
+#   Agent(subagent) ツールを run_in_background=true なしで呼ぶと、subagent が
+#   完了するまで呼び出し元セッションが同期ブロックされる。窓口がブロックされると
+#   人間との接点が止まり、ワーカーがブロックされると窓口からの差し込み
+#   (peer message / ack / SUSPEND) に即応できなくなる。
+#   そこで本フックは窓口・ワーカーを問わず一律に前景 subagent を禁止し、
+#   run_in_background=true の非同期起動のみを許可する。これにより全ロールが
+#   常に「次の指示・割り込みに応答可能」な状態を保つ。
+#
+#   実機検証(PreToolUse payload):
+#     - subagent ツールの tool_name は "Agent"(安全のため legacy "Task" も対象)。
+#     - 前景起動では tool_input.run_in_background キー自体が欠落する
+#       (false で送られるのではなく省略 = 既定前景)。
+#     - 非同期起動でのみ tool_input.run_in_background == true (厳密に boolean)。
+#   したがって「厳密に boolean true」以外(false / 欠落 / 文字列 "true" 等)は
+#   すべて前景扱いで deny する(安全側)。
+#
+# 入力: stdin から PreToolUse JSON ({tool_name, tool_input})
+# 出力: 拒否時 exit 2 + stderr。許可時 exit 0。
+#
+# 検知方針:
+#   1. tool_name が "Agent" / "Task" でなければ passthrough(exit 0)。
+#   2. tool_input.run_in_background が厳密な boolean true のときだけ許可。
+#      それ以外(false / 欠落 / 非 boolean)は前景とみなし deny。
+#
+# 既知の制限:
+#   - jq が無い環境では fail-closed で全 Agent/Task 呼び出しを deny する
+#     (既存 block-no-verify.sh / block-git-push.sh と同じ安全側挙動)。
+#   - stdin が不正な JSON の場合も fail-closed で deny する。enforcement
+#     フックとして parse 不能な payload を素通り(fail-open)させない
+#     (本フックには permissions.deny の backstop が無いため、兄弟フックより
+#     fail-open の影響が大きい)。実運用ではハーネスが整形済み JSON のみを
+#     PreToolUse へ渡すため、この経路は理論上のもの。
+#   - 人間が直接 CLI で起動する場合は本フックは効かない。Claude Code の
+#     ツール呼び出し経路でのみ作用する。
+
+set -euo pipefail
+
+# Helper: deny decision を stderr + exit 2 で返す
+deny_with_reason() {
+  local reason="$1"
+  echo "ブロック: $reason" >&2
+  exit 2
+}
+
+# jq チェック (fail closed)
+if ! command -v jq &>/dev/null; then
+  echo "ブロック: jq がインストールされていません。セキュリティ Hook の実行に必要です。" >&2
+  exit 2
+fi
+
+# stdin から JSON を読み取り
+INPUT=$(cat)
+
+# top-level が JSON object か検証する (fail closed)。
+# set -euo pipefail 下で `VAR=$(echo "$INPUT" | jq ...)` 形式は、jq の parse
+# error や非 object への index error 時に exit 5 でスクリプトを中断し、
+# PreToolUse では exit!=2 が非ブロッキング扱い = fail-open になる。これを避ける
+# ため、deny ロジック前に明示的な `if !` 条件で「parse 可能 かつ top-level が
+# object」を一括検査し、満たさなければ exit 2 で deny する。
+#   - `jq -e 'type == "object"'`: object なら true 出力 exit 0、配列/文字列/
+#     数値/bool/null なら false 出力 exit 1、不正 JSON なら parse error exit 5。
+#     いずれの非 object/不正系も非ゼロ → fail-closed deny。
+# これにより後続の `.tool_name` / `.tool_input` の index は top-level が object
+# である前提で安全に評価できる。
+if ! echo "$INPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  deny_with_reason "PreToolUse payload が JSON object として解析できませんでした。subagent ツール呼び出しは安全側 (fail-closed) で拒否します。"
+fi
+
+# tool_name を取得。subagent ツール以外は passthrough。
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+if [[ "$TOOL_NAME" != "Agent" && "$TOOL_NAME" != "Task" ]]; then
+  exit 0
+fi
+
+# run_in_background が厳密に boolean true のときだけ許可。
+# jq の `== true` は厳密比較: boolean true のみ真。文字列 "true" / 数値 1 /
+# null / 欠落はすべて偽になるため、安全側(前景とみなす)に倒れる。
+# tool_input が object でない(文字列・配列等)JSON-valid payload では
+# `.tool_input.run_in_background` の index が jq error(exit 5)になり
+# fail-open するため、先に `type == "object"` で型ガードする。jq の `and` は
+# 短絡評価で、左が false なら右の index は評価されないので error にならない。
+IS_BACKGROUND=$(echo "$INPUT" | jq -r 'if ((.tool_input | type) == "object") and (.tool_input.run_in_background == true) then "yes" else "no" end')
+
+if [[ "$IS_BACKGROUND" != "yes" ]]; then
+  deny_with_reason "subagent (${TOOL_NAME}) の前景(同期)起動は禁止です。run_in_background=true を指定して非同期で起動してください。前景起動は呼び出し元(窓口・ワーカー)をブロックし、人間接点や窓口からの差し込みへの即応を止めるため、ハーネスで一律に拒否しています。"
+fi
+
+exit 0

--- a/tests/test-block-foreground-subagent.sh
+++ b/tests/test-block-foreground-subagent.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Tests for block-foreground-subagent.sh
+# Validates: exit code (0=allow/passthrough, 2=block) and stderr messages.
+#
+# 確認観点:
+#   - Agent + run_in_background=true (boolean)   -> allow (exit 0)
+#   - Agent + false / 欠落 / 非 boolean true      -> block (exit 2, 前景扱い)
+#   - Agent + tool_input 欠落                     -> block
+#   - top-level run_in_background (tool_input 外) -> block (.tool_input.* のみ参照)
+#   - legacy Task の前景 / 背景                    -> block / allow
+#   - 非 subagent ツール / 近接 tool_name          -> passthrough (exact match)
+#   - 不正 JSON / 空 stdin                         -> block (fail-closed)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/.hooks/block-foreground-subagent.sh"
+
+PASS=0; FAIL=0; TEST_NUM=0
+TMPFILES=()
+cleanup() { rm -f "${TMPFILES[@]}"; }
+trap cleanup EXIT
+
+assert_exit() {
+  local expected="$1" actual="$2" desc="$3"
+  ((TEST_NUM++))
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (expected exit $expected, got $actual)"
+    ((FAIL++))
+  fi
+}
+
+assert_stderr_contains() {
+  local pattern="$1" file="$2" desc="$3"
+  ((TEST_NUM++))
+  if grep -qF "$pattern" "$file" 2>/dev/null; then
+    echo "ok $TEST_NUM - $desc"
+    ((PASS++))
+  else
+    echo "not ok $TEST_NUM - $desc (stderr did not contain '$pattern')"
+    ((FAIL++))
+  fi
+}
+
+run_hook() {
+  local json="$1" stderr_file="$2"
+  local exit_code=0
+  printf '%s' "$json" | bash "$HOOK" 2>"$stderr_file" || exit_code=$?
+  echo "$exit_code"
+}
+
+# --- Allow Cases ---
+
+# 1. Agent + run_in_background=true (boolean) -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y","run_in_background":true}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Agent run_in_background=true is allowed"
+
+# 2. legacy Task + run_in_background=true -> allow
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Task","tool_input":{"description":"x","prompt":"y","run_in_background":true}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Task run_in_background=true is allowed"
+
+# --- Block Cases (foreground subagent) ---
+
+# 3. Agent + run_in_background=false -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y","run_in_background":false}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent run_in_background=false is blocked"
+assert_stderr_contains "run_in_background=true" "$stderr" "deny stderr guides run_in_background=true"
+
+# 4. Agent + run_in_background omitted (default foreground) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent run_in_background omitted is blocked"
+
+# 5. Agent + run_in_background="true" (string, not strict boolean) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y","run_in_background":"true"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent run_in_background string \"true\" is blocked"
+
+# 6. Agent + run_in_background=1 (numeric) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y","run_in_background":1}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent run_in_background numeric 1 is blocked"
+
+# 7. Agent + run_in_background=null -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","tool_input":{"description":"x","prompt":"y","run_in_background":null}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent run_in_background null is blocked"
+
+# 8. Agent + tool_input missing entirely -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent"}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Agent with no tool_input is blocked"
+
+# 9. run_in_background at TOP level (outside tool_input) -> block
+#    The hook reads .tool_input.run_in_background only; a top-level key must
+#    NOT be treated as background (guards against an over-broad fallback).
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Agent","run_in_background":true,"tool_input":{}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "top-level run_in_background (outside tool_input) is blocked"
+
+# 10. legacy Task + run_in_background omitted (foreground) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Task","tool_input":{"description":"x","prompt":"y"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 2 "$ec" "Task foreground is blocked"
+
+# --- Passthrough Cases (non-subagent / exact-match semantics) ---
+
+# 11. Bash tool -> passthrough
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"ls"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash tool passes through"
+
+# 12. Bash tool with run_in_background=false -> passthrough (only subagent tools gated)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Bash","tool_input":{"command":"ls","run_in_background":false}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Bash tool with run_in_background=false passes through"
+
+# 13. Edit tool -> passthrough
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"Edit","tool_input":{"file_path":"/x","old_string":"a","new_string":"b"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "Edit tool passes through"
+
+# 14. tool_name missing -> passthrough
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_input":{"foo":"bar"}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "missing tool_name passes through"
+
+# 15. AgentFoo (substring, not exact) -> passthrough (exact-match only)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"AgentFoo","tool_input":{}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "AgentFoo (substring) passes through (exact match)"
+
+# 16. lowercase agent -> passthrough (exact-match is case-sensitive)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+json='{"tool_name":"agent","tool_input":{}}'
+ec=$(run_hook "$json" "$stderr")
+assert_exit 0 "$ec" "lowercase agent passes through (case-sensitive exact match)"
+
+# --- Fail-closed Cases (malformed input) ---
+
+# 17. Malformed JSON -> block (fail-closed, NOT fail-open exit 5)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook 'not json{' "$stderr")
+assert_exit 2 "$ec" "malformed JSON is blocked (fail-closed)"
+
+# 18. Truncated JSON -> block (fail-closed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '{"tool_name":"Agent","tool_input":{' "$stderr")
+assert_exit 2 "$ec" "truncated JSON is blocked (fail-closed)"
+
+# 19. Empty stdin -> block (fail-closed; not valid JSON)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '' "$stderr")
+assert_exit 2 "$ec" "empty stdin is blocked (fail-closed)"
+
+# 20. tool_input is a string (JSON-valid but not an object) -> block
+#     Without a type guard, .tool_input.run_in_background would make jq
+#     error (exit 5) and fail OPEN. Must deny (exit 2) instead.
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '{"tool_name":"Agent","tool_input":"not-object"}' "$stderr")
+assert_exit 2 "$ec" "Agent with non-object (string) tool_input is blocked"
+
+# 21. tool_input is an array (JSON-valid but not an object) -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '{"tool_name":"Agent","tool_input":[1,2,3]}' "$stderr")
+assert_exit 2 "$ec" "Agent with array tool_input is blocked"
+
+# 22. tool_input is a boolean -> block
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '{"tool_name":"Agent","tool_input":true}' "$stderr")
+assert_exit 2 "$ec" "Agent with boolean tool_input is blocked"
+
+# 23. Top-level JSON is an array (valid JSON, not an object) -> block (fail-closed)
+#     Without a top-level type guard, .tool_name indexing would jq-error (exit 5)
+#     and fail OPEN. Must deny (exit 2).
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '[]' "$stderr")
+assert_exit 2 "$ec" "top-level array payload is blocked (fail-closed)"
+
+# 24. Top-level JSON is a string -> block (fail-closed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '"str"' "$stderr")
+assert_exit 2 "$ec" "top-level string payload is blocked (fail-closed)"
+
+# 25. Top-level JSON is a boolean -> block (fail-closed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook 'true' "$stderr")
+assert_exit 2 "$ec" "top-level boolean payload is blocked (fail-closed)"
+
+# 26. Top-level JSON is a number -> block (fail-closed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook '1' "$stderr")
+assert_exit 2 "$ec" "top-level number payload is blocked (fail-closed)"
+
+# 27. Top-level JSON is null -> block (fail-closed)
+stderr=$(mktemp); TMPFILES+=("$stderr")
+ec=$(run_hook 'null' "$stderr")
+assert_exit 2 "$ec" "top-level null payload is blocked (fail-closed)"
+
+# --- Summary ---
+echo "# $PASS passed, $FAIL failed out of $TEST_NUM tests"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#560](https://github.com/suisya-systems/claude-org-ja/pull/560)

Merge SHA: `28d7d19e9a6c8502d83194dfe22b5e6ac5b7fe71`

Source: ja PR [#560](https://github.com/suisya-systems/claude-org-ja/pull/560)
Merge SHA: `28d7d19e9a6c8502d83194dfe22b5e6ac5b7fe71`

| class | count |
|---|---|
| runtime | 3 |
| translation | 1 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `.claude/settings.json`
- `.hooks/block-foreground-subagent.sh`
- `tests/test-block-foreground-subagent.sh`

</details>
<details><summary>translation (1)</summary>

- `CLAUDE.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
