### PR TITLE
auto-mirror: ja#696 feat(claude): runtime drift check の sandbox silent-skip を根治 (#119)

### DIFF
--- a/tools/check_runtime_version.py
+++ b/tools/check_runtime_version.py
@@ -2,28 +2,46 @@
 """Runtime version drift check for /org-start (Issue #472).
 
 Compares the installed ``claude-org-runtime`` version against the
-latest release on PyPI that still satisfies ja's pin window
-(declared in ``pyproject.toml`` dependencies). If they differ,
-prints a single warning line to stdout so /org-start can splice it
-into its Step 4 readiness report. In all other cases — versions
-match, package not installed, PyPI unreachable, parse failure, no
-pin-compatible release found, ``packaging`` import failure — the
-script stays silent.
+latest release on PyPI that still satisfies ja's pin window (declared
+in ``pyproject.toml`` dependencies), and reports the outcome through a
+small **exit-code contract** so a sandboxed or offline run can no
+longer hide a stale pin behind a silent skip.
 
-The pin window matters because /org-start's warning must not steer
-users into an upgrade that breaks ja's compatibility contract: when
-ja's upper bound is exclusive and PyPI ships a release past it, we
-still want to bring users up to the latest in-window release but
-never recommend the out-of-window one. No specific version is
-hard-coded anywhere — installed comes from ``importlib.metadata``,
-latest from the PyPI JSON API, and the pin spec from a regex over
-``pyproject.toml`` at read time.
+That silent skip was the #119 phantom-dispatch root cause: /org-start's
+drift check ran inside the Claude Code Bash sandbox, PyPI was
+unreachable, the script printed nothing and exited 0, and the operator
+read the silence as "up to date" -- then delegated a runtime bug that
+had already been fixed upstream (0.1.36) while the venv sat on 0.1.34.
 
-The script never auto-upgrades and never exits non-zero — drift is
-informational, and skipping silently is the correct behavior when the
-machine is offline or in a sandboxed CI lane.
+Outcome contract:
 
-Used by ``.claude/skills/org-start/SKILL.md`` Block C2.
+* stdout carries the single ``[runtime drift] ...`` line **only** on
+  the drift outcome, so /org-start can keep splicing stdout verbatim
+  into its readiness report.
+* Every "couldn't verify" and "not installed" outcome prints a human
+  diagnostic to **stderr** (never stdout) so the reason is visible
+  without polluting the spliceable stdout line.
+* The process exit code distinguishes the outcomes:
+
+    0  EXIT_OK             installed is the pin-window latest (or a
+                           newer preview build); PyPI was reached.
+    1  EXIT_DRIFT          installed != latest-in-window; stdout has
+                           the ``[runtime drift]`` line.
+    2  EXIT_UNVERIFIED     latest could not be determined (offline /
+                           PyPI error / JSON parse / no in-window
+                           release / packaging missing / pin parse
+                           failure); stderr has a reason diagnostic.
+    3  EXIT_NOT_INSTALLED  package not importable from this Python;
+                           stderr note.
+
+The script still never auto-upgrades. No version is hard-coded:
+installed comes from ``importlib.metadata``, latest from the PyPI JSON
+API, and the pin spec from a regex over ``pyproject.toml`` at read
+time.
+
+Used by ``.claude/skills/org-start/SKILL.md`` Block C2, which runs this
+outside the sandbox (``dangerouslyDisableSandbox: true``) so exit 2 is
+the rare degraded case, not the norm.
 """
 
 from __future__ import annotations
@@ -35,20 +53,65 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-try:
-    sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
-except (AttributeError, OSError):
-    pass
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except (AttributeError, OSError):
+        pass
 
 PACKAGE = "claude-org-runtime"
 PYPI_JSON_URL = f"https://pypi.org/pypi/{PACKAGE}/json"
