### PR TITLE
auto-mirror: ja#592 fix(peer-notify): transport-neutral にして broker で窓口通知が届くようにする

### DIFF
--- a/tools/conftest.py
+++ b/tools/conftest.py
@@ -8,9 +8,17 @@ renga session that environment variable is set, so test runs with a real
 peer channel. The existing tests didn't notice this because CI runners
 have neither the env var nor the binary.
 
-This autouse fixture scrubs ``RENGA_SOCKET`` for the duration of every
-test in ``tools/``. Tests that explicitly want to test peer-emit behaviour
-should mock ``tools.peer_notify.notify_peer`` directly instead.
+Issue #590 makes ``notify_peer`` transport-neutral: with
+``ORG_TRANSPORT=broker`` it instead shells out to
+``claude-org-runtime broker send``. A test run inside a live broker
+session would leak the same fake messages onto the broker channel, so we
+scrub ``ORG_TRANSPORT`` too — forcing the renga branch, which then
+no-ops immediately because ``RENGA_SOCKET`` is also scrubbed.
+
+This autouse fixture scrubs ``RENGA_SOCKET`` and ``ORG_TRANSPORT`` for
+the duration of every test in ``tools/``. Tests that explicitly want to
+test peer-emit behaviour should mock ``tools.peer_notify.notify_peer``
+(or set the env vars themselves) instead.
 """
 from __future__ import annotations
 
@@ -21,12 +29,16 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _scrub_renga_socket(monkeypatch):
-    """Disable renga peer-emit fall-through for the test's duration.
+    """Disable peer-emit fall-through (both transports) for the test.
 
     `peer_notify.notify_peer` returns False immediately when
-    ``RENGA_SOCKET`` is unset, which short-circuits the whole subprocess
-    handshake. That is exactly the behaviour we want for hermetic tests
-    that aren't asserting on the peer channel.
+    ``RENGA_SOCKET`` is unset, which short-circuits the renga subprocess
+    handshake. Scrubbing ``ORG_TRANSPORT`` keeps the dispatch on the
+    renga branch so a live broker session can't shell out to
+    ``claude-org-runtime broker send``. Together that is exactly the
+    hermetic behaviour we want for tests not asserting on the peer
+    channel.
     """
     monkeypatch.delenv("RENGA_SOCKET", raising=False)
+    monkeypatch.delenv("ORG_TRANSPORT", raising=False)
     yield

--- a/tools/peer_notify.py
+++ b/tools/peer_notify.py
@@ -1,18 +1,30 @@
-"""Best-effort renga-peers message dispatch from CLI subprocesses.
+"""Best-effort peer-message dispatch from CLI subprocesses.
 
-Issue #326. ``mcp__renga-peers__send_message`` is only reachable from
-inside a Claude Code session — a CLI helper like ``tools/pr_watch.py``
-cannot call MCP tools directly. The renga binary, however, ships an
-``mcp-peer`` subcommand that runs the same MCP server over stdio, so
-spawning it as a subprocess and driving a one-shot JSON-RPC handshake
-is the simplest reliable bridge from a Python CLI back into the
-peer-message channel.
+Issue #326 / #590. ``mcp__{renga-peers,org-broker}__send_message`` is
+only reachable from inside a Claude Code session — a CLI helper like
+``tools/pr_watch.py`` cannot call MCP tools directly. ``notify_peer``
+bridges a Python CLI back into the peer-message channel and is
+**transport-neutral**: it picks the path from ``ORG_TRANSPORT``.
 
