### PR TITLE
auto-mirror: ja#606 fix(claude): #603 dispatcher 監視の idle 誤分類を decision register gate で解消

### DIFF
--- a/tests/test_pending_decisions.py
+++ b/tests/test_pending_decisions.py
@@ -493,5 +493,233 @@ class MarkUserRepliedTests(unittest.TestCase):
         self.assertIsNotNone(final.user_replied_at)
 
 
+class LatestForTaskAndStaleTraceTests(unittest.TestCase):
+    """Tests for Issue #603 latest_for_task / escalation_trace_is_stale."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.store = Path(self._tmpdir.name) / "pending_decisions.json"
+
+    def _seed(self, entries: list[dict]) -> None:
+        self.store.parent.mkdir(parents=True, exist_ok=True)
+        self.store.write_text(json.dumps(entries), encoding="utf-8")
+
+    # latest_for_task -----------------------------------------------------
+    def test_latest_for_task_picks_greatest_received_at(self) -> None:
+        # Three entries for the same task with distinct received_at; the
+        # one with the greatest timestamp must be returned regardless of
+        # store order (newest seeded first, oldest last).
+        self._seed(
+            [
+                {
+                    "task_id": "t1",
+                    "received_at": "2026-05-05T06:00:00Z",
+                    "raw_message": "round2-pending",
+                    "status": "pending",
+                },
+                {
+                    "task_id": "t1",
+                    "received_at": "2026-05-05T05:00:00Z",
+                    "raw_message": "round1-resolved",
+                    "status": "resolved",
+                    "resolved_at": "2026-05-05T05:30:00Z",
+                    "resolution_kind": "to_worker",
+                },
+                {
+                    "task_id": "t1",
+                    "received_at": "2026-05-05T04:00:00Z",
+                    "raw_message": "round0-escalated",
+                    "status": "escalated",
+                    "resolved_at": "2026-05-05T04:10:00Z",
+                    "resolution_kind": "to_user",
+                },
+            ]
+        )
+        latest = pd.latest_for_task("t1", store_path=self.store)
+        self.assertIsNotNone(latest)
+        assert latest is not None
+        self.assertEqual(latest.received_at, "2026-05-05T06:00:00Z")
+        self.assertEqual(latest.raw_message, "round2-pending")
+
+    def test_latest_for_task_tie_breaks_by_append_order(self) -> None:
+        # Equal received_at: the later (append order) entry wins.
+        self._seed(
+            [
+                {
+                    "task_id": "t1",
+                    "received_at": "2026-05-05T05:00:00Z",
+                    "raw_message": "first-appended",
+                    "status": "escalated",
+                    "resolved_at": "2026-05-05T05:01:00Z",
+                    "resolution_kind": "to_user",
+                },
+                {
+                    "task_id": "t1",
+                    "received_at": "2026-05-05T05:00:00Z",
+                    "raw_message": "later-appended",
+                    "status": "resolved",
+                    "resolved_at": "2026-05-05T05:02:00Z",
+                    "resolution_kind": "to_worker",
+                },
+            ]
+        )
+        latest = pd.latest_for_task("t1", store_path=self.store)
+        assert latest is not None
+        self.assertEqual(latest.raw_message, "later-appended")
+
+    def test_latest_for_task_unknown_returns_none(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        self.assertIsNone(pd.latest_for_task("nope", store_path=self.store))
+
+    def test_latest_for_task_empty_store_returns_none(self) -> None:
+        self.assertIsNone(pd.latest_for_task("t1", store_path=self.store))
+
+    # escalation_trace_is_stale ------------------------------------------
+    def test_stale_true_for_resolved_to_worker(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        self.assertTrue(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+
+    def test_stale_false_for_pending(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        self.assertFalse(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+
+    def test_stale_false_for_escalated_to_user(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        self.assertFalse(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+
+    def test_stale_false_for_escalated_user_replied(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.mark_user_replied("t1", store_path=self.store)
+        # status is still escalated (user replied but not yet relayed
+        # back to worker) -> open wait, not stale.
+        self.assertFalse(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+
+    def test_stale_false_for_unknown_task(self) -> None:
+        self.assertFalse(
+            pd.escalation_trace_is_stale("nope", store_path=self.store)
+        )
+
+    def test_stale_false_after_reopen_pending_following_resolve(self) -> None:
+        # The crucial case: a prior round was resolved(to_worker), then a
+        # NEW judgment-request re-opened the wait (append -> pending). The
+        # latest decision is now pending, so the escalation trace is a
+        # live wait again -> NOT stale (acked must be restored).
+        pd.append("t1", "round1", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        # re-open
+        reopened = pd.append("t1", "round2", store_path=self.store)
+        self.assertEqual(reopened.status, "pending")
+        self.assertFalse(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+
+    # CLI latest-resolution ----------------------------------------------
+    def _run_cli_capture(self, task_id: str) -> dict:
+        import contextlib
+        import io
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = pd.main(
+                [
+                    "--store",
+                    str(self.store),
+                    "latest-resolution",
+                    "--task-id",
+                    task_id,
+                ]
+            )
+        self.assertEqual(rc, 0)
+        lines = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)
+        return json.loads(lines[0])
+
+    def test_cli_latest_resolution_stale_true(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        pd.resolve("t1", "to_user", store_path=self.store)
+        pd.resolve("t1", "to_worker", store_path=self.store)
+        out = self._run_cli_capture("t1")
+        self.assertEqual(out["status"], "resolved")
+        self.assertEqual(out["resolution_kind"], "to_worker")
+        self.assertTrue(out["escalation_trace_is_stale"])
+
+    def test_cli_latest_resolution_pending_not_stale(self) -> None:
+        pd.append("t1", "ask", store_path=self.store)
+        out = self._run_cli_capture("t1")
+        self.assertEqual(out["status"], "pending")
+        self.assertFalse(out["escalation_trace_is_stale"])
+
+    def test_cli_latest_resolution_none(self) -> None:
+        out = self._run_cli_capture("nope")
+        self.assertEqual(out["status"], "none")
+        self.assertIsNone(out["resolution_kind"])
+        self.assertFalse(out["escalation_trace_is_stale"])
+
+    # multi-task discrimination ------------------------------------------
+    def test_latest_for_task_discriminates_across_tasks(self) -> None:
+        # A newer resolved/to_worker entry for t2 must not leak into t1's
+        # latest_for_task / escalation_trace_is_stale: the task_id filter
+        # is what keeps Step 5's per-worker gate correct (Issue #603).
+        self.store.write_text(
+            json.dumps(
+                [
+                    {
+                        "task_id": "t1",
+                        "received_at": "2026-05-05T05:00:00Z",
+                        "raw_message": "t1-still-open",
+                        "status": "pending",
+                    },
+                    {
+                        "task_id": "t2",
+                        "received_at": "2026-05-05T06:00:00Z",
+                        "raw_message": "t2-relayed-back",
+                        "status": "resolved",
+                        "resolved_at": "2026-05-05T06:01:00Z",
+                        "resolution_kind": "to_worker",
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+        t1_latest = pd.latest_for_task("t1", store_path=self.store)
+        assert t1_latest is not None
+        self.assertEqual(t1_latest.task_id, "t1")
+        # t2's newer resolved/to_worker does not make t1 stale.
+        self.assertFalse(
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+        )
+        self.assertTrue(
+            pd.escalation_trace_is_stale("t2", store_path=self.store)
+        )
+
+    # malformed register through the new API -----------------------------
+    def test_latest_for_task_propagates_malformed_json(self) -> None:
+        # _load raises ValueError on malformed JSON; the new public API
+        # must propagate (not silently swallow) so the dispatcher's
+        # (c)(1-bis) gate falls back to register_unavailable rather than
+        # misreading a corrupt store as "no decision" (Issue #603).
+        self.store.write_text("not json{", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            pd.latest_for_task("t1", store_path=self.store)
+        with self.assertRaises(ValueError):
+            pd.escalation_trace_is_stale("t1", store_path=self.store)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/pending_decisions.py
+++ b/tools/pending_decisions.py
@@ -378,6 +378,64 @@ def list_escalated_user_replied_older_than(
     return out
 
 
+def latest_for_task(
+    task_id: str,
+    store_path: Path = DEFAULT_PATH,
+) -> Optional[PendingDecision]:
+    """Return the most recent entry for ``task_id`` (by ``received_at``).
+
+    Issue #603. The dispatcher's worker-monitoring Step 5 stall judgement
+    needs to decide whether an idle worker is genuinely "awaiting a
+    judgment-reply" (acked, suppress STALL) or whether its journal
+    worker_escalation trace is stale because the escalation has already
+    been resolved back to the worker (re-evaluate as a stuck candidate).
+    This helper locates the decision that matters for that judgement: the
+    latest entry for the task.
+
+    "Latest" is the entry whose ``received_at`` is greatest. ISO-8601 UTC
+    timestamps sort lexicographically in time order, so a string compare
+    suffices. Ties (equal ``received_at``) are broken by append order —
+    the later entry in the store wins. Returns ``None`` when no entry
+    exists for ``task_id``.
+    """
+    latest: Optional[PendingDecision] = None
+    for entry in _load(store_path):
+        if entry.task_id != task_id:
+            continue
+        # ">=" so that, on an exact received_at tie, the later (append
+        # order) entry wins — matches the resolve()/mark side semantics.
+        if latest is None or entry.received_at >= latest.received_at:
+            latest = entry
+    return latest
+
+
+def escalation_trace_is_stale(
+    task_id: str,
+    store_path: Path = DEFAULT_PATH,
+) -> bool:
+    """Whether ``task_id``'s worker_escalation journal trace is stale.
+
+    Issue #603. Returns ``True`` only when the latest decision for
+    ``task_id`` exists and is in the terminal ``resolved`` /
+    ``to_worker`` shape — i.e. the user's answer has already been relayed
+    back to the worker. In that state, any worker_escalation trace the
+    dispatcher sees in the journal is no longer an *open* judgment-wait:
+    the worker is expected to be working, so the dispatcher must NOT count
+    its idle as "awaiting decision (acked)". Instead the idle should fall
+    back into STALL / ERROR re-evaluation as a stuck candidate.
+
+    Returns ``False`` when the latest decision is still ``pending`` (a
+    fresh judgment-request re-opened the wait), ``escalated`` (awaiting
+    human reply), or absent — in those states the escalation trace is a
+    legitimate open wait and the dispatcher should keep treating the idle
+    as acked.
+    """
+    latest = latest_for_task(task_id, store_path=store_path)
+    if latest is None:
+        return False
+    return latest.status == "resolved" and latest.resolution_kind == "to_worker"
+
+
 # --------------------------------------------------------------------- CLI
 
 
@@ -429,6 +487,30 @@ def _cmd_mark_user_replied(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_latest_resolution(args: argparse.Namespace) -> int:
+    store_path = Path(args.store) if args.store else DEFAULT_PATH
+    latest = latest_for_task(args.task_id, store_path=store_path)
+    if latest is None:
+        print(
+            json.dumps(
+                {
+                    "task_id": args.task_id,
+                    "status": "none",
+                    "resolution_kind": None,
+                    "escalation_trace_is_stale": False,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    out = latest.to_dict()
+    out["escalation_trace_is_stale"] = (
+        latest.status == "resolved" and latest.resolution_kind == "to_worker"
+    )
+    print(json.dumps(out, ensure_ascii=False))
+    return 0
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         prog="tools/pending_decisions.py",
@@ -476,6 +558,16 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     p_mark.add_argument("--task-id", required=True)
     p_mark.set_defaults(func=_cmd_mark_user_replied)
+
+    p_latest = sub.add_parser(
+        "latest-resolution",
+        help=(
+            "emit the latest decision for a task plus escalation_trace_is_stale "
+            "(Issue #603, dispatcher Step 5 stall judgement)"
+        ),
+    )
+    p_latest.add_argument("--task-id", required=True)
+    p_latest.set_defaults(func=_cmd_latest_resolution)
 
     args = parser.parse_args(argv)
     return args.func(args)


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#606](https://github.com/suisya-systems/claude-org-ja/pull/606)

Merge SHA: `ed213c4f68243130813b48369fc569e4e59417ee`

Source: ja PR [#606](https://github.com/suisya-systems/claude-org-ja/pull/606)
Merge SHA: `ed213c4f68243130813b48369fc569e4e59417ee`

| class | count |
|---|---|
| runtime | 2 |
| translation | 0 |
| divergence-allowed | 3 |
| unknown | 0 |

<details><summary>runtime (2)</summary>

- `tests/test_pending_decisions.py`
- `tools/pending_decisions.py`

</details>
<details><summary>divergence-allowed (3)</summary>

- `.dispatcher/CLAUDE.md`
- `.dispatcher/references/worker-monitoring.md`
- `.dispatcher/references/worker-monitoring.md.in`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