-TIMEOUT_SEC = 3.0
+# Widened from 3.0s: a slow-but-reachable network must not be misread
+# as offline. Offline is now surfaced (exit 2 + stderr) rather than
+# silently skipped, so a longer wait before giving up is worthwhile.
+TIMEOUT_SEC = 8.0
 PYPROJECT_PATH = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+# Exit codes -- the outcome contract described in the module docstring.
+EXIT_OK = 0
+EXIT_DRIFT = 1
+EXIT_UNVERIFIED = 2
+EXIT_NOT_INSTALLED = 3
 
 # Sentinel so callers can pass ``pin=None`` to *opt out* of the pin
 # window, while leaving the default unspecified branch free to
 # auto-discover the pin from pyproject.toml.
 _AUTO_PIN = object()
+
+# Reason codes for the EXIT_UNVERIFIED outcome. They let /org-start
+# tell "offline -- retry on a networked host" apart from "the check
+# itself is degraded" (e.g. packaging missing), and each maps to a
+# human diagnostic below.
+REASON_OFFLINE = "offline"
+REASON_PYPI_ERROR = "pypi_error"
+REASON_NO_IN_WINDOW_RELEASE = "no_in_window_release"
+REASON_PACKAGING_MISSING = "packaging_missing"
+REASON_PIN_PARSE_FAILED = "pin_parse_failed"
+
+_REASON_DIAGNOSTICS = {
+    REASON_OFFLINE: (
+        "PyPI ({url}) に到達できませんでした（オフライン / sandbox 内実行の"
+        "可能性）。ネットワーク到達可能なホストで再実行するまで drift は"
+        "未確認です。"
+    ),
+    REASON_PYPI_ERROR: (
+        "PyPI ({url}) の応答を解釈できませんでした（HTTP エラー / 不正な"
+        "JSON）。drift は未確認です。"
+    ),
+    REASON_NO_IN_WINDOW_RELEASE: (
+        "PyPI に pin 窓 ({pin}) を満たす stable release が見つかりません"
+        "でした。drift は未確認です（pin 窓が upstream の実リリースと"
+        "乖離している可能性）。"
+    ),
+    REASON_PACKAGING_MISSING: (
+        "packaging が未インストールのため pin 窓 ({pin}) を適用した latest"
+        "解決ができませんでした。drift は未確認です。"
+    ),
+    REASON_PIN_PARSE_FAILED: (
+        "pyproject.toml の pin 指定 ({pin}) を解釈できませんでした。窓外"
+        " upgrade を促さないため drift は未確認扱いにします。"
+    ),
+}
 
 
 def _installed_version() -> str | None:
@@ -84,7 +147,13 @@ def _read_pin_spec() -> str | None:
     return spec or None
 
 
-def _fetch_pypi_payload() -> dict | None:
+def _fetch_pypi_payload() -> tuple[dict | None, str | None]:
+    """Return ``(payload, reason)``. On success ``reason`` is None. On
+    failure ``payload`` is None and ``reason`` distinguishes a network
+    reach failure (``REASON_OFFLINE``) from a reached-but-bad response
+    (``REASON_PYPI_ERROR`` -- HTTP error status or undecodable JSON) so
+    the caller can print an accurate diagnostic instead of skipping
+    silently."""
     try:
         req = urllib.request.Request(
             PYPI_JSON_URL,
@@ -92,23 +161,31 @@ def _fetch_pypi_payload() -> dict | None:
         )
         with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
             payload = json.load(resp)
+    except urllib.error.HTTPError:
+        # Reached PyPI but got a non-2xx status: a server-side problem,
+        # not an offline host.
+        return None, REASON_PYPI_ERROR
     except (urllib.error.URLError, TimeoutError, ConnectionError, OSError):
-        return None
+        return None, REASON_OFFLINE
     except (json.JSONDecodeError, ValueError):
-        return None
+        return None, REASON_PYPI_ERROR
     except Exception:
