### PR TITLE
fix(deps): hotfix pin claude-org-runtime <0.1.28 (drain transition)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.9,<0.2",
+    "claude-org-runtime>=0.1.9,<0.1.28",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
Temporary cap to preserve pre-flip test expectations during the auto-mirror backlog drain (Option B). Will be naturally superseded by #355 (ja#597) which bumps the floor to 0.1.28 and intentionally activates the broker transport-default flip.