### PR TITLE
auto-mirror: ja#632 fix(claude): remove unary commas from install.ps1 $pyCandidates literal

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -216,9 +216,9 @@ $reqFile = Join-Path $Dir 'requirements.txt'
 $pyCmd = $null
 if ((Test-Path -LiteralPath $pyprojectFile) -or (Test-Path -LiteralPath $reqFile)) {
     $pyCandidates = @(
-        ,@('python'),
-        ,@('python3'),
-        ,@('py', '-3')
+        @('python'),
+        @('python3'),
+        @('py', '-3')
     )
     foreach ($cand in $pyCandidates) {
         if (-not (Get-Command $cand[0] -ErrorAction SilentlyContinue)) { continue }


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#632](https://github.com/suisya-systems/claude-org-ja/pull/632)

Merge SHA: `4667edc25707cec61bf30782701d4c0933089daa`

Source: ja PR [#632](https://github.com/suisya-systems/claude-org-ja/pull/632)
Merge SHA: `4667edc25707cec61bf30782701d4c0933089daa`

| class | count |
|---|---|
| runtime | 1 |
| translation | 0 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (1)</summary>

- `scripts/install.ps1`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