-        return None
-    return payload if isinstance(payload, dict) else None
+        return None, REASON_PYPI_ERROR
+    if not isinstance(payload, dict):
+        return None, REASON_PYPI_ERROR
+    return payload, None
 
 
-def _latest_version(pin=_AUTO_PIN) -> str | None:
-    """Return the newest stable release of PACKAGE on PyPI that
-    satisfies ``pin``. Pass ``pin=None`` to disable the pin window;
-    omit the argument to auto-discover the pin from pyproject.toml.
-    Returns None on any failure path so the caller stays silent."""
-    payload = _fetch_pypi_payload()
+def _latest_version_with_reason(pin=_AUTO_PIN) -> tuple[str | None, str | None]:
+    """Return ``(version, reason)`` for the newest stable release of
+    PACKAGE on PyPI that satisfies ``pin``. On success ``reason`` is
+    None; on any failure ``version`` is None and ``reason`` is one of
+    the ``REASON_*`` codes. Pass ``pin=None`` to disable the pin
+    window; omit the argument to auto-discover the pin from
+    pyproject.toml."""
+    payload, reason = _fetch_pypi_payload()
     if payload is None:
-        return None
+        return None, reason
 
     if pin is _AUTO_PIN:
         pin = _read_pin_spec()
@@ -119,15 +196,17 @@ def _latest_version(pin=_AUTO_PIN) -> str | None:
             from packaging.specifiers import InvalidSpecifier, SpecifierSet
             from packaging.version import InvalidVersion, Version
         except ImportError:
-            return _fallback_info_version(payload, pin)
+            fallback = _fallback_info_version(payload, pin)
+            if fallback is not None:
+                return fallback, None
+            return None, REASON_PACKAGING_MISSING
         if pin:
             try:
                 spec: SpecifierSet | None = SpecifierSet(pin)
             except InvalidSpecifier:
-                # Pin parse failure: prefer silence over recommending an
-                # out-of-window upgrade (the docstring guarantees silent
-                # skip on parse failure).
-                return None
+                # Pin parse failure: prefer an explicit "unverified"
+                # over recommending an out-of-window upgrade.
+                return None, REASON_PIN_PARSE_FAILED
         else:
             spec = None
         candidates: list[Version] = []
@@ -144,10 +223,25 @@ def _latest_version(pin=_AUTO_PIN) -> str | None:
                 continue
             candidates.append(ver)
         if candidates:
-            return str(max(candidates))
-        return None
+            return str(max(candidates)), None
+        return None, REASON_NO_IN_WINDOW_RELEASE
 
-    return _fallback_info_version(payload, pin)
+    fallback = _fallback_info_version(payload, pin)
+    if fallback is not None:
+        return fallback, None
+    # No releases dict and no usable info.version. With a pin we can't
+    # enforce the window (treat as no in-window release); without one
+    # the payload is simply malformed.
+    if pin:
+        return None, REASON_NO_IN_WINDOW_RELEASE
+    return None, REASON_PYPI_ERROR
+
+
+def _latest_version(pin=_AUTO_PIN) -> str | None:
+    """Backward-compatible thin wrapper returning just the resolved
+    version (or None). ``main()`` uses ``_latest_version_with_reason``
+    to also surface *why* resolution failed."""
+    return _latest_version_with_reason(pin)[0]
 
 
 def _release_is_yanked(files) -> bool:
@@ -168,7 +262,7 @@ def _release_is_yanked(files) -> bool:
 def _fallback_info_version(payload: dict, pin: str | None) -> str | None:
     """Last-resort path when releases dict is missing or packaging is
     unavailable. Trusts info.version only when no pin window applies
-    — silent skip otherwise to avoid recommending an out-of-window
+    -- returns None otherwise to avoid recommending an out-of-window
     upgrade."""
     info = payload.get("info") if isinstance(payload, dict) else None
     if not isinstance(info, dict):
@@ -181,16 +275,37 @@ def _fallback_info_version(payload: dict, pin: str | None) -> str | None:
     return latest
 
 