-When ``RENGA_SOCKET`` is unset (plain shell, CI, etc.), this helper is a
-silent no-op so the calling tool keeps working in non-renga
-environments. All failures (binary missing, handshake error, timeout,
-peer not found, backend unreachable) are swallowed — peer notification
-is decoration on top of the canonical event row, never a precondition.
+* ``ORG_TRANSPORT`` unset / anything but ``broker`` → renga path. The
+  renga binary ships an ``mcp-peer`` subcommand that runs the same MCP
+  server over stdio, so spawning it as a subprocess and driving a
+  one-shot JSON-RPC handshake is the simplest reliable bridge. When
+  ``RENGA_SOCKET`` is unset (plain shell, CI, etc.) this is a silent
+  no-op so the caller keeps working in non-renga environments.
+* ``ORG_TRANSPORT=broker`` → broker path. Shells out to the frozen
+  ``claude-org-runtime broker send --to <id> --message <text>`` CLI and
+  treats ``returncode == 0`` as delivered. Until that CLI ships
+  (claude-org-runtime #93) the subprocess raises ``FileNotFoundError``,
+  which — like every other failure — maps to ``False``, so the broker
+  branch lands as a graceful no-op and end-to-end delivery is enabled
+  later by a runtime release + ja pin bump.
+
+The signature and the best-effort ``bool`` contract are identical across
+both transports. All failures (binary missing, handshake error, timeout,
+peer not found, backend unreachable, non-zero exit) are swallowed — peer
+notification is decoration on top of the canonical event row, never a
+precondition. ``notify_peer`` never raises.
 
 Failure handling notes:
 * ``stdout.readline()`` would block indefinitely on a renga binary that
@@ -36,11 +48,68 @@ import threading
 from typing import Optional
 
 _RENGA_BIN = "renga"
+_RUNTIME_BIN = "claude-org-runtime"
 _HANDSHAKE_TIMEOUT_SEC = 5.0
 _DROPPED_PREFIX = "(message dropped"
 
 
 def notify_peer(
+    to_id: str,
+    message: str,
+    *,
+    timeout: float = _HANDSHAKE_TIMEOUT_SEC,
+    renga_bin: str = _RENGA_BIN,
+) -> bool:
+    """Send a peer message on the active transport. Best-effort.
+
+    Dispatches on ``ORG_TRANSPORT``: ``broker`` shells out to the
+    ``claude-org-runtime broker send`` CLI; anything else (including
+    unset) uses the renga ``mcp-peer`` JSON-RPC path. Returns ``True``
+    only on confirmed delivery and ``False`` for every other outcome
+    (transport not configured, binary missing, subprocess crash,
+    protocol error, timeout, non-zero exit, backend-unreachable shim).
+    Never raises. The signature and ``bool`` contract are identical
+    across transports.
+    """
+    # Deliberately a raw env check, NOT tools.transport.resolve(): this
+    # module is stdlib-only and best-effort. transport.resolve() imports
+    # claude_org_runtime at load time (coupling this CLI bridge to the
+    # runtime install) and raises ValueError on unknown/empty values,
+    # which would violate the never-raise contract. The dispatch is
+    # binary anyway — broker vs. "everything else falls back to renga" —
+    # so the SoT resolver buys nothing here. (Issue #590.)
+    if os.environ.get("ORG_TRANSPORT") == "broker":
+        return _notify_peer_broker(to_id, message, timeout=timeout)
+    return _notify_peer_renga(to_id, message, timeout=timeout, renga_bin=renga_bin)
+
+
+def _notify_peer_broker(
+    to_id: str,
+    message: str,
+    *,
+    timeout: float = _HANDSHAKE_TIMEOUT_SEC,
+    runtime_bin: str = _RUNTIME_BIN,
+) -> bool:
+    """Send via the ``claude-org-runtime broker send`` CLI. Best-effort.
+
+    Frozen contract (claude-org-runtime #93)::
+
+        claude-org-runtime broker send --to <to_id> --message <message>
+
+    Returns ``True`` iff the subprocess exits 0. ``FileNotFoundError``
+    (CLI not installed — the common case until runtime#93 ships),
+    non-zero exit, timeout, and any other exception all map to ``False``.
+    Never raises.
+    """
+    cmd = [runtime_bin, "broker", "send", "--to", to_id, "--message", message]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, timeout=timeout)
+    except Exception:  # noqa: BLE001 — best-effort; CLI absent, timeout, etc.
+        return False
+    return proc.returncode == 0
+
+
+def _notify_peer_renga(
     to_id: str,
     message: str,
     *,

--- a/tools/test_peer_notify.py
+++ b/tools/test_peer_notify.py
@@ -1,10 +1,17 @@
-"""Direct unit tests for tools/peer_notify.py (Issue #326).
+"""Direct unit tests for tools/peer_notify.py (Issue #326 / #590).
 
-These exercise the JSON-RPC handshake, timeout, and the ok-text
-``(message dropped — …)`` rejection without invoking the real renga
-binary. The helper spawns ``renga mcp-peer`` with subprocess.Popen,
-so we substitute a fake Popen that wires its stdin/stdout to in-memory
-streams scripted by each test.
+``NotifyPeerTests`` exercise the renga JSON-RPC handshake, timeout, and
+the ok-text ``(message dropped — …)`` rejection without invoking the
+real renga binary. The helper spawns ``renga mcp-peer`` with
+subprocess.Popen, so we substitute a fake Popen that wires its
+stdin/stdout to in-memory streams scripted by each test.
+
+``NotifyPeerBrokerTests`` cover the ``ORG_TRANSPORT=broker`` branch,
+which shells out to the frozen ``claude-org-runtime broker send`` CLI.
+These stub ``subprocess.run`` so they verify the argv, the
+``returncode == 0`` success mapping, and the best-effort ``False`` for
+non-zero exit / CLI-absent (FileNotFoundError) / timeout — all without a
+live broker daemon or an installed runtime.
 """
 from __future__ import annotations
 
@@ -97,9 +104,13 @@ def _ok_init(req: dict) -> dict:
 class NotifyPeerTests(unittest.TestCase):
     def setUp(self) -> None:
         # Pretend renga is on PATH and RENGA_SOCKET is set so the
-        # short-circuit guards don't fire.
+        # short-circuit guards don't fire. Pin ORG_TRANSPORT=renga so a
+        # real broker session env (ORG_TRANSPORT=broker) can't misroute
+        # these renga-path tests through the broker branch.
         self._env = mock.patch.dict(
-            os.environ, {"RENGA_SOCKET": r"\\.\pipe\fake"}, clear=False,
+            os.environ,
+            {"RENGA_SOCKET": r"\\.\pipe\fake", "ORG_TRANSPORT": "renga"},
+            clear=False,
         )
         self._env.start()
         self._which = mock.patch.object(
@@ -243,6 +254,99 @@ class NotifyPeerTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertLess(elapsed, 5.0,
                         f"timeout not enforced; elapsed={elapsed:.2f}s")
+
+
+class _FakeCompleted:
+    """Minimal subprocess.CompletedProcess stand-in."""
+
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+        self.stdout = b""
+        self.stderr = b""
+
+
+class NotifyPeerBrokerTests(unittest.TestCase):
+    """ORG_TRANSPORT=broker branch — shells out to the runtime CLI."""
+
+    def setUp(self) -> None:
+        self._env = mock.patch.dict(
+            os.environ, {"ORG_TRANSPORT": "broker"}, clear=False,
+        )
+        self._env.start()
+
+    def tearDown(self) -> None:
+        self._env.stop()
+
+    def _patch_run(self, **kwargs):
+        return mock.patch.object(peer_notify.subprocess, "run", **kwargs)
+
+    def test_returncode_zero_is_delivered(self) -> None:
+        with self._patch_run(return_value=_FakeCompleted(0)) as run:
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+        run.assert_called_once()
+
+    def test_nonzero_returncode_is_false(self) -> None:
+        with self._patch_run(return_value=_FakeCompleted(1)):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_cli_absent_filenotfound_is_false(self) -> None:
+        """Until runtime#93 ships the CLI is not on PATH; the subprocess
+        raises FileNotFoundError, which must map to a graceful no-op."""
+        with self._patch_run(side_effect=FileNotFoundError("no runtime")):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_timeout_is_false(self) -> None:
+        exc = peer_notify.subprocess.TimeoutExpired(cmd="x", timeout=0.1)
+        with self._patch_run(side_effect=exc):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_generic_exception_is_false_not_raised(self) -> None:
+        with self._patch_run(side_effect=RuntimeError("boom")):
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+
+    def test_argv_matches_frozen_contract(self) -> None:
+        """`claude-org-runtime broker send --to <id> --message <text>`."""
+        with self._patch_run(return_value=_FakeCompleted(0)) as run:
+            peer_notify.notify_peer("secretary", "a message")
+        argv = run.call_args.args[0]
+        self.assertEqual(
+            argv,
+            ["claude-org-runtime", "broker", "send",
+             "--to", "secretary", "--message", "a message"],
+        )
+
+    def test_broker_branch_does_not_spawn_renga(self) -> None:
+        """ORG_TRANSPORT=broker must never reach the renga Popen path,
+        even if RENGA_SOCKET happens to be set in the environment."""
+        with mock.patch.dict(os.environ, {"RENGA_SOCKET": "x"}, clear=False), \
+                mock.patch.object(peer_notify.subprocess, "Popen") as popen, \
+                self._patch_run(return_value=_FakeCompleted(0)):
+            self.assertTrue(peer_notify.notify_peer("secretary", "hi"))
+        popen.assert_not_called()
+
+
+class NotifyPeerDispatchTests(unittest.TestCase):
+    """ORG_TRANSPORT routing: only ``broker`` takes the broker branch."""
+
+    def _assert_renga_path(self, transport_env: dict) -> None:
+        """With a non-broker transport the broker CLI is never called and
+        the renga branch runs (and no-ops False when RENGA_SOCKET unset)."""
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("RENGA_SOCKET", "ORG_TRANSPORT")}
+        env.update(transport_env)
+        with mock.patch.dict(os.environ, env, clear=True), \
+                mock.patch.object(peer_notify.subprocess, "run") as run:
+            self.assertFalse(peer_notify.notify_peer("secretary", "hi"))
+        run.assert_not_called()
+
+    def test_unset_transport_uses_renga(self) -> None:
+        self._assert_renga_path({})
+
+    def test_renga_transport_uses_renga(self) -> None:
+        self._assert_renga_path({"ORG_TRANSPORT": "renga"})
+
+    def test_unknown_transport_falls_back_to_renga(self) -> None:
+        self._assert_renga_path({"ORG_TRANSPORT": "something-else"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#592](https://github.com/suisya-systems/claude-org-ja/pull/592)

Merge SHA: `8ec03dab4bfa92de46833e87ce472836cf64f502`

Source: ja PR [#592](https://github.com/suisya-systems/claude-org-ja/pull/592)
Merge SHA: `8ec03dab4bfa92de46833e87ce472836cf64f502`

| class | count |
|---|---|
| runtime | 3 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tools/conftest.py`
- `tools/peer_notify.py`
- `tools/test_peer_notify.py`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
