### PR TITLE
chore: bump claude-org-runtime pin floor to >=0.1.36,<0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 # pre-1.0; widening is Phase 5e+ scope per CLAUDE.local.md.
 dependencies = [
     "core-harness>=0.3.2,<0.4",
-    "claude-org-runtime>=0.1.29,<0.2",
+    "claude-org-runtime>=0.1.36,<0.2",
     "tomli>=2.0,<3 ; python_version < '3.11'",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ core-harness>=0.3.2,<0.4
 # PyPI via Trusted Publisher; pinned to the 0.1.x range. 0.x bumps may be
 # breaking per the runtime's compatibility policy, so widen this pin
 # deliberately when adopting a new minor.
-claude-org-runtime>=0.1.9,<0.2
+claude-org-runtime>=0.1.36,<0.2
 
 # tools/gen_worker_brief.py reads TOML config. tomllib is stdlib in 3.11+,
 # but ja still supports 3.10 (CLAUDE.local.md template recommends 3.10).


### PR DESCRIPTION
## Summary

Raise the runtime pin floor to 0.1.36 in pyproject.toml and requirements.txt (also fixing the stale 0.1.9 entry in requirements.txt), matching the ja SoT.

With the schema-drift goldens already regenerated on main, this makes the pin explicit and closes the folded pin-bump mirror issues.

Closes #462
Closes #463
Closes #466
Closes #470

These are pure pin bumps with no separate mirror-repo payload; runtime changes ship in the pinned wheel. Folding into this single bump per the mirror triage - no work lost.

## Verification

- schema-drift check green against runtime 0.1.36 (bundled schema == org_extension_schema.json)
- Full local run of tests.yml steps on this base: 581 tests OK, shell 412/412, state-db OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)