+def _emit_diagnostic(reason: str | None, pin: str | None) -> None:
+    """Print the human-readable reason for an EXIT_UNVERIFIED outcome
+    to stderr (never stdout, which is reserved for the drift line)."""
+    template = _REASON_DIAGNOSTICS.get(
+        reason, "latest を判定できませんでした（reason={reason}）。drift は未確認です。"
+    )
+    message = template.format(
+        url=PYPI_JSON_URL,
+        pin=pin if pin else "(pin 未指定)",
+        reason=reason,
+    )
+    print(f"[runtime drift-check] {PACKAGE}: {message}", file=sys.stderr)
+
+
 def main() -> int:
     installed = _installed_version()
     if installed is None:
-        return 0
+        print(
+            f"[runtime drift-check] {PACKAGE} をこの Python から import できません"
+            "（未インストール / 別 venv）。installed 版を確認できないため drift は"
+            "未確認です。",
+            file=sys.stderr,
+        )
+        return EXIT_NOT_INSTALLED
     pin = _read_pin_spec()
-    latest = _latest_version(pin)
+    latest, reason = _latest_version_with_reason(pin)
     if latest is None:
-        return 0
+        _emit_diagnostic(reason, pin)
+        return EXIT_UNVERIFIED
     if installed == latest:
-        return 0
+        return EXIT_OK
     # Bare ``pip install --upgrade claude-org-runtime`` would fetch the
     # PyPI maximum, which may be out of ja's pin window. Bake the pin
     # spec into the recommended command so the user never gets steered
@@ -201,7 +316,7 @@ def main() -> int:
         f"[runtime drift] {PACKAGE}: installed={installed} latest={latest} "
         f"-- `python -m pip install --upgrade '{upgrade_target}'` で更新できます"
     )
-    return 0
+    return EXIT_DRIFT
 
 
 if __name__ == "__main__":

