### PR TITLE
auto-mirror: ja#615 refactor(claude): runtime 0.1.29 consumer follow-up — spike to broker rename

### DIFF
--- a/tools/skill_src/fragments/pane-layout-initial.broker.md
+++ b/tools/skill_src/fragments/pane-layout-initial.broker.md
@@ -1,0 +1,7 @@
+## 初期レイアウト (ディスパッチャー・キュレーター起動後)
+
+broker では各ペインが **tmux の detached 独立セッション**（POSIX / WSL2、専用 socket `claude-org-broker` 上の `claude-org-broker-<pid>-<連番>`）または **WezTerm の別 GUI ウィンドウ**（Windows、`isolated_session=False`）で起動する。窓口 (`secretary`) は adapter 実ペインを持たない **logical pane**（bookkeeping entry。`register_logical_pane`）であり、org を起動した人間の手元 terminal でそのまま動く。したがって renga のような「一画面に複数ペインを並べる視覚的タイリング」は **現状 manifest しない**（broker-spawned 子ペインは default では人間の画面に出ず、走行中の観察は `tmux -L claude-org-broker attach -r -t claude-org-broker-<pid>-<連番>` の per-session attach 導線で行う。単一セッション化＝一画面一望は設計確定だが **未 land**）。
+
+ただし **geometry / role 優先の balanced split スケジューリング自体は契約上 transport-neutral に走る** — `list_panes` の geometry は契約 Surface 1.5 で REQUIRED、balanced split は Surface 2.2 で load-bearing と明記され（[`docs/contracts/backend-interface-contract.md`]({{ROOT}}docs/contracts/backend-interface-contract.md)）、backend 非依存で retain される。balanced split が決める「`secretary / curator / worker / dispatcher` の 4 役を候補とする role-priority 付き動的ワーカー zone 生成」（詳細は下記アルゴリズム節）はスケジューリング順序であり、視覚タイリングが無くても同一に効く。視覚レイアウトの ASCII 図（renga 面の一画面タイリング）は broker 面では実体に対応しないため割愛する。
+
+> **設計 SoT 注記**: 視覚タイリング不在および単一セッション化（一画面一望）の一次設計 SoT は transport-lab（`docs/design/broker-native-roles.md` §9 / §8.2 / §3.4、`docs/design/ja-migration-plan.md` §5 / §8）であり本リポジトリにはローカル不在。本リポジトリ内の二次参照は [`docs/operations/broker-dogfood-runbook.md`]({{ROOT}}docs/operations/broker-dogfood-runbook.md) §8（観察性 — 走行中 org への attach 導線。detached 独立セッション / logical 窓口 / 未 land の単一セッション化を記述）。


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#615](https://github.com/suisya-systems/claude-org-ja/pull/615)

Merge SHA: `1d7b96ddd583173b01aa735606ddfaa68ecd19ad`

Source: ja PR [#615](https://github.com/suisya-systems/claude-org-ja/pull/615)
Merge SHA: `1d7b96ddd583173b01aa735606ddfaa68ecd19ad`

| class | count |
|---|---|
| runtime | 1 |
| translation | 3 |
| divergence-allowed | 0 |
| unknown | 2 |

<details><summary>runtime (1)</summary>

- `tools/skill_src/fragments/pane-layout-initial.broker.md`

</details>
<details><summary>translation (3)</summary>

- `.claude/skills/org-attach/SKILL.md`
- `.claude/skills/org-delegate/references/pane-layout.md`
- `docs/operations/broker-dogfood-runbook.md`

</details>
<details><summary>unknown (2)</summary>

- `pyproject.toml`
- `requirements.txt`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