--- a/tools/test_check_runtime_version.py
+++ b/tools/test_check_runtime_version.py
@@ -1,14 +1,17 @@
-"""Unit tests for tools/check_runtime_version.py (Issue #472).
+"""Unit tests for tools/check_runtime_version.py (Issue #472 + the
+#119 follow-up that surfaces the sandbox/offline silent skip).
 
-The script is invoked by /org-start Block C2. It must:
+The script is invoked by /org-start Block C2. Its outcome contract:
 
-* print one warning line when installed != latest-in-pin-window
-* print nothing (and exit 0) when installed == latest
-* print nothing on every "can't tell" branch — package missing,
-  PyPI unreachable, JSON parse failure, no pin-compatible release
-* respect ja's pin window declared in pyproject.toml so the warning
-  never steers users to an out-of-window upgrade (Codex review,
-  Issue #472)
+* stdout carries the single ``[runtime drift]`` line ONLY on drift
+  (exit 1); every other non-OK outcome puts its diagnostic on stderr,
+  keeping stdout empty and spliceable.
+* exit codes distinguish the outcomes so a sandboxed/offline run is no
+  longer read as "up to date": 0 up-to-date, 1 drift, 2 could-not-
+  verify (offline / PyPI error / JSON parse / no in-window release /
+  packaging missing / pin parse failure), 3 package not installed.
+* ja's pin window declared in pyproject.toml is respected so the
+  warning never steers users to an out-of-window upgrade.
 """
 
 from __future__ import annotations
@@ -68,57 +71,96 @@ def _payload(*versions: str, yanked: tuple[str, ...] = ()) -> dict:
 
 
 class MainCliTest(unittest.TestCase):
-    def _run_main(self) -> tuple[int, str]:
-        buf = io.StringIO()
-        with mock.patch.object(sys, "stdout", buf):
+    def _run_main(self) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with mock.patch.object(sys, "stdout", out), mock.patch.object(
+            sys, "stderr", err
+        ):
             code = check_runtime_version.main()
-        return code, buf.getvalue()
+        return code, out.getvalue(), err.getvalue()
 
-    def test_drift_prints_one_warning_line(self):
+    def test_drift_prints_one_warning_line_to_stdout(self):
         with mock.patch.object(
             check_runtime_version, "_installed_version", return_value="0.1.2"
         ), mock.patch.object(
-            check_runtime_version, "_latest_version", return_value="0.1.11"
+            check_runtime_version,
+            "_latest_version_with_reason",
+            return_value=("0.1.11", None),
         ):
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
+            code, out, err = self._run_main()
+        self.assertEqual(code, check_runtime_version.EXIT_DRIFT)
         lines = [ln for ln in out.splitlines() if ln.strip()]
         self.assertEqual(len(lines), 1)
         self.assertIn("[runtime drift]", lines[0])
         self.assertIn("installed=0.1.2", lines[0])
         self.assertIn("latest=0.1.11", lines[0])
+        # drift is a clean result: nothing on stderr.
+        self.assertEqual(err, "")
 
-    def test_match_is_silent(self):
+    def test_match_is_ok_and_silent(self):
         with mock.patch.object(
             check_runtime_version, "_installed_version", return_value="0.1.11"
         ), mock.patch.object(
-            check_runtime_version, "_latest_version", return_value="0.1.11"
+            check_runtime_version,
+            "_latest_version_with_reason",
+            return_value=("0.1.11", None),
         ):
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
+            code, out, err = self._run_main()
+        self.assertEqual(code, check_runtime_version.EXIT_OK)
         self.assertEqual(out, "")
+        self.assertEqual(err, "")
 
-    def test_package_not_installed_is_silent(self):
+    def test_package_not_installed_reports_on_stderr(self):
         with mock.patch.object(
             check_runtime_version, "_installed_version", return_value=None
         ), mock.patch.object(
-            check_runtime_version, "_latest_version"
+            check_runtime_version, "_latest_version_with_reason"
         ) as latest_mock:
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
+            code, out, err = self._run_main()
+        self.assertEqual(code, check_runtime_version.EXIT_NOT_INSTALLED)
+        # stdout stays clean; the reason is surfaced on stderr, not swallowed.
         self.assertEqual(out, "")
+        self.assertNotEqual(err.strip(), "")
         latest_mock.assert_not_called()
 
-    def test_offline_is_silent(self):
+    def test_offline_is_reported_not_silent(self):
+        """#119 regression guard: an unreachable PyPI must NOT be a
+        silent exit 0. It surfaces as EXIT_UNVERIFIED with a stderr
+        diagnostic, while stdout stays empty (no drift line)."""
         with mock.patch.object(
             check_runtime_version, "_installed_version", return_value="0.1.2"
         ), mock.patch(
             "urllib.request.urlopen",
             side_effect=urllib.error.URLError("offline"),
         ):
-            code, out = self._run_main()
-        self.assertEqual(code, 0)
+            code, out, err = self._run_main()
+        self.assertEqual(code, check_runtime_version.EXIT_UNVERIFIED)
         self.assertEqual(out, "")
+        self.assertIn("PyPI", err)
+
+    def test_unverified_reason_goes_to_stderr(self):
+        """Every non-offline "could not determine latest" reason also
+        yields EXIT_UNVERIFIED + a stderr diagnostic, stdout empty."""
+        for reason in (
+            check_runtime_version.REASON_PYPI_ERROR,
+            check_runtime_version.REASON_NO_IN_WINDOW_RELEASE,
+            check_runtime_version.REASON_PACKAGING_MISSING,
+            check_runtime_version.REASON_PIN_PARSE_FAILED,
+        ):
+            with self.subTest(reason=reason):
+                with mock.patch.object(
+                    check_runtime_version,
+                    "_installed_version",
+                    return_value="0.1.2",
+                ), mock.patch.object(
+                    check_runtime_version,
+                    "_latest_version_with_reason",
+                    return_value=(None, reason),
+                ):
+                    code, out, err = self._run_main()
+                self.assertEqual(code, check_runtime_version.EXIT_UNVERIFIED)
+                self.assertEqual(out, "")
+                self.assertNotEqual(err.strip(), "")
 
 
 class LatestVersionTest(unittest.TestCase):
@@ -221,6 +263,35 @@ class LatestVersionTest(unittest.TestCase):
                 check_runtime_version._latest_version(pin=">=0.1.9,<0.2")
             )
 
+    def test_with_reason_reports_offline(self):
+        """_latest_version_with_reason surfaces REASON_OFFLINE when the
+        host can't reach PyPI -- the channel that drives main()'s
+        EXIT_UNVERIFIED + stderr diagnostic instead of a silent skip."""
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            version, reason = (
+                check_runtime_version._latest_version_with_reason(pin=None)
+            )
+        self.assertIsNone(version)
+        self.assertEqual(reason, check_runtime_version.REASON_OFFLINE)
+
+    @requires_packaging
+    def test_with_reason_success_has_no_reason(self):
+        """On success the reason channel is None and the version is the
+        pin-window latest (keeps the wrapper and the reason function in
+        agreement)."""
+        payload = _payload("0.1.9", "0.1.11", "0.2.0")
+        with mock.patch("urllib.request.urlopen", _fake_urlopen(payload)):
+            version, reason = (
+                check_runtime_version._latest_version_with_reason(
+                    pin=">=0.1.9,<0.2"
+                )
+            )
+        self.assertEqual(version, "0.1.11")
+        self.assertIsNone(reason)
+
 
 class ReadPinSpecTest(unittest.TestCase):
     def test_reads_pin_from_real_pyproject(self):
@@ -246,7 +317,9 @@ class UpgradeCommandShapeTest(unittest.TestCase):
         ), mock.patch.object(
             check_runtime_version, "_read_pin_spec", return_value=pin
         ), mock.patch.object(
-            check_runtime_version, "_latest_version", return_value="0.1.11"
+            check_runtime_version,
+            "_latest_version_with_reason",
+            return_value=("0.1.11", None),
         ), mock.patch.object(sys, "stdout", buf):
             check_runtime_version.main()
         return buf.getvalue()

--- a/tools/update_runtime.py
+++ b/tools/update_runtime.py
@@ -20,8 +20,10 @@ idempotent: when the installed version already equals the in-window
 latest, it is a no-op and never shells out to pip, even under
 ``--apply``.
 
-Exit-code convention (consistent with check_runtime_version.py, which
-returns 0 in every informational/skip/no-op/drift case):
+Exit-code convention (update_runtime's own two-value scheme -- it does
+NOT mirror check_runtime_version.py's 0/1/2/3 reporting contract, since
+for an *actor* a non-zero code is reserved for a real ``--apply``
+failure, not for merely reporting drift/offline):
 
     * 0  -- dry-run report, no-op (already up to date), and every
             non-fatal skip (offline / PyPI unreachable / package not


### PR DESCRIPTION
auto-mirror: runtime files from ja PR [#696](https://github.com/suisya-systems/claude-org-ja/pull/696)

Merge SHA: `2670ce3ea61bbcf14dfec6365fb5294bb799cb32`

Source: ja PR [#696](https://github.com/suisya-systems/claude-org-ja/pull/696)
Merge SHA: `2670ce3ea61bbcf14dfec6365fb5294bb799cb32`

| class | count |
|---|---|
| runtime | 3 |
| translation | 3 |
| divergence-allowed | 0 |
| unknown | 0 |

<details><summary>runtime (3)</summary>

- `tools/check_runtime_version.py`
- `tools/test_check_runtime_version.py`
- `tools/update_runtime.py`

</details>
<details><summary>translation (3)</summary>

- `.claude/skills/org-delegate/SKILL.md`
- `.claude/skills/org-delegate/SKILL.md.in`
- `.claude/skills/org-start/SKILL.md`

</details>

Phase: **P2 (mirror PR, manual merge)**.
See `docs/runbook/auto-mirror-runtime.md` for the rollout plan.

---

Phase: **P2** (manual merge). Reviewer: confirm runtime parity, then squash-merge.
If conflicts surface, rebase locally or close in favor of a hand-applied port.
